### PR TITLE
Remove redundant schema ref from configure options element ui json

### DIFF
--- a/charts/kubedbcom-mongodb-editor-options/ui/create-ui.yaml
+++ b/charts/kubedbcom-mongodb-editor-options/ui/create-ui.yaml
@@ -1,281 +1,279 @@
 hasPreviewPanel: true
 steps:
-- form:
-    discriminator:
-      createAuthSecret:
-        default: true
-        type: boolean
-    elements:
-    - label:
-        hasLine: true
-        text: labels.basic_info
-      type: label-element
-    - label:
-        text: labels.database.name
-      schema:
-        $ref: schema#/properties/metadata/properties/release/properties/name
-      type: input
-    - fetch: getResources|core|v1|namespaces
-      label:
-        text: labels.namespace
-      schema:
-        $ref: schema#/properties/metadata/properties/release/properties/namespace
-      type: select
-    - fetch: getMongoDbVersions|catalog.kubedb.com|v1alpha1|mongodbversions
-      label:
-        text: labels.database.version
-      schema:
-        $ref: schema#/properties/spec/properties/version
-      type: select
-    - isArray: true
-      keys:
-        label:
-          text: labels.labels.key
-      label:
-        text: labels.labels.label
-      schema:
-        $ref: schema#/properties/spec/properties/labels
-      type: key-value-input-form
-      values:
-        label:
-          text: labels.labels.value
-        schema:
-          $ref: schema#/properties/spec/properties/labels/additionalProperties
-        type: input
-    - isArray: true
-      keys:
-        label:
-          text: labels.annotations.key
-      label:
-        text: labels.annotations.label
-      schema:
-        $ref: schema#/properties/spec/properties/annotations
-      type: key-value-input-form
-      values:
-        label:
-          text: labels.annotations.value
-        schema:
-          $ref: schema#/properties/spec/properties/annotations/additionalProperties
-        type: input
-    - hasDescription: true
-      label:
-        text: labels.database.mode
-      options:
-      - description: options.database.mode.Standalone.description
-        text: options.database.mode.Standalone.label
-        value: Standalone
-      - description: options.database.mode.Replicaset.description
-        text: options.database.mode.Replicaset.label
-        value: Replicaset
-      - description: options.database.mode.Sharded.description
-        text: options.database.mode.Sharded.label
-        value: Sharded
-      schema:
-        $ref: schema#/properties/spec/properties/mode
-      type: radio
-    - elements:
-      - label:
-          text: labels.replicaset.name
-        schema:
-          $ref: schema#/properties/spec/properties/replicaSet/properties/name
-        type: input
-      - label:
-          text: labels.replicaset.number
-        schema:
-          $ref: schema#/properties/spec/properties/replicas
-        type: input
-      if: isEqualToModelPathValue|Replicaset|/spec/mode
+  - form:
+      discriminator:
+        createAuthSecret:
+          default: true
+          type: boolean
+      elements:
+        - label:
+            hasLine: true
+            text: labels.basic_info
+          type: label-element
+        - label:
+            text: labels.database.name
+          schema:
+            $ref: schema#/properties/metadata/properties/release/properties/name
+          type: input
+        - fetch: getResources|core|v1|namespaces
+          label:
+            text: labels.namespace
+          schema:
+            $ref: schema#/properties/metadata/properties/release/properties/namespace
+          type: select
+        - fetch: getMongoDbVersions|catalog.kubedb.com|v1alpha1|mongodbversions
+          label:
+            text: labels.database.version
+          schema:
+            $ref: schema#/properties/spec/properties/version
+          type: select
+        - isArray: true
+          keys:
+            label:
+              text: labels.labels.key
+          label:
+            text: labels.labels.label
+          schema:
+            $ref: schema#/properties/spec/properties/labels
+          type: key-value-input-form
+          values:
+            label:
+              text: labels.labels.value
+            schema:
+              $ref: schema#/properties/spec/properties/labels/additionalProperties
+            type: input
+        - isArray: true
+          keys:
+            label:
+              text: labels.annotations.key
+          label:
+            text: labels.annotations.label
+          schema:
+            $ref: schema#/properties/spec/properties/annotations
+          type: key-value-input-form
+          values:
+            label:
+              text: labels.annotations.value
+            schema:
+              $ref: schema#/properties/spec/properties/annotations/additionalProperties
+            type: input
+        - hasDescription: true
+          label:
+            text: labels.database.mode
+          options:
+            - description: options.database.mode.Standalone.description
+              text: options.database.mode.Standalone.label
+              value: Standalone
+            - description: options.database.mode.Replicaset.description
+              text: options.database.mode.Replicaset.label
+              value: Replicaset
+            - description: options.database.mode.Sharded.description
+              text: options.database.mode.Sharded.label
+              value: Sharded
+          schema:
+            $ref: schema#/properties/spec/properties/mode
+          type: radio
+        - elements:
+            - label:
+                text: labels.replicaset.name
+              schema:
+                $ref: schema#/properties/spec/properties/replicaSet/properties/name
+              type: input
+            - label:
+                text: labels.replicaset.number
+              schema:
+                $ref: schema#/properties/spec/properties/replicas
+              type: input
+          if: isEqualToModelPathValue|Replicaset|/spec/mode
+          type: single-step-form
+        - if: showStorageSizeField
+          label:
+            text: labels.storage.size
+          schema:
+            $ref: schema#/properties/spec/properties/persistence/properties/size
+          type: input
+        - fetch: getResources|storage.k8s.io|v1|storageclasses
+          label:
+            text: labels.storage.class
+          schema:
+            $ref: schema#/properties/spec/properties/storageClass/properties/name
+          type: select
+        - elements:
+            - label:
+                hasLine: true
+                text: labels.shardNodes
+              type: label-element
+            - label:
+                text: labels.shards
+              schema:
+                $ref: schema#/properties/spec/properties/shardTopology/properties/shard/properties/shards
+              type: input
+            - label:
+                text: labels.storage.size
+              schema:
+                $ref: schema#/properties/spec/properties/shardTopology/properties/shard/properties/persistence/properties/size
+              type: input
+            - label:
+                hasLine: true
+                text: labels.configServer
+              type: label-element
+            - label:
+                text: labels.storage.size
+              schema:
+                $ref: schema#/properties/spec/properties/shardTopology/properties/configServer/properties/persistence/properties/size
+              type: input
+            - label:
+                hasLine: true
+                text: labels.mongos
+              type: label-element
+            - label:
+                text: labels.replicaset.number
+              schema:
+                $ref: schema#/properties/spec/properties/shardTopology/properties/mongos/properties/replicas
+              type: input
+          if: isEqualToModelPathValue|Sharded|/spec/mode
+          type: single-step-form
+        - hasDescription: true
+          label:
+            text: labels.terminationPolicy
+          options:
+            - description: options.terminationPolicy.delete.description
+              text: options.terminationPolicy.delete.label
+              value: Delete
+            - description: options.terminationPolicy.halt.description
+              text: options.terminationPolicy.halt.label
+              value: Halt
+            - description: options.terminationPolicy.wipeOut.description
+              text: options.terminationPolicy.wipeOut.label
+              value: WipeOut
+            - description: options.terminationPolicy.doNotTerminate.description
+              text: options.terminationPolicy.doNotTerminate.label
+              value: DoNotTerminate
+          schema:
+            $ref: schema#/properties/spec/properties/terminationPolicy
+          type: radio
+        - label:
+            hasLine: true
+            text: labels.database.secret
+          type: label-element
+        - options:
+            - text: options.database.secret.customSecret.label
+              value: true
+            - text: options.database.secret.existingSecret.label
+              value: false
+          schema:
+            $ref: discriminator#/createAuthSecret
+          type: radio
+        - elements:
+            - fetch: getSecrets
+              if: hasExistingSecret
+              label:
+                text: labels.secret
+              schema:
+                $ref: schema#/properties/spec/properties/authSecret/properties/name
+              type: select
+            - if: hasNoExistingSecret
+              label:
+                text: labels.secret
+              schema:
+                $ref: schema#/properties/spec/properties/authSecret/properties/name
+              type: input
+          if: showAuthSecretField
+          type: single-step-form
+        - if: showAuthPasswordField
+          label:
+            text: labels.password
+          schema:
+            $ref: schema#/properties/spec/properties/authSecret/properties/password
+          type: input
+        - label:
+            hasLine: true
+            text: Machine Info
+          type: label-element
+        - fetch: getMachineListForOptions
+          label:
+            text: Machine
+          onChange: setResourceLimit
+          schema:
+            $ref: schema#/properties/spec/properties/machine
+          type: select
+        - customClass: mb-10 mt-20
+          label:
+            hasLine: true
+            text: labels.resources
+          type: label-element
+        - label:
+            isSubsection: true
+            text: labels.limit
+          type: label-element
+        - computed: setLimitsCpuOrMem|cpu
+          disabled: disableLimit
+          label:
+            text: labels.cpu
+          schema:
+            $ref: schema#/properties/spec/properties/resources/properties/limits/properties/cpu
+          type: input
+        - computed: setLimitsCpuOrMem|memory
+          disabled: disableLimit
+          label:
+            text: labels.memory
+          schema:
+            $ref: schema#/properties/spec/properties/resources/properties/limits/properties/memory
+          type: input
+        - label:
+            hasLine: true
+            text: labels.configOptions
+          type: label-element
+        - cluster:
+            $ref: store#/clusterInfo/name
+          hasDependencies: true
+          hasDescription: true
+          options:
+            - description: options.configOptions.topology.description
+              text: options.configOptions.topology.label
+              value: topology
+            - dependencies:
+                - group: cert-manager.io
+                  name: Cert-Manager
+                  resource: issuers
+                  url: https://cert-manager.io/docs/
+                  version: v1
+              description: options.configOptions.tls.description
+              text: options.configOptions.tls.label
+              value: tls
+            - description: options.configOptions.initialization.description
+              text: options.configOptions.initialization.label
+              value: initialization
+            - dependencies:
+                - group: stash.appscode.com
+                  name: Stash
+                  resource: backupconfigurations
+                  url: https://stash.run/
+                  version: v1beta1
+              description: options.configOptions.backup.description
+              text: options.configOptions.backup.label
+              value: backupconfiguration
+            - description: options.configOptions.networking.description
+              text: options.configOptions.networking.label
+              value: networking
+            - dependencies:
+                - group: monitoring.coreos.com
+                  name: Prometheus Operator
+                  resource: servicemonitors
+                  url: https://github.com/prometheus-operator
+                  version: v1
+              description: options.configOptions.monitoring.description
+              text: options.configOptions.monitoring.label
+              value: monitoring
+            - description: options.configOptions.customConfig.description
+              text: options.configOptions.customConfig.label
+              value: custom-config
+            - description: options.configOptions.podTemplate.description
+              text: options.configOptions.podTemplate.label
+              value: pod-template
+          owner:
+            $ref: store#/user/username
+          type: configure-options
       type: single-step-form
-    - if: showStorageSizeField
-      label:
-        text: labels.storage.size
-      schema:
-        $ref: schema#/properties/spec/properties/persistence/properties/size
-      type: input
-    - fetch: getResources|storage.k8s.io|v1|storageclasses
-      label:
-        text: labels.storage.class
-      schema:
-        $ref: schema#/properties/spec/properties/storageClass/properties/name
-      type: select
-    - elements:
-      - label:
-          hasLine: true
-          text: labels.shardNodes
-        type: label-element
-      - label:
-          text: labels.shards
-        schema:
-          $ref: schema#/properties/spec/properties/shardTopology/properties/shard/properties/shards
-        type: input
-      - label:
-          text: labels.storage.size
-        schema:
-          $ref: schema#/properties/spec/properties/shardTopology/properties/shard/properties/persistence/properties/size
-        type: input
-      - label:
-          hasLine: true
-          text: labels.configServer
-        type: label-element
-      - label:
-          text: labels.storage.size
-        schema:
-          $ref: schema#/properties/spec/properties/shardTopology/properties/configServer/properties/persistence/properties/size
-        type: input
-      - label:
-          hasLine: true
-          text: labels.mongos
-        type: label-element
-      - label:
-          text: labels.replicaset.number
-        schema:
-          $ref: schema#/properties/spec/properties/shardTopology/properties/mongos/properties/replicas
-        type: input
-      if: isEqualToModelPathValue|Sharded|/spec/mode
-      type: single-step-form
-    - hasDescription: true
-      label:
-        text: labels.terminationPolicy
-      options:
-      - description: options.terminationPolicy.delete.description
-        text: options.terminationPolicy.delete.label
-        value: Delete
-      - description: options.terminationPolicy.halt.description
-        text: options.terminationPolicy.halt.label
-        value: Halt
-      - description: options.terminationPolicy.wipeOut.description
-        text: options.terminationPolicy.wipeOut.label
-        value: WipeOut
-      - description: options.terminationPolicy.doNotTerminate.description
-        text: options.terminationPolicy.doNotTerminate.label
-        value: DoNotTerminate
-      schema:
-        $ref: schema#/properties/spec/properties/terminationPolicy
-      type: radio
-    - label:
-        hasLine: true
-        text: labels.database.secret
-      type: label-element
-    - options:
-      - text: options.database.secret.customSecret.label
-        value: true
-      - text: options.database.secret.existingSecret.label
-        value: false
-      schema:
-        $ref: discriminator#/createAuthSecret
-      type: radio
-    - elements:
-      - fetch: getSecrets
-        if: hasExistingSecret
-        label:
-          text: labels.secret
-        schema:
-          $ref: schema#/properties/spec/properties/authSecret/properties/name
-        type: select
-      - if: hasNoExistingSecret
-        label:
-          text: labels.secret
-        schema:
-          $ref: schema#/properties/spec/properties/authSecret/properties/name
-        type: input
-      if: showAuthSecretField
-      type: single-step-form
-    - if: showAuthPasswordField
-      label:
-        text: labels.password
-      schema:
-        $ref: schema#/properties/spec/properties/authSecret/properties/password
-      type: input
-    - label:
-        hasLine: true
-        text: Machine Info
-      type: label-element
-    - fetch: getMachineListForOptions
-      label:
-        text: Machine
-      onChange: setResourceLimit
-      schema:
-        $ref: schema#/properties/spec/properties/machine
-      type: select
-    - customClass: mb-10 mt-20
-      label:
-        hasLine: true
-        text: labels.resources
-      type: label-element
-    - label:
-        isSubsection: true
-        text: labels.limit
-      type: label-element
-    - computed: setLimitsCpuOrMem|cpu
-      disabled: disableLimit
-      label:
-        text: labels.cpu
-      schema:
-        $ref: schema#/properties/spec/properties/resources/properties/limits/properties/cpu
-      type: input
-    - computed: setLimitsCpuOrMem|memory
-      disabled: disableLimit
-      label:
-        text: labels.memory
-      schema:
-        $ref: schema#/properties/spec/properties/resources/properties/limits/properties/memory
-      type: input
-    - label:
-        hasLine: true
-        text: labels.configOptions
-      type: label-element
-    - cluster:
-        $ref: store#/clusterInfo/name
-      hasDependencies: true
-      hasDescription: true
-      options:
-      - description: options.configOptions.topology.description
-        text: options.configOptions.topology.label
-        value: topology
-      - dependencies:
-        - group: cert-manager.io
-          name: Cert-Manager
-          resource: issuers
-          url: https://cert-manager.io/docs/
-          version: v1
-        description: options.configOptions.tls.description
-        text: options.configOptions.tls.label
-        value: tls
-      - description: options.configOptions.initialization.description
-        text: options.configOptions.initialization.label
-        value: initialization
-      - dependencies:
-        - group: stash.appscode.com
-          name: Stash
-          resource: backupconfigurations
-          url: https://stash.run/
-          version: v1beta1
-        description: options.configOptions.backup.description
-        text: options.configOptions.backup.label
-        value: backupconfiguration
-      - description: options.configOptions.networking.description
-        text: options.configOptions.networking.label
-        value: networking
-      - dependencies:
-        - group: monitoring.coreos.com
-          name: Prometheus Operator
-          resource: servicemonitors
-          url: https://github.com/prometheus-operator
-          version: v1
-        description: options.configOptions.monitoring.description
-        text: options.configOptions.monitoring.label
-        value: monitoring
-      - description: options.configOptions.customConfig.description
-        text: options.configOptions.customConfig.label
-        value: custom-config
-      - description: options.configOptions.podTemplate.description
-        text: options.configOptions.podTemplate.label
-        value: pod-template
-      owner:
-        $ref: store#/user/username
-      schema:
-        $ref: schema#/properties/spec/properties/configurationOptions
-      type: configure-options
-    type: single-step-form
-  title: steps.0.label
+    title: steps.0.label
 type: multi-step-form

--- a/charts/kubedbcom-mongodb-editor-options/ui/create-ui.yaml
+++ b/charts/kubedbcom-mongodb-editor-options/ui/create-ui.yaml
@@ -1,279 +1,279 @@
 hasPreviewPanel: true
 steps:
-  - form:
-      discriminator:
-        createAuthSecret:
-          default: true
-          type: boolean
-      elements:
-        - label:
-            hasLine: true
-            text: labels.basic_info
-          type: label-element
-        - label:
-            text: labels.database.name
-          schema:
-            $ref: schema#/properties/metadata/properties/release/properties/name
-          type: input
-        - fetch: getResources|core|v1|namespaces
-          label:
-            text: labels.namespace
-          schema:
-            $ref: schema#/properties/metadata/properties/release/properties/namespace
-          type: select
-        - fetch: getMongoDbVersions|catalog.kubedb.com|v1alpha1|mongodbversions
-          label:
-            text: labels.database.version
-          schema:
-            $ref: schema#/properties/spec/properties/version
-          type: select
-        - isArray: true
-          keys:
-            label:
-              text: labels.labels.key
-          label:
-            text: labels.labels.label
-          schema:
-            $ref: schema#/properties/spec/properties/labels
-          type: key-value-input-form
-          values:
-            label:
-              text: labels.labels.value
-            schema:
-              $ref: schema#/properties/spec/properties/labels/additionalProperties
-            type: input
-        - isArray: true
-          keys:
-            label:
-              text: labels.annotations.key
-          label:
-            text: labels.annotations.label
-          schema:
-            $ref: schema#/properties/spec/properties/annotations
-          type: key-value-input-form
-          values:
-            label:
-              text: labels.annotations.value
-            schema:
-              $ref: schema#/properties/spec/properties/annotations/additionalProperties
-            type: input
-        - hasDescription: true
-          label:
-            text: labels.database.mode
-          options:
-            - description: options.database.mode.Standalone.description
-              text: options.database.mode.Standalone.label
-              value: Standalone
-            - description: options.database.mode.Replicaset.description
-              text: options.database.mode.Replicaset.label
-              value: Replicaset
-            - description: options.database.mode.Sharded.description
-              text: options.database.mode.Sharded.label
-              value: Sharded
-          schema:
-            $ref: schema#/properties/spec/properties/mode
-          type: radio
-        - elements:
-            - label:
-                text: labels.replicaset.name
-              schema:
-                $ref: schema#/properties/spec/properties/replicaSet/properties/name
-              type: input
-            - label:
-                text: labels.replicaset.number
-              schema:
-                $ref: schema#/properties/spec/properties/replicas
-              type: input
-          if: isEqualToModelPathValue|Replicaset|/spec/mode
-          type: single-step-form
-        - if: showStorageSizeField
-          label:
-            text: labels.storage.size
-          schema:
-            $ref: schema#/properties/spec/properties/persistence/properties/size
-          type: input
-        - fetch: getResources|storage.k8s.io|v1|storageclasses
-          label:
-            text: labels.storage.class
-          schema:
-            $ref: schema#/properties/spec/properties/storageClass/properties/name
-          type: select
-        - elements:
-            - label:
-                hasLine: true
-                text: labels.shardNodes
-              type: label-element
-            - label:
-                text: labels.shards
-              schema:
-                $ref: schema#/properties/spec/properties/shardTopology/properties/shard/properties/shards
-              type: input
-            - label:
-                text: labels.storage.size
-              schema:
-                $ref: schema#/properties/spec/properties/shardTopology/properties/shard/properties/persistence/properties/size
-              type: input
-            - label:
-                hasLine: true
-                text: labels.configServer
-              type: label-element
-            - label:
-                text: labels.storage.size
-              schema:
-                $ref: schema#/properties/spec/properties/shardTopology/properties/configServer/properties/persistence/properties/size
-              type: input
-            - label:
-                hasLine: true
-                text: labels.mongos
-              type: label-element
-            - label:
-                text: labels.replicaset.number
-              schema:
-                $ref: schema#/properties/spec/properties/shardTopology/properties/mongos/properties/replicas
-              type: input
-          if: isEqualToModelPathValue|Sharded|/spec/mode
-          type: single-step-form
-        - hasDescription: true
-          label:
-            text: labels.terminationPolicy
-          options:
-            - description: options.terminationPolicy.delete.description
-              text: options.terminationPolicy.delete.label
-              value: Delete
-            - description: options.terminationPolicy.halt.description
-              text: options.terminationPolicy.halt.label
-              value: Halt
-            - description: options.terminationPolicy.wipeOut.description
-              text: options.terminationPolicy.wipeOut.label
-              value: WipeOut
-            - description: options.terminationPolicy.doNotTerminate.description
-              text: options.terminationPolicy.doNotTerminate.label
-              value: DoNotTerminate
-          schema:
-            $ref: schema#/properties/spec/properties/terminationPolicy
-          type: radio
-        - label:
-            hasLine: true
-            text: labels.database.secret
-          type: label-element
-        - options:
-            - text: options.database.secret.customSecret.label
-              value: true
-            - text: options.database.secret.existingSecret.label
-              value: false
-          schema:
-            $ref: discriminator#/createAuthSecret
-          type: radio
-        - elements:
-            - fetch: getSecrets
-              if: hasExistingSecret
-              label:
-                text: labels.secret
-              schema:
-                $ref: schema#/properties/spec/properties/authSecret/properties/name
-              type: select
-            - if: hasNoExistingSecret
-              label:
-                text: labels.secret
-              schema:
-                $ref: schema#/properties/spec/properties/authSecret/properties/name
-              type: input
-          if: showAuthSecretField
-          type: single-step-form
-        - if: showAuthPasswordField
-          label:
-            text: labels.password
-          schema:
-            $ref: schema#/properties/spec/properties/authSecret/properties/password
-          type: input
-        - label:
-            hasLine: true
-            text: Machine Info
-          type: label-element
-        - fetch: getMachineListForOptions
-          label:
-            text: Machine
-          onChange: setResourceLimit
-          schema:
-            $ref: schema#/properties/spec/properties/machine
-          type: select
-        - customClass: mb-10 mt-20
-          label:
-            hasLine: true
-            text: labels.resources
-          type: label-element
-        - label:
-            isSubsection: true
-            text: labels.limit
-          type: label-element
-        - computed: setLimitsCpuOrMem|cpu
-          disabled: disableLimit
-          label:
-            text: labels.cpu
-          schema:
-            $ref: schema#/properties/spec/properties/resources/properties/limits/properties/cpu
-          type: input
-        - computed: setLimitsCpuOrMem|memory
-          disabled: disableLimit
-          label:
-            text: labels.memory
-          schema:
-            $ref: schema#/properties/spec/properties/resources/properties/limits/properties/memory
-          type: input
-        - label:
-            hasLine: true
-            text: labels.configOptions
-          type: label-element
-        - cluster:
-            $ref: store#/clusterInfo/name
-          hasDependencies: true
-          hasDescription: true
-          options:
-            - description: options.configOptions.topology.description
-              text: options.configOptions.topology.label
-              value: topology
-            - dependencies:
-                - group: cert-manager.io
-                  name: Cert-Manager
-                  resource: issuers
-                  url: https://cert-manager.io/docs/
-                  version: v1
-              description: options.configOptions.tls.description
-              text: options.configOptions.tls.label
-              value: tls
-            - description: options.configOptions.initialization.description
-              text: options.configOptions.initialization.label
-              value: initialization
-            - dependencies:
-                - group: stash.appscode.com
-                  name: Stash
-                  resource: backupconfigurations
-                  url: https://stash.run/
-                  version: v1beta1
-              description: options.configOptions.backup.description
-              text: options.configOptions.backup.label
-              value: backupconfiguration
-            - description: options.configOptions.networking.description
-              text: options.configOptions.networking.label
-              value: networking
-            - dependencies:
-                - group: monitoring.coreos.com
-                  name: Prometheus Operator
-                  resource: servicemonitors
-                  url: https://github.com/prometheus-operator
-                  version: v1
-              description: options.configOptions.monitoring.description
-              text: options.configOptions.monitoring.label
-              value: monitoring
-            - description: options.configOptions.customConfig.description
-              text: options.configOptions.customConfig.label
-              value: custom-config
-            - description: options.configOptions.podTemplate.description
-              text: options.configOptions.podTemplate.label
-              value: pod-template
-          owner:
-            $ref: store#/user/username
-          type: configure-options
+- form:
+    discriminator:
+      createAuthSecret:
+        default: true
+        type: boolean
+    elements:
+    - label:
+        hasLine: true
+        text: labels.basic_info
+      type: label-element
+    - label:
+        text: labels.database.name
+      schema:
+        $ref: schema#/properties/metadata/properties/release/properties/name
+      type: input
+    - fetch: getResources|core|v1|namespaces
+      label:
+        text: labels.namespace
+      schema:
+        $ref: schema#/properties/metadata/properties/release/properties/namespace
+      type: select
+    - fetch: getMongoDbVersions|catalog.kubedb.com|v1alpha1|mongodbversions
+      label:
+        text: labels.database.version
+      schema:
+        $ref: schema#/properties/spec/properties/version
+      type: select
+    - isArray: true
+      keys:
+        label:
+          text: labels.labels.key
+      label:
+        text: labels.labels.label
+      schema:
+        $ref: schema#/properties/spec/properties/labels
+      type: key-value-input-form
+      values:
+        label:
+          text: labels.labels.value
+        schema:
+          $ref: schema#/properties/spec/properties/labels/additionalProperties
+        type: input
+    - isArray: true
+      keys:
+        label:
+          text: labels.annotations.key
+      label:
+        text: labels.annotations.label
+      schema:
+        $ref: schema#/properties/spec/properties/annotations
+      type: key-value-input-form
+      values:
+        label:
+          text: labels.annotations.value
+        schema:
+          $ref: schema#/properties/spec/properties/annotations/additionalProperties
+        type: input
+    - hasDescription: true
+      label:
+        text: labels.database.mode
+      options:
+      - description: options.database.mode.Standalone.description
+        text: options.database.mode.Standalone.label
+        value: Standalone
+      - description: options.database.mode.Replicaset.description
+        text: options.database.mode.Replicaset.label
+        value: Replicaset
+      - description: options.database.mode.Sharded.description
+        text: options.database.mode.Sharded.label
+        value: Sharded
+      schema:
+        $ref: schema#/properties/spec/properties/mode
+      type: radio
+    - elements:
+      - label:
+          text: labels.replicaset.name
+        schema:
+          $ref: schema#/properties/spec/properties/replicaSet/properties/name
+        type: input
+      - label:
+          text: labels.replicaset.number
+        schema:
+          $ref: schema#/properties/spec/properties/replicas
+        type: input
+      if: isEqualToModelPathValue|Replicaset|/spec/mode
       type: single-step-form
-    title: steps.0.label
+    - if: showStorageSizeField
+      label:
+        text: labels.storage.size
+      schema:
+        $ref: schema#/properties/spec/properties/persistence/properties/size
+      type: input
+    - fetch: getResources|storage.k8s.io|v1|storageclasses
+      label:
+        text: labels.storage.class
+      schema:
+        $ref: schema#/properties/spec/properties/storageClass/properties/name
+      type: select
+    - elements:
+      - label:
+          hasLine: true
+          text: labels.shardNodes
+        type: label-element
+      - label:
+          text: labels.shards
+        schema:
+          $ref: schema#/properties/spec/properties/shardTopology/properties/shard/properties/shards
+        type: input
+      - label:
+          text: labels.storage.size
+        schema:
+          $ref: schema#/properties/spec/properties/shardTopology/properties/shard/properties/persistence/properties/size
+        type: input
+      - label:
+          hasLine: true
+          text: labels.configServer
+        type: label-element
+      - label:
+          text: labels.storage.size
+        schema:
+          $ref: schema#/properties/spec/properties/shardTopology/properties/configServer/properties/persistence/properties/size
+        type: input
+      - label:
+          hasLine: true
+          text: labels.mongos
+        type: label-element
+      - label:
+          text: labels.replicaset.number
+        schema:
+          $ref: schema#/properties/spec/properties/shardTopology/properties/mongos/properties/replicas
+        type: input
+      if: isEqualToModelPathValue|Sharded|/spec/mode
+      type: single-step-form
+    - hasDescription: true
+      label:
+        text: labels.terminationPolicy
+      options:
+      - description: options.terminationPolicy.delete.description
+        text: options.terminationPolicy.delete.label
+        value: Delete
+      - description: options.terminationPolicy.halt.description
+        text: options.terminationPolicy.halt.label
+        value: Halt
+      - description: options.terminationPolicy.wipeOut.description
+        text: options.terminationPolicy.wipeOut.label
+        value: WipeOut
+      - description: options.terminationPolicy.doNotTerminate.description
+        text: options.terminationPolicy.doNotTerminate.label
+        value: DoNotTerminate
+      schema:
+        $ref: schema#/properties/spec/properties/terminationPolicy
+      type: radio
+    - label:
+        hasLine: true
+        text: labels.database.secret
+      type: label-element
+    - options:
+      - text: options.database.secret.customSecret.label
+        value: true
+      - text: options.database.secret.existingSecret.label
+        value: false
+      schema:
+        $ref: discriminator#/createAuthSecret
+      type: radio
+    - elements:
+      - fetch: getSecrets
+        if: hasExistingSecret
+        label:
+          text: labels.secret
+        schema:
+          $ref: schema#/properties/spec/properties/authSecret/properties/name
+        type: select
+      - if: hasNoExistingSecret
+        label:
+          text: labels.secret
+        schema:
+          $ref: schema#/properties/spec/properties/authSecret/properties/name
+        type: input
+      if: showAuthSecretField
+      type: single-step-form
+    - if: showAuthPasswordField
+      label:
+        text: labels.password
+      schema:
+        $ref: schema#/properties/spec/properties/authSecret/properties/password
+      type: input
+    - label:
+        hasLine: true
+        text: Machine Info
+      type: label-element
+    - fetch: getMachineListForOptions
+      label:
+        text: Machine
+      onChange: setResourceLimit
+      schema:
+        $ref: schema#/properties/spec/properties/machine
+      type: select
+    - customClass: mb-10 mt-20
+      label:
+        hasLine: true
+        text: labels.resources
+      type: label-element
+    - label:
+        isSubsection: true
+        text: labels.limit
+      type: label-element
+    - computed: setLimitsCpuOrMem|cpu
+      disabled: disableLimit
+      label:
+        text: labels.cpu
+      schema:
+        $ref: schema#/properties/spec/properties/resources/properties/limits/properties/cpu
+      type: input
+    - computed: setLimitsCpuOrMem|memory
+      disabled: disableLimit
+      label:
+        text: labels.memory
+      schema:
+        $ref: schema#/properties/spec/properties/resources/properties/limits/properties/memory
+      type: input
+    - label:
+        hasLine: true
+        text: labels.configOptions
+      type: label-element
+    - cluster:
+        $ref: store#/clusterInfo/name
+      hasDependencies: true
+      hasDescription: true
+      options:
+      - description: options.configOptions.topology.description
+        text: options.configOptions.topology.label
+        value: topology
+      - dependencies:
+        - group: cert-manager.io
+          name: Cert-Manager
+          resource: issuers
+          url: https://cert-manager.io/docs/
+          version: v1
+        description: options.configOptions.tls.description
+        text: options.configOptions.tls.label
+        value: tls
+      - description: options.configOptions.initialization.description
+        text: options.configOptions.initialization.label
+        value: initialization
+      - dependencies:
+        - group: stash.appscode.com
+          name: Stash
+          resource: backupconfigurations
+          url: https://stash.run/
+          version: v1beta1
+        description: options.configOptions.backup.description
+        text: options.configOptions.backup.label
+        value: backupconfiguration
+      - description: options.configOptions.networking.description
+        text: options.configOptions.networking.label
+        value: networking
+      - dependencies:
+        - group: monitoring.coreos.com
+          name: Prometheus Operator
+          resource: servicemonitors
+          url: https://github.com/prometheus-operator
+          version: v1
+        description: options.configOptions.monitoring.description
+        text: options.configOptions.monitoring.label
+        value: monitoring
+      - description: options.configOptions.customConfig.description
+        text: options.configOptions.customConfig.label
+        value: custom-config
+      - description: options.configOptions.podTemplate.description
+        text: options.configOptions.podTemplate.label
+        value: pod-template
+      owner:
+        $ref: store#/user/username
+      type: configure-options
+    type: single-step-form
+  title: steps.0.label
 type: multi-step-form


### PR DESCRIPTION
Most of the changes are auto formatting changes.
Main change is the removal of `schema` from `configure-options` type ui element