### PR TITLE
Prepare for release v0.4.9

### DIFF
--- a/charts/acmecertmanagerio-challenge-editor/Chart.yaml
+++ b/charts/acmecertmanagerio-challenge-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"acme.cert-manager.io","version":"v1","resource":"challenges"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: Challenge Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: acmecertmanagerio-challenge-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/acmecertmanagerio-challenge-editor/README.md
+++ b/charts/acmecertmanagerio-challenge-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/acmecertmanagerio-challenge-editor --version=v0.4.8
-$ helm upgrade -i acmecertmanagerio-challenge-editor bytebuilders-ui/acmecertmanagerio-challenge-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/acmecertmanagerio-challenge-editor --version=v0.4.9
+$ helm upgrade -i acmecertmanagerio-challenge-editor bytebuilders-ui/acmecertmanagerio-challenge-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a Challenge Editor on a [Kubernetes](http://kubernetes.io) cl
 To install/upgrade the chart with the release name `acmecertmanagerio-challenge-editor`:
 
 ```bash
-$ helm upgrade -i acmecertmanagerio-challenge-editor bytebuilders-ui/acmecertmanagerio-challenge-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i acmecertmanagerio-challenge-editor bytebuilders-ui/acmecertmanagerio-challenge-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a Challenge Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `acmecertmanagerio-
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i acmecertmanagerio-challenge-editor bytebuilders-ui/acmecertmanagerio-challenge-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=acme.cert-manager.io/v1
+$ helm upgrade -i acmecertmanagerio-challenge-editor bytebuilders-ui/acmecertmanagerio-challenge-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=acme.cert-manager.io/v1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i acmecertmanagerio-challenge-editor bytebuilders-ui/acmecertmanagerio-challenge-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i acmecertmanagerio-challenge-editor bytebuilders-ui/acmecertmanagerio-challenge-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/acmecertmanagerio-order-editor/Chart.yaml
+++ b/charts/acmecertmanagerio-order-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"acme.cert-manager.io","version":"v1","resource":"orders"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: Order Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: acmecertmanagerio-order-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/acmecertmanagerio-order-editor/README.md
+++ b/charts/acmecertmanagerio-order-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/acmecertmanagerio-order-editor --version=v0.4.8
-$ helm upgrade -i acmecertmanagerio-order-editor bytebuilders-ui/acmecertmanagerio-order-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/acmecertmanagerio-order-editor --version=v0.4.9
+$ helm upgrade -i acmecertmanagerio-order-editor bytebuilders-ui/acmecertmanagerio-order-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a Order Editor on a [Kubernetes](http://kubernetes.io) cluste
 To install/upgrade the chart with the release name `acmecertmanagerio-order-editor`:
 
 ```bash
-$ helm upgrade -i acmecertmanagerio-order-editor bytebuilders-ui/acmecertmanagerio-order-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i acmecertmanagerio-order-editor bytebuilders-ui/acmecertmanagerio-order-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a Order Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `acmecertmanagerio-
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i acmecertmanagerio-order-editor bytebuilders-ui/acmecertmanagerio-order-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=acme.cert-manager.io/v1
+$ helm upgrade -i acmecertmanagerio-order-editor bytebuilders-ui/acmecertmanagerio-order-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=acme.cert-manager.io/v1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i acmecertmanagerio-order-editor bytebuilders-ui/acmecertmanagerio-order-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i acmecertmanagerio-order-editor bytebuilders-ui/acmecertmanagerio-order-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/admissionregistrationk8sio-mutatingwebhookconfiguration-editor/Chart.yaml
+++ b/charts/admissionregistrationk8sio-mutatingwebhookconfiguration-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"admissionregistration.k8s.io","version":"v1","resource":"mutatingwebhookconfigurations"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: MutatingWebhookConfiguration Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: admissionregistrationk8sio-mutatingwebhookconfiguration-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/admissionregistrationk8sio-mutatingwebhookconfiguration-editor/README.md
+++ b/charts/admissionregistrationk8sio-mutatingwebhookconfiguration-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/admissionregistrationk8sio-mutatingwebhookconfiguration-editor --version=v0.4.8
-$ helm upgrade -i admissionregistrationk8sio-mutatingwebhookconfiguration-editor bytebuilders-ui/admissionregistrationk8sio-mutatingwebhookconfiguration-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/admissionregistrationk8sio-mutatingwebhookconfiguration-editor --version=v0.4.9
+$ helm upgrade -i admissionregistrationk8sio-mutatingwebhookconfiguration-editor bytebuilders-ui/admissionregistrationk8sio-mutatingwebhookconfiguration-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a MutatingWebhookConfiguration Editor on a [Kubernetes](http:
 To install/upgrade the chart with the release name `admissionregistrationk8sio-mutatingwebhookconfiguration-editor`:
 
 ```bash
-$ helm upgrade -i admissionregistrationk8sio-mutatingwebhookconfiguration-editor bytebuilders-ui/admissionregistrationk8sio-mutatingwebhookconfiguration-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i admissionregistrationk8sio-mutatingwebhookconfiguration-editor bytebuilders-ui/admissionregistrationk8sio-mutatingwebhookconfiguration-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a MutatingWebhookConfiguration Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `admissionregistrat
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i admissionregistrationk8sio-mutatingwebhookconfiguration-editor bytebuilders-ui/admissionregistrationk8sio-mutatingwebhookconfiguration-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=admissionregistration.k8s.io/v1
+$ helm upgrade -i admissionregistrationk8sio-mutatingwebhookconfiguration-editor bytebuilders-ui/admissionregistrationk8sio-mutatingwebhookconfiguration-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=admissionregistration.k8s.io/v1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i admissionregistrationk8sio-mutatingwebhookconfiguration-editor bytebuilders-ui/admissionregistrationk8sio-mutatingwebhookconfiguration-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i admissionregistrationk8sio-mutatingwebhookconfiguration-editor bytebuilders-ui/admissionregistrationk8sio-mutatingwebhookconfiguration-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/admissionregistrationk8sio-validatingwebhookconfiguration-editor/Chart.yaml
+++ b/charts/admissionregistrationk8sio-validatingwebhookconfiguration-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"admissionregistration.k8s.io","version":"v1","resource":"validatingwebhookconfigurations"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: ValidatingWebhookConfiguration Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: admissionregistrationk8sio-validatingwebhookconfiguration-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/admissionregistrationk8sio-validatingwebhookconfiguration-editor/README.md
+++ b/charts/admissionregistrationk8sio-validatingwebhookconfiguration-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/admissionregistrationk8sio-validatingwebhookconfiguration-editor --version=v0.4.8
-$ helm upgrade -i admissionregistrationk8sio-validatingwebhookconfiguration-editor bytebuilders-ui/admissionregistrationk8sio-validatingwebhookconfiguration-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/admissionregistrationk8sio-validatingwebhookconfiguration-editor --version=v0.4.9
+$ helm upgrade -i admissionregistrationk8sio-validatingwebhookconfiguration-editor bytebuilders-ui/admissionregistrationk8sio-validatingwebhookconfiguration-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a ValidatingWebhookConfiguration Editor on a [Kubernetes](htt
 To install/upgrade the chart with the release name `admissionregistrationk8sio-validatingwebhookconfiguration-editor`:
 
 ```bash
-$ helm upgrade -i admissionregistrationk8sio-validatingwebhookconfiguration-editor bytebuilders-ui/admissionregistrationk8sio-validatingwebhookconfiguration-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i admissionregistrationk8sio-validatingwebhookconfiguration-editor bytebuilders-ui/admissionregistrationk8sio-validatingwebhookconfiguration-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a ValidatingWebhookConfiguration Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `admissionregistrat
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i admissionregistrationk8sio-validatingwebhookconfiguration-editor bytebuilders-ui/admissionregistrationk8sio-validatingwebhookconfiguration-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=admissionregistration.k8s.io/v1
+$ helm upgrade -i admissionregistrationk8sio-validatingwebhookconfiguration-editor bytebuilders-ui/admissionregistrationk8sio-validatingwebhookconfiguration-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=admissionregistration.k8s.io/v1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i admissionregistrationk8sio-validatingwebhookconfiguration-editor bytebuilders-ui/admissionregistrationk8sio-validatingwebhookconfiguration-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i admissionregistrationk8sio-validatingwebhookconfiguration-editor bytebuilders-ui/admissionregistrationk8sio-validatingwebhookconfiguration-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/apiextensionsk8sio-customresourcedefinition-editor/Chart.yaml
+++ b/charts/apiextensionsk8sio-customresourcedefinition-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"apiextensions.k8s.io","version":"v1","resource":"customresourcedefinitions"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: CustomResourceDefinition Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: apiextensionsk8sio-customresourcedefinition-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/apiextensionsk8sio-customresourcedefinition-editor/README.md
+++ b/charts/apiextensionsk8sio-customresourcedefinition-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/apiextensionsk8sio-customresourcedefinition-editor --version=v0.4.8
-$ helm upgrade -i apiextensionsk8sio-customresourcedefinition-editor bytebuilders-ui/apiextensionsk8sio-customresourcedefinition-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/apiextensionsk8sio-customresourcedefinition-editor --version=v0.4.9
+$ helm upgrade -i apiextensionsk8sio-customresourcedefinition-editor bytebuilders-ui/apiextensionsk8sio-customresourcedefinition-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a CustomResourceDefinition Editor on a [Kubernetes](http://ku
 To install/upgrade the chart with the release name `apiextensionsk8sio-customresourcedefinition-editor`:
 
 ```bash
-$ helm upgrade -i apiextensionsk8sio-customresourcedefinition-editor bytebuilders-ui/apiextensionsk8sio-customresourcedefinition-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i apiextensionsk8sio-customresourcedefinition-editor bytebuilders-ui/apiextensionsk8sio-customresourcedefinition-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a CustomResourceDefinition Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `apiextensionsk8sio
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i apiextensionsk8sio-customresourcedefinition-editor bytebuilders-ui/apiextensionsk8sio-customresourcedefinition-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=apiextensions.k8s.io/v1
+$ helm upgrade -i apiextensionsk8sio-customresourcedefinition-editor bytebuilders-ui/apiextensionsk8sio-customresourcedefinition-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=apiextensions.k8s.io/v1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i apiextensionsk8sio-customresourcedefinition-editor bytebuilders-ui/apiextensionsk8sio-customresourcedefinition-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i apiextensionsk8sio-customresourcedefinition-editor bytebuilders-ui/apiextensionsk8sio-customresourcedefinition-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/apiregistrationk8sio-apiservice-editor/Chart.yaml
+++ b/charts/apiregistrationk8sio-apiservice-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"apiregistration.k8s.io","version":"v1","resource":"apiservices"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: APIService Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: apiregistrationk8sio-apiservice-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/apiregistrationk8sio-apiservice-editor/README.md
+++ b/charts/apiregistrationk8sio-apiservice-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/apiregistrationk8sio-apiservice-editor --version=v0.4.8
-$ helm upgrade -i apiregistrationk8sio-apiservice-editor bytebuilders-ui/apiregistrationk8sio-apiservice-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/apiregistrationk8sio-apiservice-editor --version=v0.4.9
+$ helm upgrade -i apiregistrationk8sio-apiservice-editor bytebuilders-ui/apiregistrationk8sio-apiservice-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a APIService Editor on a [Kubernetes](http://kubernetes.io) c
 To install/upgrade the chart with the release name `apiregistrationk8sio-apiservice-editor`:
 
 ```bash
-$ helm upgrade -i apiregistrationk8sio-apiservice-editor bytebuilders-ui/apiregistrationk8sio-apiservice-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i apiregistrationk8sio-apiservice-editor bytebuilders-ui/apiregistrationk8sio-apiservice-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a APIService Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `apiregistrationk8s
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i apiregistrationk8sio-apiservice-editor bytebuilders-ui/apiregistrationk8sio-apiservice-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=apiregistration.k8s.io/v1
+$ helm upgrade -i apiregistrationk8sio-apiservice-editor bytebuilders-ui/apiregistrationk8sio-apiservice-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=apiregistration.k8s.io/v1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i apiregistrationk8sio-apiservice-editor bytebuilders-ui/apiregistrationk8sio-apiservice-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i apiregistrationk8sio-apiservice-editor bytebuilders-ui/apiregistrationk8sio-apiservice-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/appcatalogappscodecom-appbinding-editor/Chart.yaml
+++ b/charts/appcatalogappscodecom-appbinding-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"appcatalog.appscode.com","version":"v1alpha1","resource":"appbindings"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: AppBinding Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: appcatalogappscodecom-appbinding-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/appcatalogappscodecom-appbinding-editor/README.md
+++ b/charts/appcatalogappscodecom-appbinding-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/appcatalogappscodecom-appbinding-editor --version=v0.4.8
-$ helm upgrade -i appcatalogappscodecom-appbinding-editor bytebuilders-ui/appcatalogappscodecom-appbinding-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/appcatalogappscodecom-appbinding-editor --version=v0.4.9
+$ helm upgrade -i appcatalogappscodecom-appbinding-editor bytebuilders-ui/appcatalogappscodecom-appbinding-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a AppBinding Editor on a [Kubernetes](http://kubernetes.io) c
 To install/upgrade the chart with the release name `appcatalogappscodecom-appbinding-editor`:
 
 ```bash
-$ helm upgrade -i appcatalogappscodecom-appbinding-editor bytebuilders-ui/appcatalogappscodecom-appbinding-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i appcatalogappscodecom-appbinding-editor bytebuilders-ui/appcatalogappscodecom-appbinding-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a AppBinding Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `appcatalogappscode
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i appcatalogappscodecom-appbinding-editor bytebuilders-ui/appcatalogappscodecom-appbinding-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=appcatalog.appscode.com/v1alpha1
+$ helm upgrade -i appcatalogappscodecom-appbinding-editor bytebuilders-ui/appcatalogappscodecom-appbinding-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=appcatalog.appscode.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i appcatalogappscodecom-appbinding-editor bytebuilders-ui/appcatalogappscodecom-appbinding-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i appcatalogappscodecom-appbinding-editor bytebuilders-ui/appcatalogappscodecom-appbinding-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/appk8sio-application-editor/Chart.yaml
+++ b/charts/appk8sio-application-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"app.k8s.io","version":"v1beta1","resource":"applications"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: Application Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: appk8sio-application-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/appk8sio-application-editor/README.md
+++ b/charts/appk8sio-application-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/appk8sio-application-editor --version=v0.4.8
-$ helm upgrade -i appk8sio-application-editor bytebuilders-ui/appk8sio-application-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/appk8sio-application-editor --version=v0.4.9
+$ helm upgrade -i appk8sio-application-editor bytebuilders-ui/appk8sio-application-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a Application Editor on a [Kubernetes](http://kubernetes.io) 
 To install/upgrade the chart with the release name `appk8sio-application-editor`:
 
 ```bash
-$ helm upgrade -i appk8sio-application-editor bytebuilders-ui/appk8sio-application-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i appk8sio-application-editor bytebuilders-ui/appk8sio-application-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a Application Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `appk8sio-applicati
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i appk8sio-application-editor bytebuilders-ui/appk8sio-application-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=app.k8s.io/v1beta1
+$ helm upgrade -i appk8sio-application-editor bytebuilders-ui/appk8sio-application-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=app.k8s.io/v1beta1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i appk8sio-application-editor bytebuilders-ui/appk8sio-application-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i appk8sio-application-editor bytebuilders-ui/appk8sio-application-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/apps-controllerrevision-editor/Chart.yaml
+++ b/charts/apps-controllerrevision-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"apps","version":"v1","resource":"controllerrevisions"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: ControllerRevision Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: apps-controllerrevision-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/apps-controllerrevision-editor/README.md
+++ b/charts/apps-controllerrevision-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/apps-controllerrevision-editor --version=v0.4.8
-$ helm upgrade -i apps-controllerrevision-editor bytebuilders-ui/apps-controllerrevision-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/apps-controllerrevision-editor --version=v0.4.9
+$ helm upgrade -i apps-controllerrevision-editor bytebuilders-ui/apps-controllerrevision-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a ControllerRevision Editor on a [Kubernetes](http://kubernet
 To install/upgrade the chart with the release name `apps-controllerrevision-editor`:
 
 ```bash
-$ helm upgrade -i apps-controllerrevision-editor bytebuilders-ui/apps-controllerrevision-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i apps-controllerrevision-editor bytebuilders-ui/apps-controllerrevision-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a ControllerRevision Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `apps-controllerrev
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i apps-controllerrevision-editor bytebuilders-ui/apps-controllerrevision-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=apps/v1
+$ helm upgrade -i apps-controllerrevision-editor bytebuilders-ui/apps-controllerrevision-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=apps/v1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i apps-controllerrevision-editor bytebuilders-ui/apps-controllerrevision-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i apps-controllerrevision-editor bytebuilders-ui/apps-controllerrevision-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/apps-daemonset-editor/Chart.yaml
+++ b/charts/apps-daemonset-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"apps","version":"v1","resource":"daemonsets"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: DaemonSet Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: apps-daemonset-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/apps-daemonset-editor/README.md
+++ b/charts/apps-daemonset-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/apps-daemonset-editor --version=v0.4.8
-$ helm upgrade -i apps-daemonset-editor bytebuilders-ui/apps-daemonset-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/apps-daemonset-editor --version=v0.4.9
+$ helm upgrade -i apps-daemonset-editor bytebuilders-ui/apps-daemonset-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a DaemonSet Editor on a [Kubernetes](http://kubernetes.io) cl
 To install/upgrade the chart with the release name `apps-daemonset-editor`:
 
 ```bash
-$ helm upgrade -i apps-daemonset-editor bytebuilders-ui/apps-daemonset-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i apps-daemonset-editor bytebuilders-ui/apps-daemonset-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a DaemonSet Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `apps-daemonset-edi
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i apps-daemonset-editor bytebuilders-ui/apps-daemonset-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=apps/v1
+$ helm upgrade -i apps-daemonset-editor bytebuilders-ui/apps-daemonset-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=apps/v1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i apps-daemonset-editor bytebuilders-ui/apps-daemonset-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i apps-daemonset-editor bytebuilders-ui/apps-daemonset-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/apps-deployment-editor/Chart.yaml
+++ b/charts/apps-deployment-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"apps","version":"v1","resource":"deployments"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: Deployment Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: apps-deployment-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/apps-deployment-editor/README.md
+++ b/charts/apps-deployment-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/apps-deployment-editor --version=v0.4.8
-$ helm upgrade -i apps-deployment-editor bytebuilders-ui/apps-deployment-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/apps-deployment-editor --version=v0.4.9
+$ helm upgrade -i apps-deployment-editor bytebuilders-ui/apps-deployment-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a Deployment Editor on a [Kubernetes](http://kubernetes.io) c
 To install/upgrade the chart with the release name `apps-deployment-editor`:
 
 ```bash
-$ helm upgrade -i apps-deployment-editor bytebuilders-ui/apps-deployment-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i apps-deployment-editor bytebuilders-ui/apps-deployment-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a Deployment Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `apps-deployment-ed
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i apps-deployment-editor bytebuilders-ui/apps-deployment-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=apps/v1
+$ helm upgrade -i apps-deployment-editor bytebuilders-ui/apps-deployment-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=apps/v1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i apps-deployment-editor bytebuilders-ui/apps-deployment-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i apps-deployment-editor bytebuilders-ui/apps-deployment-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/apps-replicaset-editor/Chart.yaml
+++ b/charts/apps-replicaset-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"apps","version":"v1","resource":"replicasets"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: ReplicaSet Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: apps-replicaset-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/apps-replicaset-editor/README.md
+++ b/charts/apps-replicaset-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/apps-replicaset-editor --version=v0.4.8
-$ helm upgrade -i apps-replicaset-editor bytebuilders-ui/apps-replicaset-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/apps-replicaset-editor --version=v0.4.9
+$ helm upgrade -i apps-replicaset-editor bytebuilders-ui/apps-replicaset-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a ReplicaSet Editor on a [Kubernetes](http://kubernetes.io) c
 To install/upgrade the chart with the release name `apps-replicaset-editor`:
 
 ```bash
-$ helm upgrade -i apps-replicaset-editor bytebuilders-ui/apps-replicaset-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i apps-replicaset-editor bytebuilders-ui/apps-replicaset-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a ReplicaSet Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `apps-replicaset-ed
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i apps-replicaset-editor bytebuilders-ui/apps-replicaset-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=apps/v1
+$ helm upgrade -i apps-replicaset-editor bytebuilders-ui/apps-replicaset-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=apps/v1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i apps-replicaset-editor bytebuilders-ui/apps-replicaset-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i apps-replicaset-editor bytebuilders-ui/apps-replicaset-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/apps-statefulset-editor/Chart.yaml
+++ b/charts/apps-statefulset-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"apps","version":"v1","resource":"statefulsets"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: StatefulSet Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: apps-statefulset-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/apps-statefulset-editor/README.md
+++ b/charts/apps-statefulset-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/apps-statefulset-editor --version=v0.4.8
-$ helm upgrade -i apps-statefulset-editor bytebuilders-ui/apps-statefulset-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/apps-statefulset-editor --version=v0.4.9
+$ helm upgrade -i apps-statefulset-editor bytebuilders-ui/apps-statefulset-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a StatefulSet Editor on a [Kubernetes](http://kubernetes.io) 
 To install/upgrade the chart with the release name `apps-statefulset-editor`:
 
 ```bash
-$ helm upgrade -i apps-statefulset-editor bytebuilders-ui/apps-statefulset-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i apps-statefulset-editor bytebuilders-ui/apps-statefulset-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a StatefulSet Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `apps-statefulset-e
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i apps-statefulset-editor bytebuilders-ui/apps-statefulset-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=apps/v1
+$ helm upgrade -i apps-statefulset-editor bytebuilders-ui/apps-statefulset-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=apps/v1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i apps-statefulset-editor bytebuilders-ui/apps-statefulset-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i apps-statefulset-editor bytebuilders-ui/apps-statefulset-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/auditorappscodecom-siteinfo-editor/Chart.yaml
+++ b/charts/auditorappscodecom-siteinfo-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"auditor.appscode.com","version":"v1alpha1","resource":"siteinfos"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: SiteInfo Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: auditorappscodecom-siteinfo-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/auditorappscodecom-siteinfo-editor/README.md
+++ b/charts/auditorappscodecom-siteinfo-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/auditorappscodecom-siteinfo-editor --version=v0.4.8
-$ helm upgrade -i auditorappscodecom-siteinfo-editor bytebuilders-ui/auditorappscodecom-siteinfo-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/auditorappscodecom-siteinfo-editor --version=v0.4.9
+$ helm upgrade -i auditorappscodecom-siteinfo-editor bytebuilders-ui/auditorappscodecom-siteinfo-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a SiteInfo Editor on a [Kubernetes](http://kubernetes.io) clu
 To install/upgrade the chart with the release name `auditorappscodecom-siteinfo-editor`:
 
 ```bash
-$ helm upgrade -i auditorappscodecom-siteinfo-editor bytebuilders-ui/auditorappscodecom-siteinfo-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i auditorappscodecom-siteinfo-editor bytebuilders-ui/auditorappscodecom-siteinfo-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a SiteInfo Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `auditorappscodecom
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i auditorappscodecom-siteinfo-editor bytebuilders-ui/auditorappscodecom-siteinfo-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=auditor.appscode.com/v1alpha1
+$ helm upgrade -i auditorappscodecom-siteinfo-editor bytebuilders-ui/auditorappscodecom-siteinfo-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=auditor.appscode.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i auditorappscodecom-siteinfo-editor bytebuilders-ui/auditorappscodecom-siteinfo-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i auditorappscodecom-siteinfo-editor bytebuilders-ui/auditorappscodecom-siteinfo-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/auditregistrationk8sio-auditsink-editor/Chart.yaml
+++ b/charts/auditregistrationk8sio-auditsink-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"auditregistration.k8s.io","version":"v1alpha1","resource":"auditsinks"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: AuditSink Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: auditregistrationk8sio-auditsink-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/auditregistrationk8sio-auditsink-editor/README.md
+++ b/charts/auditregistrationk8sio-auditsink-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/auditregistrationk8sio-auditsink-editor --version=v0.4.8
-$ helm upgrade -i auditregistrationk8sio-auditsink-editor bytebuilders-ui/auditregistrationk8sio-auditsink-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/auditregistrationk8sio-auditsink-editor --version=v0.4.9
+$ helm upgrade -i auditregistrationk8sio-auditsink-editor bytebuilders-ui/auditregistrationk8sio-auditsink-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a AuditSink Editor on a [Kubernetes](http://kubernetes.io) cl
 To install/upgrade the chart with the release name `auditregistrationk8sio-auditsink-editor`:
 
 ```bash
-$ helm upgrade -i auditregistrationk8sio-auditsink-editor bytebuilders-ui/auditregistrationk8sio-auditsink-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i auditregistrationk8sio-auditsink-editor bytebuilders-ui/auditregistrationk8sio-auditsink-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a AuditSink Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `auditregistrationk
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i auditregistrationk8sio-auditsink-editor bytebuilders-ui/auditregistrationk8sio-auditsink-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=auditregistration.k8s.io/v1alpha1
+$ helm upgrade -i auditregistrationk8sio-auditsink-editor bytebuilders-ui/auditregistrationk8sio-auditsink-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=auditregistration.k8s.io/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i auditregistrationk8sio-auditsink-editor bytebuilders-ui/auditregistrationk8sio-auditsink-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i auditregistrationk8sio-auditsink-editor bytebuilders-ui/auditregistrationk8sio-auditsink-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/authenticationk8sio-tokenrequest-editor/Chart.yaml
+++ b/charts/authenticationk8sio-tokenrequest-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"authentication.k8s.io","version":"v1","resource":"tokenrequests"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: TokenRequest Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: authenticationk8sio-tokenrequest-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/authenticationk8sio-tokenrequest-editor/README.md
+++ b/charts/authenticationk8sio-tokenrequest-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/authenticationk8sio-tokenrequest-editor --version=v0.4.8
-$ helm upgrade -i authenticationk8sio-tokenrequest-editor bytebuilders-ui/authenticationk8sio-tokenrequest-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/authenticationk8sio-tokenrequest-editor --version=v0.4.9
+$ helm upgrade -i authenticationk8sio-tokenrequest-editor bytebuilders-ui/authenticationk8sio-tokenrequest-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a TokenRequest Editor on a [Kubernetes](http://kubernetes.io)
 To install/upgrade the chart with the release name `authenticationk8sio-tokenrequest-editor`:
 
 ```bash
-$ helm upgrade -i authenticationk8sio-tokenrequest-editor bytebuilders-ui/authenticationk8sio-tokenrequest-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i authenticationk8sio-tokenrequest-editor bytebuilders-ui/authenticationk8sio-tokenrequest-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a TokenRequest Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `authenticationk8si
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i authenticationk8sio-tokenrequest-editor bytebuilders-ui/authenticationk8sio-tokenrequest-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=authentication.k8s.io/v1
+$ helm upgrade -i authenticationk8sio-tokenrequest-editor bytebuilders-ui/authenticationk8sio-tokenrequest-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=authentication.k8s.io/v1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i authenticationk8sio-tokenrequest-editor bytebuilders-ui/authenticationk8sio-tokenrequest-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i authenticationk8sio-tokenrequest-editor bytebuilders-ui/authenticationk8sio-tokenrequest-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/authenticationk8sio-tokenreview-editor/Chart.yaml
+++ b/charts/authenticationk8sio-tokenreview-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"authentication.k8s.io","version":"v1","resource":"tokenreviews"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: TokenReview Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: authenticationk8sio-tokenreview-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/authenticationk8sio-tokenreview-editor/README.md
+++ b/charts/authenticationk8sio-tokenreview-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/authenticationk8sio-tokenreview-editor --version=v0.4.8
-$ helm upgrade -i authenticationk8sio-tokenreview-editor bytebuilders-ui/authenticationk8sio-tokenreview-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/authenticationk8sio-tokenreview-editor --version=v0.4.9
+$ helm upgrade -i authenticationk8sio-tokenreview-editor bytebuilders-ui/authenticationk8sio-tokenreview-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a TokenReview Editor on a [Kubernetes](http://kubernetes.io) 
 To install/upgrade the chart with the release name `authenticationk8sio-tokenreview-editor`:
 
 ```bash
-$ helm upgrade -i authenticationk8sio-tokenreview-editor bytebuilders-ui/authenticationk8sio-tokenreview-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i authenticationk8sio-tokenreview-editor bytebuilders-ui/authenticationk8sio-tokenreview-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a TokenReview Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `authenticationk8si
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i authenticationk8sio-tokenreview-editor bytebuilders-ui/authenticationk8sio-tokenreview-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=authentication.k8s.io/v1
+$ helm upgrade -i authenticationk8sio-tokenreview-editor bytebuilders-ui/authenticationk8sio-tokenreview-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=authentication.k8s.io/v1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i authenticationk8sio-tokenreview-editor bytebuilders-ui/authenticationk8sio-tokenreview-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i authenticationk8sio-tokenreview-editor bytebuilders-ui/authenticationk8sio-tokenreview-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/authorizationk8sio-localsubjectaccessreview-editor/Chart.yaml
+++ b/charts/authorizationk8sio-localsubjectaccessreview-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"authorization.k8s.io","version":"v1","resource":"localsubjectaccessreviews"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: LocalSubjectAccessReview Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: authorizationk8sio-localsubjectaccessreview-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/authorizationk8sio-localsubjectaccessreview-editor/README.md
+++ b/charts/authorizationk8sio-localsubjectaccessreview-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/authorizationk8sio-localsubjectaccessreview-editor --version=v0.4.8
-$ helm upgrade -i authorizationk8sio-localsubjectaccessreview-editor bytebuilders-ui/authorizationk8sio-localsubjectaccessreview-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/authorizationk8sio-localsubjectaccessreview-editor --version=v0.4.9
+$ helm upgrade -i authorizationk8sio-localsubjectaccessreview-editor bytebuilders-ui/authorizationk8sio-localsubjectaccessreview-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a LocalSubjectAccessReview Editor on a [Kubernetes](http://ku
 To install/upgrade the chart with the release name `authorizationk8sio-localsubjectaccessreview-editor`:
 
 ```bash
-$ helm upgrade -i authorizationk8sio-localsubjectaccessreview-editor bytebuilders-ui/authorizationk8sio-localsubjectaccessreview-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i authorizationk8sio-localsubjectaccessreview-editor bytebuilders-ui/authorizationk8sio-localsubjectaccessreview-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a LocalSubjectAccessReview Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `authorizationk8sio
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i authorizationk8sio-localsubjectaccessreview-editor bytebuilders-ui/authorizationk8sio-localsubjectaccessreview-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=authorization.k8s.io/v1
+$ helm upgrade -i authorizationk8sio-localsubjectaccessreview-editor bytebuilders-ui/authorizationk8sio-localsubjectaccessreview-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=authorization.k8s.io/v1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i authorizationk8sio-localsubjectaccessreview-editor bytebuilders-ui/authorizationk8sio-localsubjectaccessreview-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i authorizationk8sio-localsubjectaccessreview-editor bytebuilders-ui/authorizationk8sio-localsubjectaccessreview-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/authorizationk8sio-selfsubjectaccessreview-editor/Chart.yaml
+++ b/charts/authorizationk8sio-selfsubjectaccessreview-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"authorization.k8s.io","version":"v1","resource":"selfsubjectaccessreviews"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: SelfSubjectAccessReview Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: authorizationk8sio-selfsubjectaccessreview-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/authorizationk8sio-selfsubjectaccessreview-editor/README.md
+++ b/charts/authorizationk8sio-selfsubjectaccessreview-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/authorizationk8sio-selfsubjectaccessreview-editor --version=v0.4.8
-$ helm upgrade -i authorizationk8sio-selfsubjectaccessreview-editor bytebuilders-ui/authorizationk8sio-selfsubjectaccessreview-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/authorizationk8sio-selfsubjectaccessreview-editor --version=v0.4.9
+$ helm upgrade -i authorizationk8sio-selfsubjectaccessreview-editor bytebuilders-ui/authorizationk8sio-selfsubjectaccessreview-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a SelfSubjectAccessReview Editor on a [Kubernetes](http://kub
 To install/upgrade the chart with the release name `authorizationk8sio-selfsubjectaccessreview-editor`:
 
 ```bash
-$ helm upgrade -i authorizationk8sio-selfsubjectaccessreview-editor bytebuilders-ui/authorizationk8sio-selfsubjectaccessreview-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i authorizationk8sio-selfsubjectaccessreview-editor bytebuilders-ui/authorizationk8sio-selfsubjectaccessreview-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a SelfSubjectAccessReview Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `authorizationk8sio
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i authorizationk8sio-selfsubjectaccessreview-editor bytebuilders-ui/authorizationk8sio-selfsubjectaccessreview-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=authorization.k8s.io/v1
+$ helm upgrade -i authorizationk8sio-selfsubjectaccessreview-editor bytebuilders-ui/authorizationk8sio-selfsubjectaccessreview-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=authorization.k8s.io/v1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i authorizationk8sio-selfsubjectaccessreview-editor bytebuilders-ui/authorizationk8sio-selfsubjectaccessreview-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i authorizationk8sio-selfsubjectaccessreview-editor bytebuilders-ui/authorizationk8sio-selfsubjectaccessreview-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/authorizationk8sio-selfsubjectrulesreview-editor/Chart.yaml
+++ b/charts/authorizationk8sio-selfsubjectrulesreview-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"authorization.k8s.io","version":"v1","resource":"selfsubjectrulesreviews"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: SelfSubjectRulesReview Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: authorizationk8sio-selfsubjectrulesreview-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/authorizationk8sio-selfsubjectrulesreview-editor/README.md
+++ b/charts/authorizationk8sio-selfsubjectrulesreview-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/authorizationk8sio-selfsubjectrulesreview-editor --version=v0.4.8
-$ helm upgrade -i authorizationk8sio-selfsubjectrulesreview-editor bytebuilders-ui/authorizationk8sio-selfsubjectrulesreview-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/authorizationk8sio-selfsubjectrulesreview-editor --version=v0.4.9
+$ helm upgrade -i authorizationk8sio-selfsubjectrulesreview-editor bytebuilders-ui/authorizationk8sio-selfsubjectrulesreview-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a SelfSubjectRulesReview Editor on a [Kubernetes](http://kube
 To install/upgrade the chart with the release name `authorizationk8sio-selfsubjectrulesreview-editor`:
 
 ```bash
-$ helm upgrade -i authorizationk8sio-selfsubjectrulesreview-editor bytebuilders-ui/authorizationk8sio-selfsubjectrulesreview-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i authorizationk8sio-selfsubjectrulesreview-editor bytebuilders-ui/authorizationk8sio-selfsubjectrulesreview-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a SelfSubjectRulesReview Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `authorizationk8sio
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i authorizationk8sio-selfsubjectrulesreview-editor bytebuilders-ui/authorizationk8sio-selfsubjectrulesreview-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=authorization.k8s.io/v1
+$ helm upgrade -i authorizationk8sio-selfsubjectrulesreview-editor bytebuilders-ui/authorizationk8sio-selfsubjectrulesreview-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=authorization.k8s.io/v1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i authorizationk8sio-selfsubjectrulesreview-editor bytebuilders-ui/authorizationk8sio-selfsubjectrulesreview-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i authorizationk8sio-selfsubjectrulesreview-editor bytebuilders-ui/authorizationk8sio-selfsubjectrulesreview-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/authorizationk8sio-subjectaccessreview-editor/Chart.yaml
+++ b/charts/authorizationk8sio-subjectaccessreview-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"authorization.k8s.io","version":"v1","resource":"subjectaccessreviews"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: SubjectAccessReview Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: authorizationk8sio-subjectaccessreview-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/authorizationk8sio-subjectaccessreview-editor/README.md
+++ b/charts/authorizationk8sio-subjectaccessreview-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/authorizationk8sio-subjectaccessreview-editor --version=v0.4.8
-$ helm upgrade -i authorizationk8sio-subjectaccessreview-editor bytebuilders-ui/authorizationk8sio-subjectaccessreview-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/authorizationk8sio-subjectaccessreview-editor --version=v0.4.9
+$ helm upgrade -i authorizationk8sio-subjectaccessreview-editor bytebuilders-ui/authorizationk8sio-subjectaccessreview-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a SubjectAccessReview Editor on a [Kubernetes](http://kuberne
 To install/upgrade the chart with the release name `authorizationk8sio-subjectaccessreview-editor`:
 
 ```bash
-$ helm upgrade -i authorizationk8sio-subjectaccessreview-editor bytebuilders-ui/authorizationk8sio-subjectaccessreview-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i authorizationk8sio-subjectaccessreview-editor bytebuilders-ui/authorizationk8sio-subjectaccessreview-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a SubjectAccessReview Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `authorizationk8sio
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i authorizationk8sio-subjectaccessreview-editor bytebuilders-ui/authorizationk8sio-subjectaccessreview-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=authorization.k8s.io/v1
+$ helm upgrade -i authorizationk8sio-subjectaccessreview-editor bytebuilders-ui/authorizationk8sio-subjectaccessreview-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=authorization.k8s.io/v1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i authorizationk8sio-subjectaccessreview-editor bytebuilders-ui/authorizationk8sio-subjectaccessreview-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i authorizationk8sio-subjectaccessreview-editor bytebuilders-ui/authorizationk8sio-subjectaccessreview-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/autoscaling-horizontalpodautoscaler-editor/Chart.yaml
+++ b/charts/autoscaling-horizontalpodautoscaler-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"autoscaling","version":"v2beta2","resource":"horizontalpodautoscalers"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: HorizontalPodAutoscaler Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: autoscaling-horizontalpodautoscaler-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/autoscaling-horizontalpodautoscaler-editor/README.md
+++ b/charts/autoscaling-horizontalpodautoscaler-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/autoscaling-horizontalpodautoscaler-editor --version=v0.4.8
-$ helm upgrade -i autoscaling-horizontalpodautoscaler-editor bytebuilders-ui/autoscaling-horizontalpodautoscaler-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/autoscaling-horizontalpodautoscaler-editor --version=v0.4.9
+$ helm upgrade -i autoscaling-horizontalpodautoscaler-editor bytebuilders-ui/autoscaling-horizontalpodautoscaler-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a HorizontalPodAutoscaler Editor on a [Kubernetes](http://kub
 To install/upgrade the chart with the release name `autoscaling-horizontalpodautoscaler-editor`:
 
 ```bash
-$ helm upgrade -i autoscaling-horizontalpodautoscaler-editor bytebuilders-ui/autoscaling-horizontalpodautoscaler-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i autoscaling-horizontalpodautoscaler-editor bytebuilders-ui/autoscaling-horizontalpodautoscaler-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a HorizontalPodAutoscaler Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `autoscaling-horizo
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i autoscaling-horizontalpodautoscaler-editor bytebuilders-ui/autoscaling-horizontalpodautoscaler-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=autoscaling/v2beta2
+$ helm upgrade -i autoscaling-horizontalpodautoscaler-editor bytebuilders-ui/autoscaling-horizontalpodautoscaler-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=autoscaling/v2beta2
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i autoscaling-horizontalpodautoscaler-editor bytebuilders-ui/autoscaling-horizontalpodautoscaler-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i autoscaling-horizontalpodautoscaler-editor bytebuilders-ui/autoscaling-horizontalpodautoscaler-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/autoscalingk8sio-verticalpodautoscaler-editor/Chart.yaml
+++ b/charts/autoscalingk8sio-verticalpodautoscaler-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"autoscaling.k8s.io","version":"v1","resource":"verticalpodautoscalers"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: VerticalPodAutoscaler Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: autoscalingk8sio-verticalpodautoscaler-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/autoscalingk8sio-verticalpodautoscaler-editor/README.md
+++ b/charts/autoscalingk8sio-verticalpodautoscaler-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/autoscalingk8sio-verticalpodautoscaler-editor --version=v0.4.8
-$ helm upgrade -i autoscalingk8sio-verticalpodautoscaler-editor bytebuilders-ui/autoscalingk8sio-verticalpodautoscaler-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/autoscalingk8sio-verticalpodautoscaler-editor --version=v0.4.9
+$ helm upgrade -i autoscalingk8sio-verticalpodautoscaler-editor bytebuilders-ui/autoscalingk8sio-verticalpodautoscaler-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a VerticalPodAutoscaler Editor on a [Kubernetes](http://kuber
 To install/upgrade the chart with the release name `autoscalingk8sio-verticalpodautoscaler-editor`:
 
 ```bash
-$ helm upgrade -i autoscalingk8sio-verticalpodautoscaler-editor bytebuilders-ui/autoscalingk8sio-verticalpodautoscaler-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i autoscalingk8sio-verticalpodautoscaler-editor bytebuilders-ui/autoscalingk8sio-verticalpodautoscaler-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a VerticalPodAutoscaler Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `autoscalingk8sio-v
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i autoscalingk8sio-verticalpodautoscaler-editor bytebuilders-ui/autoscalingk8sio-verticalpodautoscaler-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=autoscaling.k8s.io/v1
+$ helm upgrade -i autoscalingk8sio-verticalpodautoscaler-editor bytebuilders-ui/autoscalingk8sio-verticalpodautoscaler-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=autoscaling.k8s.io/v1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i autoscalingk8sio-verticalpodautoscaler-editor bytebuilders-ui/autoscalingk8sio-verticalpodautoscaler-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i autoscalingk8sio-verticalpodautoscaler-editor bytebuilders-ui/autoscalingk8sio-verticalpodautoscaler-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/autoscalingk8sio-verticalpodautoscalercheckpoint-editor/Chart.yaml
+++ b/charts/autoscalingk8sio-verticalpodautoscalercheckpoint-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"autoscaling.k8s.io","version":"v1","resource":"verticalpodautoscalercheckpoints"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: VerticalPodAutoscalerCheckpoint Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: autoscalingk8sio-verticalpodautoscalercheckpoint-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/autoscalingk8sio-verticalpodautoscalercheckpoint-editor/README.md
+++ b/charts/autoscalingk8sio-verticalpodautoscalercheckpoint-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/autoscalingk8sio-verticalpodautoscalercheckpoint-editor --version=v0.4.8
-$ helm upgrade -i autoscalingk8sio-verticalpodautoscalercheckpoint-editor bytebuilders-ui/autoscalingk8sio-verticalpodautoscalercheckpoint-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/autoscalingk8sio-verticalpodautoscalercheckpoint-editor --version=v0.4.9
+$ helm upgrade -i autoscalingk8sio-verticalpodautoscalercheckpoint-editor bytebuilders-ui/autoscalingk8sio-verticalpodautoscalercheckpoint-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a VerticalPodAutoscalerCheckpoint Editor on a [Kubernetes](ht
 To install/upgrade the chart with the release name `autoscalingk8sio-verticalpodautoscalercheckpoint-editor`:
 
 ```bash
-$ helm upgrade -i autoscalingk8sio-verticalpodautoscalercheckpoint-editor bytebuilders-ui/autoscalingk8sio-verticalpodautoscalercheckpoint-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i autoscalingk8sio-verticalpodautoscalercheckpoint-editor bytebuilders-ui/autoscalingk8sio-verticalpodautoscalercheckpoint-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a VerticalPodAutoscalerCheckpoint Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `autoscalingk8sio-v
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i autoscalingk8sio-verticalpodautoscalercheckpoint-editor bytebuilders-ui/autoscalingk8sio-verticalpodautoscalercheckpoint-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=autoscaling.k8s.io/v1
+$ helm upgrade -i autoscalingk8sio-verticalpodautoscalercheckpoint-editor bytebuilders-ui/autoscalingk8sio-verticalpodautoscalercheckpoint-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=autoscaling.k8s.io/v1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i autoscalingk8sio-verticalpodautoscalercheckpoint-editor bytebuilders-ui/autoscalingk8sio-verticalpodautoscalercheckpoint-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i autoscalingk8sio-verticalpodautoscalercheckpoint-editor bytebuilders-ui/autoscalingk8sio-verticalpodautoscalercheckpoint-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/autoscalingkubedbcom-elasticsearchautoscaler-editor/Chart.yaml
+++ b/charts/autoscalingkubedbcom-elasticsearchautoscaler-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"autoscaling.kubedb.com","version":"v1alpha1","resource":"elasticsearchautoscalers"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: ElasticsearchAutoscaler Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: autoscalingkubedbcom-elasticsearchautoscaler-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/autoscalingkubedbcom-elasticsearchautoscaler-editor/README.md
+++ b/charts/autoscalingkubedbcom-elasticsearchautoscaler-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/autoscalingkubedbcom-elasticsearchautoscaler-editor --version=v0.4.8
-$ helm upgrade -i autoscalingkubedbcom-elasticsearchautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-elasticsearchautoscaler-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/autoscalingkubedbcom-elasticsearchautoscaler-editor --version=v0.4.9
+$ helm upgrade -i autoscalingkubedbcom-elasticsearchautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-elasticsearchautoscaler-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a ElasticsearchAutoscaler Editor on a [Kubernetes](http://kub
 To install/upgrade the chart with the release name `autoscalingkubedbcom-elasticsearchautoscaler-editor`:
 
 ```bash
-$ helm upgrade -i autoscalingkubedbcom-elasticsearchautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-elasticsearchautoscaler-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i autoscalingkubedbcom-elasticsearchautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-elasticsearchautoscaler-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a ElasticsearchAutoscaler Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `autoscalingkubedbc
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i autoscalingkubedbcom-elasticsearchautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-elasticsearchautoscaler-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=autoscaling.kubedb.com/v1alpha1
+$ helm upgrade -i autoscalingkubedbcom-elasticsearchautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-elasticsearchautoscaler-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=autoscaling.kubedb.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i autoscalingkubedbcom-elasticsearchautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-elasticsearchautoscaler-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i autoscalingkubedbcom-elasticsearchautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-elasticsearchautoscaler-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/autoscalingkubedbcom-etcdautoscaler-editor/Chart.yaml
+++ b/charts/autoscalingkubedbcom-etcdautoscaler-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"autoscaling.kubedb.com","version":"v1alpha1","resource":"etcdautoscalers"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: EtcdAutoscaler Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: autoscalingkubedbcom-etcdautoscaler-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/autoscalingkubedbcom-etcdautoscaler-editor/README.md
+++ b/charts/autoscalingkubedbcom-etcdautoscaler-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/autoscalingkubedbcom-etcdautoscaler-editor --version=v0.4.8
-$ helm upgrade -i autoscalingkubedbcom-etcdautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-etcdautoscaler-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/autoscalingkubedbcom-etcdautoscaler-editor --version=v0.4.9
+$ helm upgrade -i autoscalingkubedbcom-etcdautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-etcdautoscaler-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a EtcdAutoscaler Editor on a [Kubernetes](http://kubernetes.i
 To install/upgrade the chart with the release name `autoscalingkubedbcom-etcdautoscaler-editor`:
 
 ```bash
-$ helm upgrade -i autoscalingkubedbcom-etcdautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-etcdautoscaler-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i autoscalingkubedbcom-etcdautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-etcdautoscaler-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a EtcdAutoscaler Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `autoscalingkubedbc
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i autoscalingkubedbcom-etcdautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-etcdautoscaler-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=autoscaling.kubedb.com/v1alpha1
+$ helm upgrade -i autoscalingkubedbcom-etcdautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-etcdautoscaler-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=autoscaling.kubedb.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i autoscalingkubedbcom-etcdautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-etcdautoscaler-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i autoscalingkubedbcom-etcdautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-etcdautoscaler-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/autoscalingkubedbcom-mariadbautoscaler-editor/Chart.yaml
+++ b/charts/autoscalingkubedbcom-mariadbautoscaler-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"autoscaling.kubedb.com","version":"v1alpha1","resource":"mariadbautoscalers"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: MariaDBAutoscaler Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: autoscalingkubedbcom-mariadbautoscaler-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/autoscalingkubedbcom-mariadbautoscaler-editor/README.md
+++ b/charts/autoscalingkubedbcom-mariadbautoscaler-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/autoscalingkubedbcom-mariadbautoscaler-editor --version=v0.4.8
-$ helm upgrade -i autoscalingkubedbcom-mariadbautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-mariadbautoscaler-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/autoscalingkubedbcom-mariadbautoscaler-editor --version=v0.4.9
+$ helm upgrade -i autoscalingkubedbcom-mariadbautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-mariadbautoscaler-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a MariaDBAutoscaler Editor on a [Kubernetes](http://kubernete
 To install/upgrade the chart with the release name `autoscalingkubedbcom-mariadbautoscaler-editor`:
 
 ```bash
-$ helm upgrade -i autoscalingkubedbcom-mariadbautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-mariadbautoscaler-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i autoscalingkubedbcom-mariadbautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-mariadbautoscaler-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a MariaDBAutoscaler Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `autoscalingkubedbc
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i autoscalingkubedbcom-mariadbautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-mariadbautoscaler-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=autoscaling.kubedb.com/v1alpha1
+$ helm upgrade -i autoscalingkubedbcom-mariadbautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-mariadbautoscaler-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=autoscaling.kubedb.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i autoscalingkubedbcom-mariadbautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-mariadbautoscaler-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i autoscalingkubedbcom-mariadbautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-mariadbautoscaler-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/autoscalingkubedbcom-memcachedautoscaler-editor/Chart.yaml
+++ b/charts/autoscalingkubedbcom-memcachedautoscaler-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"autoscaling.kubedb.com","version":"v1alpha1","resource":"memcachedautoscalers"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: MemcachedAutoscaler Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: autoscalingkubedbcom-memcachedautoscaler-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/autoscalingkubedbcom-memcachedautoscaler-editor/README.md
+++ b/charts/autoscalingkubedbcom-memcachedautoscaler-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/autoscalingkubedbcom-memcachedautoscaler-editor --version=v0.4.8
-$ helm upgrade -i autoscalingkubedbcom-memcachedautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-memcachedautoscaler-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/autoscalingkubedbcom-memcachedautoscaler-editor --version=v0.4.9
+$ helm upgrade -i autoscalingkubedbcom-memcachedautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-memcachedautoscaler-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a MemcachedAutoscaler Editor on a [Kubernetes](http://kuberne
 To install/upgrade the chart with the release name `autoscalingkubedbcom-memcachedautoscaler-editor`:
 
 ```bash
-$ helm upgrade -i autoscalingkubedbcom-memcachedautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-memcachedautoscaler-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i autoscalingkubedbcom-memcachedautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-memcachedautoscaler-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a MemcachedAutoscaler Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `autoscalingkubedbc
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i autoscalingkubedbcom-memcachedautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-memcachedautoscaler-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=autoscaling.kubedb.com/v1alpha1
+$ helm upgrade -i autoscalingkubedbcom-memcachedautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-memcachedautoscaler-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=autoscaling.kubedb.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i autoscalingkubedbcom-memcachedautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-memcachedautoscaler-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i autoscalingkubedbcom-memcachedautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-memcachedautoscaler-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/autoscalingkubedbcom-mongodbautoscaler-editor/Chart.yaml
+++ b/charts/autoscalingkubedbcom-mongodbautoscaler-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"autoscaling.kubedb.com","version":"v1alpha1","resource":"mongodbautoscalers"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: MongoDBAutoscaler Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: autoscalingkubedbcom-mongodbautoscaler-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/autoscalingkubedbcom-mongodbautoscaler-editor/README.md
+++ b/charts/autoscalingkubedbcom-mongodbautoscaler-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/autoscalingkubedbcom-mongodbautoscaler-editor --version=v0.4.8
-$ helm upgrade -i autoscalingkubedbcom-mongodbautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-mongodbautoscaler-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/autoscalingkubedbcom-mongodbautoscaler-editor --version=v0.4.9
+$ helm upgrade -i autoscalingkubedbcom-mongodbautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-mongodbautoscaler-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a MongoDBAutoscaler Editor on a [Kubernetes](http://kubernete
 To install/upgrade the chart with the release name `autoscalingkubedbcom-mongodbautoscaler-editor`:
 
 ```bash
-$ helm upgrade -i autoscalingkubedbcom-mongodbautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-mongodbautoscaler-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i autoscalingkubedbcom-mongodbautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-mongodbautoscaler-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a MongoDBAutoscaler Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `autoscalingkubedbc
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i autoscalingkubedbcom-mongodbautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-mongodbautoscaler-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=autoscaling.kubedb.com/v1alpha1
+$ helm upgrade -i autoscalingkubedbcom-mongodbautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-mongodbautoscaler-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=autoscaling.kubedb.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i autoscalingkubedbcom-mongodbautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-mongodbautoscaler-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i autoscalingkubedbcom-mongodbautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-mongodbautoscaler-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/autoscalingkubedbcom-mysqlautoscaler-editor/Chart.yaml
+++ b/charts/autoscalingkubedbcom-mysqlautoscaler-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"autoscaling.kubedb.com","version":"v1alpha1","resource":"mysqlautoscalers"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: MySQLAutoscaler Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: autoscalingkubedbcom-mysqlautoscaler-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/autoscalingkubedbcom-mysqlautoscaler-editor/README.md
+++ b/charts/autoscalingkubedbcom-mysqlautoscaler-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/autoscalingkubedbcom-mysqlautoscaler-editor --version=v0.4.8
-$ helm upgrade -i autoscalingkubedbcom-mysqlautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-mysqlautoscaler-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/autoscalingkubedbcom-mysqlautoscaler-editor --version=v0.4.9
+$ helm upgrade -i autoscalingkubedbcom-mysqlautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-mysqlautoscaler-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a MySQLAutoscaler Editor on a [Kubernetes](http://kubernetes.
 To install/upgrade the chart with the release name `autoscalingkubedbcom-mysqlautoscaler-editor`:
 
 ```bash
-$ helm upgrade -i autoscalingkubedbcom-mysqlautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-mysqlautoscaler-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i autoscalingkubedbcom-mysqlautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-mysqlautoscaler-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a MySQLAutoscaler Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `autoscalingkubedbc
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i autoscalingkubedbcom-mysqlautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-mysqlautoscaler-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=autoscaling.kubedb.com/v1alpha1
+$ helm upgrade -i autoscalingkubedbcom-mysqlautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-mysqlautoscaler-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=autoscaling.kubedb.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i autoscalingkubedbcom-mysqlautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-mysqlautoscaler-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i autoscalingkubedbcom-mysqlautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-mysqlautoscaler-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/autoscalingkubedbcom-perconaxtradbautoscaler-editor/Chart.yaml
+++ b/charts/autoscalingkubedbcom-perconaxtradbautoscaler-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"autoscaling.kubedb.com","version":"v1alpha1","resource":"perconaxtradbautoscalers"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: PerconaXtraDBAutoscaler Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: autoscalingkubedbcom-perconaxtradbautoscaler-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/autoscalingkubedbcom-perconaxtradbautoscaler-editor/README.md
+++ b/charts/autoscalingkubedbcom-perconaxtradbautoscaler-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/autoscalingkubedbcom-perconaxtradbautoscaler-editor --version=v0.4.8
-$ helm upgrade -i autoscalingkubedbcom-perconaxtradbautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-perconaxtradbautoscaler-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/autoscalingkubedbcom-perconaxtradbautoscaler-editor --version=v0.4.9
+$ helm upgrade -i autoscalingkubedbcom-perconaxtradbautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-perconaxtradbautoscaler-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a PerconaXtraDBAutoscaler Editor on a [Kubernetes](http://kub
 To install/upgrade the chart with the release name `autoscalingkubedbcom-perconaxtradbautoscaler-editor`:
 
 ```bash
-$ helm upgrade -i autoscalingkubedbcom-perconaxtradbautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-perconaxtradbautoscaler-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i autoscalingkubedbcom-perconaxtradbautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-perconaxtradbautoscaler-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a PerconaXtraDBAutoscaler Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `autoscalingkubedbc
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i autoscalingkubedbcom-perconaxtradbautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-perconaxtradbautoscaler-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=autoscaling.kubedb.com/v1alpha1
+$ helm upgrade -i autoscalingkubedbcom-perconaxtradbautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-perconaxtradbautoscaler-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=autoscaling.kubedb.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i autoscalingkubedbcom-perconaxtradbautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-perconaxtradbautoscaler-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i autoscalingkubedbcom-perconaxtradbautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-perconaxtradbautoscaler-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/autoscalingkubedbcom-pgbouncerautoscaler-editor/Chart.yaml
+++ b/charts/autoscalingkubedbcom-pgbouncerautoscaler-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"autoscaling.kubedb.com","version":"v1alpha1","resource":"pgbouncerautoscalers"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: PgBouncerAutoscaler Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: autoscalingkubedbcom-pgbouncerautoscaler-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/autoscalingkubedbcom-pgbouncerautoscaler-editor/README.md
+++ b/charts/autoscalingkubedbcom-pgbouncerautoscaler-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/autoscalingkubedbcom-pgbouncerautoscaler-editor --version=v0.4.8
-$ helm upgrade -i autoscalingkubedbcom-pgbouncerautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-pgbouncerautoscaler-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/autoscalingkubedbcom-pgbouncerautoscaler-editor --version=v0.4.9
+$ helm upgrade -i autoscalingkubedbcom-pgbouncerautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-pgbouncerautoscaler-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a PgBouncerAutoscaler Editor on a [Kubernetes](http://kuberne
 To install/upgrade the chart with the release name `autoscalingkubedbcom-pgbouncerautoscaler-editor`:
 
 ```bash
-$ helm upgrade -i autoscalingkubedbcom-pgbouncerautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-pgbouncerautoscaler-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i autoscalingkubedbcom-pgbouncerautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-pgbouncerautoscaler-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a PgBouncerAutoscaler Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `autoscalingkubedbc
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i autoscalingkubedbcom-pgbouncerautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-pgbouncerautoscaler-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=autoscaling.kubedb.com/v1alpha1
+$ helm upgrade -i autoscalingkubedbcom-pgbouncerautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-pgbouncerautoscaler-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=autoscaling.kubedb.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i autoscalingkubedbcom-pgbouncerautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-pgbouncerautoscaler-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i autoscalingkubedbcom-pgbouncerautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-pgbouncerautoscaler-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/autoscalingkubedbcom-postgresautoscaler-editor/Chart.yaml
+++ b/charts/autoscalingkubedbcom-postgresautoscaler-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"autoscaling.kubedb.com","version":"v1alpha1","resource":"postgresautoscalers"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: PostgresAutoscaler Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: autoscalingkubedbcom-postgresautoscaler-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/autoscalingkubedbcom-postgresautoscaler-editor/README.md
+++ b/charts/autoscalingkubedbcom-postgresautoscaler-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/autoscalingkubedbcom-postgresautoscaler-editor --version=v0.4.8
-$ helm upgrade -i autoscalingkubedbcom-postgresautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-postgresautoscaler-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/autoscalingkubedbcom-postgresautoscaler-editor --version=v0.4.9
+$ helm upgrade -i autoscalingkubedbcom-postgresautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-postgresautoscaler-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a PostgresAutoscaler Editor on a [Kubernetes](http://kubernet
 To install/upgrade the chart with the release name `autoscalingkubedbcom-postgresautoscaler-editor`:
 
 ```bash
-$ helm upgrade -i autoscalingkubedbcom-postgresautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-postgresautoscaler-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i autoscalingkubedbcom-postgresautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-postgresautoscaler-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a PostgresAutoscaler Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `autoscalingkubedbc
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i autoscalingkubedbcom-postgresautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-postgresautoscaler-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=autoscaling.kubedb.com/v1alpha1
+$ helm upgrade -i autoscalingkubedbcom-postgresautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-postgresautoscaler-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=autoscaling.kubedb.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i autoscalingkubedbcom-postgresautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-postgresautoscaler-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i autoscalingkubedbcom-postgresautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-postgresautoscaler-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/autoscalingkubedbcom-proxysqlautoscaler-editor/Chart.yaml
+++ b/charts/autoscalingkubedbcom-proxysqlautoscaler-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"autoscaling.kubedb.com","version":"v1alpha1","resource":"proxysqlautoscalers"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: ProxySQLAutoscaler Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: autoscalingkubedbcom-proxysqlautoscaler-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/autoscalingkubedbcom-proxysqlautoscaler-editor/README.md
+++ b/charts/autoscalingkubedbcom-proxysqlautoscaler-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/autoscalingkubedbcom-proxysqlautoscaler-editor --version=v0.4.8
-$ helm upgrade -i autoscalingkubedbcom-proxysqlautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-proxysqlautoscaler-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/autoscalingkubedbcom-proxysqlautoscaler-editor --version=v0.4.9
+$ helm upgrade -i autoscalingkubedbcom-proxysqlautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-proxysqlautoscaler-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a ProxySQLAutoscaler Editor on a [Kubernetes](http://kubernet
 To install/upgrade the chart with the release name `autoscalingkubedbcom-proxysqlautoscaler-editor`:
 
 ```bash
-$ helm upgrade -i autoscalingkubedbcom-proxysqlautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-proxysqlautoscaler-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i autoscalingkubedbcom-proxysqlautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-proxysqlautoscaler-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a ProxySQLAutoscaler Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `autoscalingkubedbc
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i autoscalingkubedbcom-proxysqlautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-proxysqlautoscaler-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=autoscaling.kubedb.com/v1alpha1
+$ helm upgrade -i autoscalingkubedbcom-proxysqlautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-proxysqlautoscaler-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=autoscaling.kubedb.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i autoscalingkubedbcom-proxysqlautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-proxysqlautoscaler-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i autoscalingkubedbcom-proxysqlautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-proxysqlautoscaler-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/autoscalingkubedbcom-redisautoscaler-editor/Chart.yaml
+++ b/charts/autoscalingkubedbcom-redisautoscaler-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"autoscaling.kubedb.com","version":"v1alpha1","resource":"redisautoscalers"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: RedisAutoscaler Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: autoscalingkubedbcom-redisautoscaler-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/autoscalingkubedbcom-redisautoscaler-editor/README.md
+++ b/charts/autoscalingkubedbcom-redisautoscaler-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/autoscalingkubedbcom-redisautoscaler-editor --version=v0.4.8
-$ helm upgrade -i autoscalingkubedbcom-redisautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-redisautoscaler-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/autoscalingkubedbcom-redisautoscaler-editor --version=v0.4.9
+$ helm upgrade -i autoscalingkubedbcom-redisautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-redisautoscaler-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a RedisAutoscaler Editor on a [Kubernetes](http://kubernetes.
 To install/upgrade the chart with the release name `autoscalingkubedbcom-redisautoscaler-editor`:
 
 ```bash
-$ helm upgrade -i autoscalingkubedbcom-redisautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-redisautoscaler-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i autoscalingkubedbcom-redisautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-redisautoscaler-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a RedisAutoscaler Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `autoscalingkubedbc
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i autoscalingkubedbcom-redisautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-redisautoscaler-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=autoscaling.kubedb.com/v1alpha1
+$ helm upgrade -i autoscalingkubedbcom-redisautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-redisautoscaler-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=autoscaling.kubedb.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i autoscalingkubedbcom-redisautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-redisautoscaler-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i autoscalingkubedbcom-redisautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-redisautoscaler-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/autoscalingkubedbcom-verticalautoscaler-editor/Chart.yaml
+++ b/charts/autoscalingkubedbcom-verticalautoscaler-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"autoscaling.kubedb.com","version":"v1alpha1","resource":"verticalautoscalers"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: VerticalAutoscaler Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: autoscalingkubedbcom-verticalautoscaler-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/autoscalingkubedbcom-verticalautoscaler-editor/README.md
+++ b/charts/autoscalingkubedbcom-verticalautoscaler-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/autoscalingkubedbcom-verticalautoscaler-editor --version=v0.4.8
-$ helm upgrade -i autoscalingkubedbcom-verticalautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-verticalautoscaler-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/autoscalingkubedbcom-verticalautoscaler-editor --version=v0.4.9
+$ helm upgrade -i autoscalingkubedbcom-verticalautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-verticalautoscaler-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a VerticalAutoscaler Editor on a [Kubernetes](http://kubernet
 To install/upgrade the chart with the release name `autoscalingkubedbcom-verticalautoscaler-editor`:
 
 ```bash
-$ helm upgrade -i autoscalingkubedbcom-verticalautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-verticalautoscaler-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i autoscalingkubedbcom-verticalautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-verticalautoscaler-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a VerticalAutoscaler Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `autoscalingkubedbc
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i autoscalingkubedbcom-verticalautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-verticalautoscaler-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=autoscaling.kubedb.com/v1alpha1
+$ helm upgrade -i autoscalingkubedbcom-verticalautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-verticalautoscaler-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=autoscaling.kubedb.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i autoscalingkubedbcom-verticalautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-verticalautoscaler-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i autoscalingkubedbcom-verticalautoscaler-editor bytebuilders-ui/autoscalingkubedbcom-verticalautoscaler-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/autoscalingkubedbcom-verticalautoscalercheckpoint-editor/Chart.yaml
+++ b/charts/autoscalingkubedbcom-verticalautoscalercheckpoint-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"autoscaling.kubedb.com","version":"v1alpha1","resource":"verticalautoscalercheckpoints"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: VerticalAutoscalerCheckpoint Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: autoscalingkubedbcom-verticalautoscalercheckpoint-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/autoscalingkubedbcom-verticalautoscalercheckpoint-editor/README.md
+++ b/charts/autoscalingkubedbcom-verticalautoscalercheckpoint-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/autoscalingkubedbcom-verticalautoscalercheckpoint-editor --version=v0.4.8
-$ helm upgrade -i autoscalingkubedbcom-verticalautoscalercheckpoint-editor bytebuilders-ui/autoscalingkubedbcom-verticalautoscalercheckpoint-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/autoscalingkubedbcom-verticalautoscalercheckpoint-editor --version=v0.4.9
+$ helm upgrade -i autoscalingkubedbcom-verticalautoscalercheckpoint-editor bytebuilders-ui/autoscalingkubedbcom-verticalautoscalercheckpoint-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a VerticalAutoscalerCheckpoint Editor on a [Kubernetes](http:
 To install/upgrade the chart with the release name `autoscalingkubedbcom-verticalautoscalercheckpoint-editor`:
 
 ```bash
-$ helm upgrade -i autoscalingkubedbcom-verticalautoscalercheckpoint-editor bytebuilders-ui/autoscalingkubedbcom-verticalautoscalercheckpoint-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i autoscalingkubedbcom-verticalautoscalercheckpoint-editor bytebuilders-ui/autoscalingkubedbcom-verticalautoscalercheckpoint-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a VerticalAutoscalerCheckpoint Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `autoscalingkubedbc
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i autoscalingkubedbcom-verticalautoscalercheckpoint-editor bytebuilders-ui/autoscalingkubedbcom-verticalautoscalercheckpoint-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=autoscaling.kubedb.com/v1alpha1
+$ helm upgrade -i autoscalingkubedbcom-verticalautoscalercheckpoint-editor bytebuilders-ui/autoscalingkubedbcom-verticalautoscalercheckpoint-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=autoscaling.kubedb.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i autoscalingkubedbcom-verticalautoscalercheckpoint-editor bytebuilders-ui/autoscalingkubedbcom-verticalautoscalercheckpoint-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i autoscalingkubedbcom-verticalautoscalercheckpoint-editor bytebuilders-ui/autoscalingkubedbcom-verticalautoscalercheckpoint-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/batch-cronjob-editor/Chart.yaml
+++ b/charts/batch-cronjob-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"batch","version":"v1","resource":"cronjobs"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: CronJob Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: batch-cronjob-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/batch-cronjob-editor/README.md
+++ b/charts/batch-cronjob-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/batch-cronjob-editor --version=v0.4.8
-$ helm upgrade -i batch-cronjob-editor bytebuilders-ui/batch-cronjob-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/batch-cronjob-editor --version=v0.4.9
+$ helm upgrade -i batch-cronjob-editor bytebuilders-ui/batch-cronjob-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a CronJob Editor on a [Kubernetes](http://kubernetes.io) clus
 To install/upgrade the chart with the release name `batch-cronjob-editor`:
 
 ```bash
-$ helm upgrade -i batch-cronjob-editor bytebuilders-ui/batch-cronjob-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i batch-cronjob-editor bytebuilders-ui/batch-cronjob-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a CronJob Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `batch-cronjob-edit
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i batch-cronjob-editor bytebuilders-ui/batch-cronjob-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=batch/v1
+$ helm upgrade -i batch-cronjob-editor bytebuilders-ui/batch-cronjob-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=batch/v1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i batch-cronjob-editor bytebuilders-ui/batch-cronjob-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i batch-cronjob-editor bytebuilders-ui/batch-cronjob-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/batch-job-editor/Chart.yaml
+++ b/charts/batch-job-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"batch","version":"v1","resource":"jobs"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: Job Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: batch-job-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/batch-job-editor/README.md
+++ b/charts/batch-job-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/batch-job-editor --version=v0.4.8
-$ helm upgrade -i batch-job-editor bytebuilders-ui/batch-job-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/batch-job-editor --version=v0.4.9
+$ helm upgrade -i batch-job-editor bytebuilders-ui/batch-job-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a Job Editor on a [Kubernetes](http://kubernetes.io) cluster 
 To install/upgrade the chart with the release name `batch-job-editor`:
 
 ```bash
-$ helm upgrade -i batch-job-editor bytebuilders-ui/batch-job-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i batch-job-editor bytebuilders-ui/batch-job-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a Job Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `batch-job-editor` 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i batch-job-editor bytebuilders-ui/batch-job-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=batch/v1
+$ helm upgrade -i batch-job-editor bytebuilders-ui/batch-job-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=batch/v1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i batch-job-editor bytebuilders-ui/batch-job-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i batch-job-editor bytebuilders-ui/batch-job-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/batch-jobtemplate-editor/Chart.yaml
+++ b/charts/batch-jobtemplate-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"batch","version":"v1beta1","resource":"jobtemplates"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: JobTemplate Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: batch-jobtemplate-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/batch-jobtemplate-editor/README.md
+++ b/charts/batch-jobtemplate-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/batch-jobtemplate-editor --version=v0.4.8
-$ helm upgrade -i batch-jobtemplate-editor bytebuilders-ui/batch-jobtemplate-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/batch-jobtemplate-editor --version=v0.4.9
+$ helm upgrade -i batch-jobtemplate-editor bytebuilders-ui/batch-jobtemplate-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a JobTemplate Editor on a [Kubernetes](http://kubernetes.io) 
 To install/upgrade the chart with the release name `batch-jobtemplate-editor`:
 
 ```bash
-$ helm upgrade -i batch-jobtemplate-editor bytebuilders-ui/batch-jobtemplate-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i batch-jobtemplate-editor bytebuilders-ui/batch-jobtemplate-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a JobTemplate Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `batch-jobtemplate-
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i batch-jobtemplate-editor bytebuilders-ui/batch-jobtemplate-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=batch/v1beta1
+$ helm upgrade -i batch-jobtemplate-editor bytebuilders-ui/batch-jobtemplate-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=batch/v1beta1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i batch-jobtemplate-editor bytebuilders-ui/batch-jobtemplate-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i batch-jobtemplate-editor bytebuilders-ui/batch-jobtemplate-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/catalogkubedbcom-elasticsearchversion-editor/Chart.yaml
+++ b/charts/catalogkubedbcom-elasticsearchversion-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"catalog.kubedb.com","version":"v1alpha1","resource":"elasticsearchversions"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: ElasticsearchVersion Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: catalogkubedbcom-elasticsearchversion-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/catalogkubedbcom-elasticsearchversion-editor/README.md
+++ b/charts/catalogkubedbcom-elasticsearchversion-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/catalogkubedbcom-elasticsearchversion-editor --version=v0.4.8
-$ helm upgrade -i catalogkubedbcom-elasticsearchversion-editor bytebuilders-ui/catalogkubedbcom-elasticsearchversion-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/catalogkubedbcom-elasticsearchversion-editor --version=v0.4.9
+$ helm upgrade -i catalogkubedbcom-elasticsearchversion-editor bytebuilders-ui/catalogkubedbcom-elasticsearchversion-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a ElasticsearchVersion Editor on a [Kubernetes](http://kubern
 To install/upgrade the chart with the release name `catalogkubedbcom-elasticsearchversion-editor`:
 
 ```bash
-$ helm upgrade -i catalogkubedbcom-elasticsearchversion-editor bytebuilders-ui/catalogkubedbcom-elasticsearchversion-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i catalogkubedbcom-elasticsearchversion-editor bytebuilders-ui/catalogkubedbcom-elasticsearchversion-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a ElasticsearchVersion Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `catalogkubedbcom-e
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i catalogkubedbcom-elasticsearchversion-editor bytebuilders-ui/catalogkubedbcom-elasticsearchversion-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=catalog.kubedb.com/v1alpha1
+$ helm upgrade -i catalogkubedbcom-elasticsearchversion-editor bytebuilders-ui/catalogkubedbcom-elasticsearchversion-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=catalog.kubedb.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i catalogkubedbcom-elasticsearchversion-editor bytebuilders-ui/catalogkubedbcom-elasticsearchversion-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i catalogkubedbcom-elasticsearchversion-editor bytebuilders-ui/catalogkubedbcom-elasticsearchversion-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/catalogkubedbcom-etcdversion-editor/Chart.yaml
+++ b/charts/catalogkubedbcom-etcdversion-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"catalog.kubedb.com","version":"v1alpha1","resource":"etcdversions"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: EtcdVersion Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: catalogkubedbcom-etcdversion-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/catalogkubedbcom-etcdversion-editor/README.md
+++ b/charts/catalogkubedbcom-etcdversion-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/catalogkubedbcom-etcdversion-editor --version=v0.4.8
-$ helm upgrade -i catalogkubedbcom-etcdversion-editor bytebuilders-ui/catalogkubedbcom-etcdversion-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/catalogkubedbcom-etcdversion-editor --version=v0.4.9
+$ helm upgrade -i catalogkubedbcom-etcdversion-editor bytebuilders-ui/catalogkubedbcom-etcdversion-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a EtcdVersion Editor on a [Kubernetes](http://kubernetes.io) 
 To install/upgrade the chart with the release name `catalogkubedbcom-etcdversion-editor`:
 
 ```bash
-$ helm upgrade -i catalogkubedbcom-etcdversion-editor bytebuilders-ui/catalogkubedbcom-etcdversion-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i catalogkubedbcom-etcdversion-editor bytebuilders-ui/catalogkubedbcom-etcdversion-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a EtcdVersion Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `catalogkubedbcom-e
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i catalogkubedbcom-etcdversion-editor bytebuilders-ui/catalogkubedbcom-etcdversion-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=catalog.kubedb.com/v1alpha1
+$ helm upgrade -i catalogkubedbcom-etcdversion-editor bytebuilders-ui/catalogkubedbcom-etcdversion-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=catalog.kubedb.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i catalogkubedbcom-etcdversion-editor bytebuilders-ui/catalogkubedbcom-etcdversion-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i catalogkubedbcom-etcdversion-editor bytebuilders-ui/catalogkubedbcom-etcdversion-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/catalogkubedbcom-mariadbversion-editor/Chart.yaml
+++ b/charts/catalogkubedbcom-mariadbversion-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"catalog.kubedb.com","version":"v1alpha1","resource":"mariadbversions"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: MariaDBVersion Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: catalogkubedbcom-mariadbversion-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/catalogkubedbcom-mariadbversion-editor/README.md
+++ b/charts/catalogkubedbcom-mariadbversion-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/catalogkubedbcom-mariadbversion-editor --version=v0.4.8
-$ helm upgrade -i catalogkubedbcom-mariadbversion-editor bytebuilders-ui/catalogkubedbcom-mariadbversion-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/catalogkubedbcom-mariadbversion-editor --version=v0.4.9
+$ helm upgrade -i catalogkubedbcom-mariadbversion-editor bytebuilders-ui/catalogkubedbcom-mariadbversion-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a MariaDBVersion Editor on a [Kubernetes](http://kubernetes.i
 To install/upgrade the chart with the release name `catalogkubedbcom-mariadbversion-editor`:
 
 ```bash
-$ helm upgrade -i catalogkubedbcom-mariadbversion-editor bytebuilders-ui/catalogkubedbcom-mariadbversion-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i catalogkubedbcom-mariadbversion-editor bytebuilders-ui/catalogkubedbcom-mariadbversion-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a MariaDBVersion Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `catalogkubedbcom-m
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i catalogkubedbcom-mariadbversion-editor bytebuilders-ui/catalogkubedbcom-mariadbversion-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=catalog.kubedb.com/v1alpha1
+$ helm upgrade -i catalogkubedbcom-mariadbversion-editor bytebuilders-ui/catalogkubedbcom-mariadbversion-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=catalog.kubedb.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i catalogkubedbcom-mariadbversion-editor bytebuilders-ui/catalogkubedbcom-mariadbversion-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i catalogkubedbcom-mariadbversion-editor bytebuilders-ui/catalogkubedbcom-mariadbversion-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/catalogkubedbcom-memcachedversion-editor/Chart.yaml
+++ b/charts/catalogkubedbcom-memcachedversion-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"catalog.kubedb.com","version":"v1alpha1","resource":"memcachedversions"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: MemcachedVersion Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: catalogkubedbcom-memcachedversion-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/catalogkubedbcom-memcachedversion-editor/README.md
+++ b/charts/catalogkubedbcom-memcachedversion-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/catalogkubedbcom-memcachedversion-editor --version=v0.4.8
-$ helm upgrade -i catalogkubedbcom-memcachedversion-editor bytebuilders-ui/catalogkubedbcom-memcachedversion-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/catalogkubedbcom-memcachedversion-editor --version=v0.4.9
+$ helm upgrade -i catalogkubedbcom-memcachedversion-editor bytebuilders-ui/catalogkubedbcom-memcachedversion-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a MemcachedVersion Editor on a [Kubernetes](http://kubernetes
 To install/upgrade the chart with the release name `catalogkubedbcom-memcachedversion-editor`:
 
 ```bash
-$ helm upgrade -i catalogkubedbcom-memcachedversion-editor bytebuilders-ui/catalogkubedbcom-memcachedversion-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i catalogkubedbcom-memcachedversion-editor bytebuilders-ui/catalogkubedbcom-memcachedversion-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a MemcachedVersion Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `catalogkubedbcom-m
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i catalogkubedbcom-memcachedversion-editor bytebuilders-ui/catalogkubedbcom-memcachedversion-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=catalog.kubedb.com/v1alpha1
+$ helm upgrade -i catalogkubedbcom-memcachedversion-editor bytebuilders-ui/catalogkubedbcom-memcachedversion-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=catalog.kubedb.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i catalogkubedbcom-memcachedversion-editor bytebuilders-ui/catalogkubedbcom-memcachedversion-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i catalogkubedbcom-memcachedversion-editor bytebuilders-ui/catalogkubedbcom-memcachedversion-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/catalogkubedbcom-mongodbversion-editor/Chart.yaml
+++ b/charts/catalogkubedbcom-mongodbversion-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"catalog.kubedb.com","version":"v1alpha1","resource":"mongodbversions"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: MongoDBVersion Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: catalogkubedbcom-mongodbversion-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/catalogkubedbcom-mongodbversion-editor/README.md
+++ b/charts/catalogkubedbcom-mongodbversion-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/catalogkubedbcom-mongodbversion-editor --version=v0.4.8
-$ helm upgrade -i catalogkubedbcom-mongodbversion-editor bytebuilders-ui/catalogkubedbcom-mongodbversion-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/catalogkubedbcom-mongodbversion-editor --version=v0.4.9
+$ helm upgrade -i catalogkubedbcom-mongodbversion-editor bytebuilders-ui/catalogkubedbcom-mongodbversion-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a MongoDBVersion Editor on a [Kubernetes](http://kubernetes.i
 To install/upgrade the chart with the release name `catalogkubedbcom-mongodbversion-editor`:
 
 ```bash
-$ helm upgrade -i catalogkubedbcom-mongodbversion-editor bytebuilders-ui/catalogkubedbcom-mongodbversion-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i catalogkubedbcom-mongodbversion-editor bytebuilders-ui/catalogkubedbcom-mongodbversion-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a MongoDBVersion Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `catalogkubedbcom-m
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i catalogkubedbcom-mongodbversion-editor bytebuilders-ui/catalogkubedbcom-mongodbversion-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=catalog.kubedb.com/v1alpha1
+$ helm upgrade -i catalogkubedbcom-mongodbversion-editor bytebuilders-ui/catalogkubedbcom-mongodbversion-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=catalog.kubedb.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i catalogkubedbcom-mongodbversion-editor bytebuilders-ui/catalogkubedbcom-mongodbversion-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i catalogkubedbcom-mongodbversion-editor bytebuilders-ui/catalogkubedbcom-mongodbversion-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/catalogkubedbcom-mysqlversion-editor/Chart.yaml
+++ b/charts/catalogkubedbcom-mysqlversion-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"catalog.kubedb.com","version":"v1alpha1","resource":"mysqlversions"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: MySQLVersion Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: catalogkubedbcom-mysqlversion-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/catalogkubedbcom-mysqlversion-editor/README.md
+++ b/charts/catalogkubedbcom-mysqlversion-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/catalogkubedbcom-mysqlversion-editor --version=v0.4.8
-$ helm upgrade -i catalogkubedbcom-mysqlversion-editor bytebuilders-ui/catalogkubedbcom-mysqlversion-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/catalogkubedbcom-mysqlversion-editor --version=v0.4.9
+$ helm upgrade -i catalogkubedbcom-mysqlversion-editor bytebuilders-ui/catalogkubedbcom-mysqlversion-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a MySQLVersion Editor on a [Kubernetes](http://kubernetes.io)
 To install/upgrade the chart with the release name `catalogkubedbcom-mysqlversion-editor`:
 
 ```bash
-$ helm upgrade -i catalogkubedbcom-mysqlversion-editor bytebuilders-ui/catalogkubedbcom-mysqlversion-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i catalogkubedbcom-mysqlversion-editor bytebuilders-ui/catalogkubedbcom-mysqlversion-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a MySQLVersion Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `catalogkubedbcom-m
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i catalogkubedbcom-mysqlversion-editor bytebuilders-ui/catalogkubedbcom-mysqlversion-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=catalog.kubedb.com/v1alpha1
+$ helm upgrade -i catalogkubedbcom-mysqlversion-editor bytebuilders-ui/catalogkubedbcom-mysqlversion-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=catalog.kubedb.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i catalogkubedbcom-mysqlversion-editor bytebuilders-ui/catalogkubedbcom-mysqlversion-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i catalogkubedbcom-mysqlversion-editor bytebuilders-ui/catalogkubedbcom-mysqlversion-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/catalogkubedbcom-perconaxtradbversion-editor/Chart.yaml
+++ b/charts/catalogkubedbcom-perconaxtradbversion-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"catalog.kubedb.com","version":"v1alpha1","resource":"perconaxtradbversions"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: PerconaXtraDBVersion Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: catalogkubedbcom-perconaxtradbversion-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/catalogkubedbcom-perconaxtradbversion-editor/README.md
+++ b/charts/catalogkubedbcom-perconaxtradbversion-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/catalogkubedbcom-perconaxtradbversion-editor --version=v0.4.8
-$ helm upgrade -i catalogkubedbcom-perconaxtradbversion-editor bytebuilders-ui/catalogkubedbcom-perconaxtradbversion-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/catalogkubedbcom-perconaxtradbversion-editor --version=v0.4.9
+$ helm upgrade -i catalogkubedbcom-perconaxtradbversion-editor bytebuilders-ui/catalogkubedbcom-perconaxtradbversion-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a PerconaXtraDBVersion Editor on a [Kubernetes](http://kubern
 To install/upgrade the chart with the release name `catalogkubedbcom-perconaxtradbversion-editor`:
 
 ```bash
-$ helm upgrade -i catalogkubedbcom-perconaxtradbversion-editor bytebuilders-ui/catalogkubedbcom-perconaxtradbversion-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i catalogkubedbcom-perconaxtradbversion-editor bytebuilders-ui/catalogkubedbcom-perconaxtradbversion-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a PerconaXtraDBVersion Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `catalogkubedbcom-p
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i catalogkubedbcom-perconaxtradbversion-editor bytebuilders-ui/catalogkubedbcom-perconaxtradbversion-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=catalog.kubedb.com/v1alpha1
+$ helm upgrade -i catalogkubedbcom-perconaxtradbversion-editor bytebuilders-ui/catalogkubedbcom-perconaxtradbversion-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=catalog.kubedb.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i catalogkubedbcom-perconaxtradbversion-editor bytebuilders-ui/catalogkubedbcom-perconaxtradbversion-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i catalogkubedbcom-perconaxtradbversion-editor bytebuilders-ui/catalogkubedbcom-perconaxtradbversion-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/catalogkubedbcom-pgbouncerversion-editor/Chart.yaml
+++ b/charts/catalogkubedbcom-pgbouncerversion-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"catalog.kubedb.com","version":"v1alpha1","resource":"pgbouncerversions"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: PgBouncerVersion Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: catalogkubedbcom-pgbouncerversion-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/catalogkubedbcom-pgbouncerversion-editor/README.md
+++ b/charts/catalogkubedbcom-pgbouncerversion-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/catalogkubedbcom-pgbouncerversion-editor --version=v0.4.8
-$ helm upgrade -i catalogkubedbcom-pgbouncerversion-editor bytebuilders-ui/catalogkubedbcom-pgbouncerversion-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/catalogkubedbcom-pgbouncerversion-editor --version=v0.4.9
+$ helm upgrade -i catalogkubedbcom-pgbouncerversion-editor bytebuilders-ui/catalogkubedbcom-pgbouncerversion-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a PgBouncerVersion Editor on a [Kubernetes](http://kubernetes
 To install/upgrade the chart with the release name `catalogkubedbcom-pgbouncerversion-editor`:
 
 ```bash
-$ helm upgrade -i catalogkubedbcom-pgbouncerversion-editor bytebuilders-ui/catalogkubedbcom-pgbouncerversion-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i catalogkubedbcom-pgbouncerversion-editor bytebuilders-ui/catalogkubedbcom-pgbouncerversion-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a PgBouncerVersion Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `catalogkubedbcom-p
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i catalogkubedbcom-pgbouncerversion-editor bytebuilders-ui/catalogkubedbcom-pgbouncerversion-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=catalog.kubedb.com/v1alpha1
+$ helm upgrade -i catalogkubedbcom-pgbouncerversion-editor bytebuilders-ui/catalogkubedbcom-pgbouncerversion-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=catalog.kubedb.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i catalogkubedbcom-pgbouncerversion-editor bytebuilders-ui/catalogkubedbcom-pgbouncerversion-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i catalogkubedbcom-pgbouncerversion-editor bytebuilders-ui/catalogkubedbcom-pgbouncerversion-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/catalogkubedbcom-postgresversion-editor/Chart.yaml
+++ b/charts/catalogkubedbcom-postgresversion-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"catalog.kubedb.com","version":"v1alpha1","resource":"postgresversions"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: PostgresVersion Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: catalogkubedbcom-postgresversion-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/catalogkubedbcom-postgresversion-editor/README.md
+++ b/charts/catalogkubedbcom-postgresversion-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/catalogkubedbcom-postgresversion-editor --version=v0.4.8
-$ helm upgrade -i catalogkubedbcom-postgresversion-editor bytebuilders-ui/catalogkubedbcom-postgresversion-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/catalogkubedbcom-postgresversion-editor --version=v0.4.9
+$ helm upgrade -i catalogkubedbcom-postgresversion-editor bytebuilders-ui/catalogkubedbcom-postgresversion-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a PostgresVersion Editor on a [Kubernetes](http://kubernetes.
 To install/upgrade the chart with the release name `catalogkubedbcom-postgresversion-editor`:
 
 ```bash
-$ helm upgrade -i catalogkubedbcom-postgresversion-editor bytebuilders-ui/catalogkubedbcom-postgresversion-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i catalogkubedbcom-postgresversion-editor bytebuilders-ui/catalogkubedbcom-postgresversion-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a PostgresVersion Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `catalogkubedbcom-p
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i catalogkubedbcom-postgresversion-editor bytebuilders-ui/catalogkubedbcom-postgresversion-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=catalog.kubedb.com/v1alpha1
+$ helm upgrade -i catalogkubedbcom-postgresversion-editor bytebuilders-ui/catalogkubedbcom-postgresversion-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=catalog.kubedb.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i catalogkubedbcom-postgresversion-editor bytebuilders-ui/catalogkubedbcom-postgresversion-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i catalogkubedbcom-postgresversion-editor bytebuilders-ui/catalogkubedbcom-postgresversion-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/catalogkubedbcom-proxysqlversion-editor/Chart.yaml
+++ b/charts/catalogkubedbcom-proxysqlversion-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"catalog.kubedb.com","version":"v1alpha1","resource":"proxysqlversions"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: ProxySQLVersion Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: catalogkubedbcom-proxysqlversion-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/catalogkubedbcom-proxysqlversion-editor/README.md
+++ b/charts/catalogkubedbcom-proxysqlversion-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/catalogkubedbcom-proxysqlversion-editor --version=v0.4.8
-$ helm upgrade -i catalogkubedbcom-proxysqlversion-editor bytebuilders-ui/catalogkubedbcom-proxysqlversion-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/catalogkubedbcom-proxysqlversion-editor --version=v0.4.9
+$ helm upgrade -i catalogkubedbcom-proxysqlversion-editor bytebuilders-ui/catalogkubedbcom-proxysqlversion-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a ProxySQLVersion Editor on a [Kubernetes](http://kubernetes.
 To install/upgrade the chart with the release name `catalogkubedbcom-proxysqlversion-editor`:
 
 ```bash
-$ helm upgrade -i catalogkubedbcom-proxysqlversion-editor bytebuilders-ui/catalogkubedbcom-proxysqlversion-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i catalogkubedbcom-proxysqlversion-editor bytebuilders-ui/catalogkubedbcom-proxysqlversion-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a ProxySQLVersion Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `catalogkubedbcom-p
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i catalogkubedbcom-proxysqlversion-editor bytebuilders-ui/catalogkubedbcom-proxysqlversion-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=catalog.kubedb.com/v1alpha1
+$ helm upgrade -i catalogkubedbcom-proxysqlversion-editor bytebuilders-ui/catalogkubedbcom-proxysqlversion-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=catalog.kubedb.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i catalogkubedbcom-proxysqlversion-editor bytebuilders-ui/catalogkubedbcom-proxysqlversion-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i catalogkubedbcom-proxysqlversion-editor bytebuilders-ui/catalogkubedbcom-proxysqlversion-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/catalogkubedbcom-redisversion-editor/Chart.yaml
+++ b/charts/catalogkubedbcom-redisversion-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"catalog.kubedb.com","version":"v1alpha1","resource":"redisversions"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: RedisVersion Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: catalogkubedbcom-redisversion-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/catalogkubedbcom-redisversion-editor/README.md
+++ b/charts/catalogkubedbcom-redisversion-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/catalogkubedbcom-redisversion-editor --version=v0.4.8
-$ helm upgrade -i catalogkubedbcom-redisversion-editor bytebuilders-ui/catalogkubedbcom-redisversion-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/catalogkubedbcom-redisversion-editor --version=v0.4.9
+$ helm upgrade -i catalogkubedbcom-redisversion-editor bytebuilders-ui/catalogkubedbcom-redisversion-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a RedisVersion Editor on a [Kubernetes](http://kubernetes.io)
 To install/upgrade the chart with the release name `catalogkubedbcom-redisversion-editor`:
 
 ```bash
-$ helm upgrade -i catalogkubedbcom-redisversion-editor bytebuilders-ui/catalogkubedbcom-redisversion-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i catalogkubedbcom-redisversion-editor bytebuilders-ui/catalogkubedbcom-redisversion-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a RedisVersion Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `catalogkubedbcom-r
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i catalogkubedbcom-redisversion-editor bytebuilders-ui/catalogkubedbcom-redisversion-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=catalog.kubedb.com/v1alpha1
+$ helm upgrade -i catalogkubedbcom-redisversion-editor bytebuilders-ui/catalogkubedbcom-redisversion-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=catalog.kubedb.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i catalogkubedbcom-redisversion-editor bytebuilders-ui/catalogkubedbcom-redisversion-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i catalogkubedbcom-redisversion-editor bytebuilders-ui/catalogkubedbcom-redisversion-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/catalogkubevaultcom-vaultserverversion-editor/Chart.yaml
+++ b/charts/catalogkubevaultcom-vaultserverversion-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"catalog.kubevault.com","version":"v1alpha1","resource":"vaultserverversions"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: VaultServerVersion Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: catalogkubevaultcom-vaultserverversion-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/catalogkubevaultcom-vaultserverversion-editor/README.md
+++ b/charts/catalogkubevaultcom-vaultserverversion-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/catalogkubevaultcom-vaultserverversion-editor --version=v0.4.8
-$ helm upgrade -i catalogkubevaultcom-vaultserverversion-editor bytebuilders-ui/catalogkubevaultcom-vaultserverversion-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/catalogkubevaultcom-vaultserverversion-editor --version=v0.4.9
+$ helm upgrade -i catalogkubevaultcom-vaultserverversion-editor bytebuilders-ui/catalogkubevaultcom-vaultserverversion-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a VaultServerVersion Editor on a [Kubernetes](http://kubernet
 To install/upgrade the chart with the release name `catalogkubevaultcom-vaultserverversion-editor`:
 
 ```bash
-$ helm upgrade -i catalogkubevaultcom-vaultserverversion-editor bytebuilders-ui/catalogkubevaultcom-vaultserverversion-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i catalogkubevaultcom-vaultserverversion-editor bytebuilders-ui/catalogkubevaultcom-vaultserverversion-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a VaultServerVersion Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `catalogkubevaultco
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i catalogkubevaultcom-vaultserverversion-editor bytebuilders-ui/catalogkubevaultcom-vaultserverversion-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=catalog.kubevault.com/v1alpha1
+$ helm upgrade -i catalogkubevaultcom-vaultserverversion-editor bytebuilders-ui/catalogkubevaultcom-vaultserverversion-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=catalog.kubevault.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i catalogkubevaultcom-vaultserverversion-editor bytebuilders-ui/catalogkubevaultcom-vaultserverversion-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i catalogkubevaultcom-vaultserverversion-editor bytebuilders-ui/catalogkubevaultcom-vaultserverversion-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/certificatesk8sio-certificatesigningrequest-editor/Chart.yaml
+++ b/charts/certificatesk8sio-certificatesigningrequest-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"certificates.k8s.io","version":"v1","resource":"certificatesigningrequests"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: CertificateSigningRequest Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: certificatesk8sio-certificatesigningrequest-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/certificatesk8sio-certificatesigningrequest-editor/README.md
+++ b/charts/certificatesk8sio-certificatesigningrequest-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/certificatesk8sio-certificatesigningrequest-editor --version=v0.4.8
-$ helm upgrade -i certificatesk8sio-certificatesigningrequest-editor bytebuilders-ui/certificatesk8sio-certificatesigningrequest-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/certificatesk8sio-certificatesigningrequest-editor --version=v0.4.9
+$ helm upgrade -i certificatesk8sio-certificatesigningrequest-editor bytebuilders-ui/certificatesk8sio-certificatesigningrequest-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a CertificateSigningRequest Editor on a [Kubernetes](http://k
 To install/upgrade the chart with the release name `certificatesk8sio-certificatesigningrequest-editor`:
 
 ```bash
-$ helm upgrade -i certificatesk8sio-certificatesigningrequest-editor bytebuilders-ui/certificatesk8sio-certificatesigningrequest-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i certificatesk8sio-certificatesigningrequest-editor bytebuilders-ui/certificatesk8sio-certificatesigningrequest-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a CertificateSigningRequest Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `certificatesk8sio-
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i certificatesk8sio-certificatesigningrequest-editor bytebuilders-ui/certificatesk8sio-certificatesigningrequest-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=certificates.k8s.io/v1
+$ helm upgrade -i certificatesk8sio-certificatesigningrequest-editor bytebuilders-ui/certificatesk8sio-certificatesigningrequest-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=certificates.k8s.io/v1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i certificatesk8sio-certificatesigningrequest-editor bytebuilders-ui/certificatesk8sio-certificatesigningrequest-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i certificatesk8sio-certificatesigningrequest-editor bytebuilders-ui/certificatesk8sio-certificatesigningrequest-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/certmanagerio-certificate-editor/Chart.yaml
+++ b/charts/certmanagerio-certificate-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"cert-manager.io","version":"v1","resource":"certificates"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: Certificate Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: certmanagerio-certificate-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/certmanagerio-certificate-editor/README.md
+++ b/charts/certmanagerio-certificate-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/certmanagerio-certificate-editor --version=v0.4.8
-$ helm upgrade -i certmanagerio-certificate-editor bytebuilders-ui/certmanagerio-certificate-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/certmanagerio-certificate-editor --version=v0.4.9
+$ helm upgrade -i certmanagerio-certificate-editor bytebuilders-ui/certmanagerio-certificate-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a Certificate Editor on a [Kubernetes](http://kubernetes.io) 
 To install/upgrade the chart with the release name `certmanagerio-certificate-editor`:
 
 ```bash
-$ helm upgrade -i certmanagerio-certificate-editor bytebuilders-ui/certmanagerio-certificate-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i certmanagerio-certificate-editor bytebuilders-ui/certmanagerio-certificate-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a Certificate Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `certmanagerio-cert
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i certmanagerio-certificate-editor bytebuilders-ui/certmanagerio-certificate-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=cert-manager.io/v1
+$ helm upgrade -i certmanagerio-certificate-editor bytebuilders-ui/certmanagerio-certificate-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=cert-manager.io/v1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i certmanagerio-certificate-editor bytebuilders-ui/certmanagerio-certificate-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i certmanagerio-certificate-editor bytebuilders-ui/certmanagerio-certificate-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/certmanagerio-certificaterequest-editor/Chart.yaml
+++ b/charts/certmanagerio-certificaterequest-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"cert-manager.io","version":"v1","resource":"certificaterequests"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: CertificateRequest Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: certmanagerio-certificaterequest-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/certmanagerio-certificaterequest-editor/README.md
+++ b/charts/certmanagerio-certificaterequest-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/certmanagerio-certificaterequest-editor --version=v0.4.8
-$ helm upgrade -i certmanagerio-certificaterequest-editor bytebuilders-ui/certmanagerio-certificaterequest-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/certmanagerio-certificaterequest-editor --version=v0.4.9
+$ helm upgrade -i certmanagerio-certificaterequest-editor bytebuilders-ui/certmanagerio-certificaterequest-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a CertificateRequest Editor on a [Kubernetes](http://kubernet
 To install/upgrade the chart with the release name `certmanagerio-certificaterequest-editor`:
 
 ```bash
-$ helm upgrade -i certmanagerio-certificaterequest-editor bytebuilders-ui/certmanagerio-certificaterequest-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i certmanagerio-certificaterequest-editor bytebuilders-ui/certmanagerio-certificaterequest-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a CertificateRequest Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `certmanagerio-cert
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i certmanagerio-certificaterequest-editor bytebuilders-ui/certmanagerio-certificaterequest-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=cert-manager.io/v1
+$ helm upgrade -i certmanagerio-certificaterequest-editor bytebuilders-ui/certmanagerio-certificaterequest-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=cert-manager.io/v1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i certmanagerio-certificaterequest-editor bytebuilders-ui/certmanagerio-certificaterequest-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i certmanagerio-certificaterequest-editor bytebuilders-ui/certmanagerio-certificaterequest-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/certmanagerio-clusterissuer-editor/Chart.yaml
+++ b/charts/certmanagerio-clusterissuer-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"cert-manager.io","version":"v1","resource":"clusterissuers"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: ClusterIssuer Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: certmanagerio-clusterissuer-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/certmanagerio-clusterissuer-editor/README.md
+++ b/charts/certmanagerio-clusterissuer-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/certmanagerio-clusterissuer-editor --version=v0.4.8
-$ helm upgrade -i certmanagerio-clusterissuer-editor bytebuilders-ui/certmanagerio-clusterissuer-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/certmanagerio-clusterissuer-editor --version=v0.4.9
+$ helm upgrade -i certmanagerio-clusterissuer-editor bytebuilders-ui/certmanagerio-clusterissuer-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a ClusterIssuer Editor on a [Kubernetes](http://kubernetes.io
 To install/upgrade the chart with the release name `certmanagerio-clusterissuer-editor`:
 
 ```bash
-$ helm upgrade -i certmanagerio-clusterissuer-editor bytebuilders-ui/certmanagerio-clusterissuer-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i certmanagerio-clusterissuer-editor bytebuilders-ui/certmanagerio-clusterissuer-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a ClusterIssuer Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `certmanagerio-clus
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i certmanagerio-clusterissuer-editor bytebuilders-ui/certmanagerio-clusterissuer-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=cert-manager.io/v1
+$ helm upgrade -i certmanagerio-clusterissuer-editor bytebuilders-ui/certmanagerio-clusterissuer-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=cert-manager.io/v1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i certmanagerio-clusterissuer-editor bytebuilders-ui/certmanagerio-clusterissuer-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i certmanagerio-clusterissuer-editor bytebuilders-ui/certmanagerio-clusterissuer-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/certmanagerio-issuer-editor/Chart.yaml
+++ b/charts/certmanagerio-issuer-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"cert-manager.io","version":"v1","resource":"issuers"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: Issuer Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: certmanagerio-issuer-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/certmanagerio-issuer-editor/README.md
+++ b/charts/certmanagerio-issuer-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/certmanagerio-issuer-editor --version=v0.4.8
-$ helm upgrade -i certmanagerio-issuer-editor bytebuilders-ui/certmanagerio-issuer-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/certmanagerio-issuer-editor --version=v0.4.9
+$ helm upgrade -i certmanagerio-issuer-editor bytebuilders-ui/certmanagerio-issuer-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a Issuer Editor on a [Kubernetes](http://kubernetes.io) clust
 To install/upgrade the chart with the release name `certmanagerio-issuer-editor`:
 
 ```bash
-$ helm upgrade -i certmanagerio-issuer-editor bytebuilders-ui/certmanagerio-issuer-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i certmanagerio-issuer-editor bytebuilders-ui/certmanagerio-issuer-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a Issuer Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `certmanagerio-issu
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i certmanagerio-issuer-editor bytebuilders-ui/certmanagerio-issuer-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=cert-manager.io/v1
+$ helm upgrade -i certmanagerio-issuer-editor bytebuilders-ui/certmanagerio-issuer-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=cert-manager.io/v1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i certmanagerio-issuer-editor bytebuilders-ui/certmanagerio-issuer-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i certmanagerio-issuer-editor bytebuilders-ui/certmanagerio-issuer-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/clusterxk8sio-machine-editor/Chart.yaml
+++ b/charts/clusterxk8sio-machine-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"cluster.x-k8s.io","version":"v1alpha3","resource":"machines"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: Machine Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: clusterxk8sio-machine-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/clusterxk8sio-machine-editor/README.md
+++ b/charts/clusterxk8sio-machine-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/clusterxk8sio-machine-editor --version=v0.4.8
-$ helm upgrade -i clusterxk8sio-machine-editor bytebuilders-ui/clusterxk8sio-machine-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/clusterxk8sio-machine-editor --version=v0.4.9
+$ helm upgrade -i clusterxk8sio-machine-editor bytebuilders-ui/clusterxk8sio-machine-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a Machine Editor on a [Kubernetes](http://kubernetes.io) clus
 To install/upgrade the chart with the release name `clusterxk8sio-machine-editor`:
 
 ```bash
-$ helm upgrade -i clusterxk8sio-machine-editor bytebuilders-ui/clusterxk8sio-machine-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i clusterxk8sio-machine-editor bytebuilders-ui/clusterxk8sio-machine-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a Machine Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `clusterxk8sio-mach
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i clusterxk8sio-machine-editor bytebuilders-ui/clusterxk8sio-machine-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=cluster.x-k8s.io/v1alpha3
+$ helm upgrade -i clusterxk8sio-machine-editor bytebuilders-ui/clusterxk8sio-machine-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=cluster.x-k8s.io/v1alpha3
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i clusterxk8sio-machine-editor bytebuilders-ui/clusterxk8sio-machine-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i clusterxk8sio-machine-editor bytebuilders-ui/clusterxk8sio-machine-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/clusterxk8sio-machineset-editor/Chart.yaml
+++ b/charts/clusterxk8sio-machineset-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"cluster.x-k8s.io","version":"v1alpha3","resource":"machinesets"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: MachineSet Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: clusterxk8sio-machineset-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/clusterxk8sio-machineset-editor/README.md
+++ b/charts/clusterxk8sio-machineset-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/clusterxk8sio-machineset-editor --version=v0.4.8
-$ helm upgrade -i clusterxk8sio-machineset-editor bytebuilders-ui/clusterxk8sio-machineset-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/clusterxk8sio-machineset-editor --version=v0.4.9
+$ helm upgrade -i clusterxk8sio-machineset-editor bytebuilders-ui/clusterxk8sio-machineset-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a MachineSet Editor on a [Kubernetes](http://kubernetes.io) c
 To install/upgrade the chart with the release name `clusterxk8sio-machineset-editor`:
 
 ```bash
-$ helm upgrade -i clusterxk8sio-machineset-editor bytebuilders-ui/clusterxk8sio-machineset-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i clusterxk8sio-machineset-editor bytebuilders-ui/clusterxk8sio-machineset-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a MachineSet Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `clusterxk8sio-mach
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i clusterxk8sio-machineset-editor bytebuilders-ui/clusterxk8sio-machineset-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=cluster.x-k8s.io/v1alpha3
+$ helm upgrade -i clusterxk8sio-machineset-editor bytebuilders-ui/clusterxk8sio-machineset-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=cluster.x-k8s.io/v1alpha3
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i clusterxk8sio-machineset-editor bytebuilders-ui/clusterxk8sio-machineset-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i clusterxk8sio-machineset-editor bytebuilders-ui/clusterxk8sio-machineset-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/coordinationk8sio-lease-editor/Chart.yaml
+++ b/charts/coordinationk8sio-lease-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"coordination.k8s.io","version":"v1","resource":"leases"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: Lease Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: coordinationk8sio-lease-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/coordinationk8sio-lease-editor/README.md
+++ b/charts/coordinationk8sio-lease-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/coordinationk8sio-lease-editor --version=v0.4.8
-$ helm upgrade -i coordinationk8sio-lease-editor bytebuilders-ui/coordinationk8sio-lease-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/coordinationk8sio-lease-editor --version=v0.4.9
+$ helm upgrade -i coordinationk8sio-lease-editor bytebuilders-ui/coordinationk8sio-lease-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a Lease Editor on a [Kubernetes](http://kubernetes.io) cluste
 To install/upgrade the chart with the release name `coordinationk8sio-lease-editor`:
 
 ```bash
-$ helm upgrade -i coordinationk8sio-lease-editor bytebuilders-ui/coordinationk8sio-lease-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i coordinationk8sio-lease-editor bytebuilders-ui/coordinationk8sio-lease-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a Lease Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `coordinationk8sio-
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i coordinationk8sio-lease-editor bytebuilders-ui/coordinationk8sio-lease-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=coordination.k8s.io/v1
+$ helm upgrade -i coordinationk8sio-lease-editor bytebuilders-ui/coordinationk8sio-lease-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=coordination.k8s.io/v1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i coordinationk8sio-lease-editor bytebuilders-ui/coordinationk8sio-lease-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i coordinationk8sio-lease-editor bytebuilders-ui/coordinationk8sio-lease-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/core-binding-editor/Chart.yaml
+++ b/charts/core-binding-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"","version":"v1","resource":"bindings"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: Binding Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: core-binding-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/core-binding-editor/README.md
+++ b/charts/core-binding-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/core-binding-editor --version=v0.4.8
-$ helm upgrade -i core-binding-editor bytebuilders-ui/core-binding-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/core-binding-editor --version=v0.4.9
+$ helm upgrade -i core-binding-editor bytebuilders-ui/core-binding-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a Binding Editor on a [Kubernetes](http://kubernetes.io) clus
 To install/upgrade the chart with the release name `core-binding-editor`:
 
 ```bash
-$ helm upgrade -i core-binding-editor bytebuilders-ui/core-binding-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i core-binding-editor bytebuilders-ui/core-binding-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a Binding Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `core-binding-edito
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i core-binding-editor bytebuilders-ui/core-binding-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=v1
+$ helm upgrade -i core-binding-editor bytebuilders-ui/core-binding-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=v1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i core-binding-editor bytebuilders-ui/core-binding-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i core-binding-editor bytebuilders-ui/core-binding-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/core-componentstatus-editor/Chart.yaml
+++ b/charts/core-componentstatus-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"","version":"v1","resource":"componentstatuses"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: ComponentStatus Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: core-componentstatus-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/core-componentstatus-editor/README.md
+++ b/charts/core-componentstatus-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/core-componentstatus-editor --version=v0.4.8
-$ helm upgrade -i core-componentstatus-editor bytebuilders-ui/core-componentstatus-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/core-componentstatus-editor --version=v0.4.9
+$ helm upgrade -i core-componentstatus-editor bytebuilders-ui/core-componentstatus-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a ComponentStatus Editor on a [Kubernetes](http://kubernetes.
 To install/upgrade the chart with the release name `core-componentstatus-editor`:
 
 ```bash
-$ helm upgrade -i core-componentstatus-editor bytebuilders-ui/core-componentstatus-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i core-componentstatus-editor bytebuilders-ui/core-componentstatus-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a ComponentStatus Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `core-componentstat
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i core-componentstatus-editor bytebuilders-ui/core-componentstatus-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=v1
+$ helm upgrade -i core-componentstatus-editor bytebuilders-ui/core-componentstatus-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=v1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i core-componentstatus-editor bytebuilders-ui/core-componentstatus-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i core-componentstatus-editor bytebuilders-ui/core-componentstatus-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/core-configmap-editor/Chart.yaml
+++ b/charts/core-configmap-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"","version":"v1","resource":"configmaps"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: ConfigMap Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: core-configmap-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/core-configmap-editor/README.md
+++ b/charts/core-configmap-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/core-configmap-editor --version=v0.4.8
-$ helm upgrade -i core-configmap-editor bytebuilders-ui/core-configmap-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/core-configmap-editor --version=v0.4.9
+$ helm upgrade -i core-configmap-editor bytebuilders-ui/core-configmap-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a ConfigMap Editor on a [Kubernetes](http://kubernetes.io) cl
 To install/upgrade the chart with the release name `core-configmap-editor`:
 
 ```bash
-$ helm upgrade -i core-configmap-editor bytebuilders-ui/core-configmap-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i core-configmap-editor bytebuilders-ui/core-configmap-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a ConfigMap Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `core-configmap-edi
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i core-configmap-editor bytebuilders-ui/core-configmap-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=v1
+$ helm upgrade -i core-configmap-editor bytebuilders-ui/core-configmap-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=v1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i core-configmap-editor bytebuilders-ui/core-configmap-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i core-configmap-editor bytebuilders-ui/core-configmap-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/core-endpoints-editor/Chart.yaml
+++ b/charts/core-endpoints-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"","version":"v1","resource":"endpoints"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: Endpoints Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: core-endpoints-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/core-endpoints-editor/README.md
+++ b/charts/core-endpoints-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/core-endpoints-editor --version=v0.4.8
-$ helm upgrade -i core-endpoints-editor bytebuilders-ui/core-endpoints-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/core-endpoints-editor --version=v0.4.9
+$ helm upgrade -i core-endpoints-editor bytebuilders-ui/core-endpoints-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a Endpoints Editor on a [Kubernetes](http://kubernetes.io) cl
 To install/upgrade the chart with the release name `core-endpoints-editor`:
 
 ```bash
-$ helm upgrade -i core-endpoints-editor bytebuilders-ui/core-endpoints-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i core-endpoints-editor bytebuilders-ui/core-endpoints-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a Endpoints Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `core-endpoints-edi
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i core-endpoints-editor bytebuilders-ui/core-endpoints-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=v1
+$ helm upgrade -i core-endpoints-editor bytebuilders-ui/core-endpoints-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=v1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i core-endpoints-editor bytebuilders-ui/core-endpoints-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i core-endpoints-editor bytebuilders-ui/core-endpoints-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/core-ephemeralcontainers-editor/Chart.yaml
+++ b/charts/core-ephemeralcontainers-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"","version":"v1","resource":"ephemeralcontainers"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: EphemeralContainers Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: core-ephemeralcontainers-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/core-ephemeralcontainers-editor/README.md
+++ b/charts/core-ephemeralcontainers-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/core-ephemeralcontainers-editor --version=v0.4.8
-$ helm upgrade -i core-ephemeralcontainers-editor bytebuilders-ui/core-ephemeralcontainers-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/core-ephemeralcontainers-editor --version=v0.4.9
+$ helm upgrade -i core-ephemeralcontainers-editor bytebuilders-ui/core-ephemeralcontainers-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a EphemeralContainers Editor on a [Kubernetes](http://kuberne
 To install/upgrade the chart with the release name `core-ephemeralcontainers-editor`:
 
 ```bash
-$ helm upgrade -i core-ephemeralcontainers-editor bytebuilders-ui/core-ephemeralcontainers-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i core-ephemeralcontainers-editor bytebuilders-ui/core-ephemeralcontainers-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a EphemeralContainers Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `core-ephemeralcont
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i core-ephemeralcontainers-editor bytebuilders-ui/core-ephemeralcontainers-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=v1
+$ helm upgrade -i core-ephemeralcontainers-editor bytebuilders-ui/core-ephemeralcontainers-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=v1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i core-ephemeralcontainers-editor bytebuilders-ui/core-ephemeralcontainers-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i core-ephemeralcontainers-editor bytebuilders-ui/core-ephemeralcontainers-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/core-event-editor/Chart.yaml
+++ b/charts/core-event-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"","version":"v1","resource":"events"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: Event Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: core-event-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/core-event-editor/README.md
+++ b/charts/core-event-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/core-event-editor --version=v0.4.8
-$ helm upgrade -i core-event-editor bytebuilders-ui/core-event-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/core-event-editor --version=v0.4.9
+$ helm upgrade -i core-event-editor bytebuilders-ui/core-event-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a Event Editor on a [Kubernetes](http://kubernetes.io) cluste
 To install/upgrade the chart with the release name `core-event-editor`:
 
 ```bash
-$ helm upgrade -i core-event-editor bytebuilders-ui/core-event-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i core-event-editor bytebuilders-ui/core-event-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a Event Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `core-event-editor`
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i core-event-editor bytebuilders-ui/core-event-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=v1
+$ helm upgrade -i core-event-editor bytebuilders-ui/core-event-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=v1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i core-event-editor bytebuilders-ui/core-event-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i core-event-editor bytebuilders-ui/core-event-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/core-limitrange-editor/Chart.yaml
+++ b/charts/core-limitrange-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"","version":"v1","resource":"limitranges"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: LimitRange Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: core-limitrange-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/core-limitrange-editor/README.md
+++ b/charts/core-limitrange-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/core-limitrange-editor --version=v0.4.8
-$ helm upgrade -i core-limitrange-editor bytebuilders-ui/core-limitrange-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/core-limitrange-editor --version=v0.4.9
+$ helm upgrade -i core-limitrange-editor bytebuilders-ui/core-limitrange-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a LimitRange Editor on a [Kubernetes](http://kubernetes.io) c
 To install/upgrade the chart with the release name `core-limitrange-editor`:
 
 ```bash
-$ helm upgrade -i core-limitrange-editor bytebuilders-ui/core-limitrange-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i core-limitrange-editor bytebuilders-ui/core-limitrange-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a LimitRange Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `core-limitrange-ed
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i core-limitrange-editor bytebuilders-ui/core-limitrange-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=v1
+$ helm upgrade -i core-limitrange-editor bytebuilders-ui/core-limitrange-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=v1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i core-limitrange-editor bytebuilders-ui/core-limitrange-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i core-limitrange-editor bytebuilders-ui/core-limitrange-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/core-namespace-editor/Chart.yaml
+++ b/charts/core-namespace-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"","version":"v1","resource":"namespaces"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: Namespace Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: core-namespace-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/core-namespace-editor/README.md
+++ b/charts/core-namespace-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/core-namespace-editor --version=v0.4.8
-$ helm upgrade -i core-namespace-editor bytebuilders-ui/core-namespace-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/core-namespace-editor --version=v0.4.9
+$ helm upgrade -i core-namespace-editor bytebuilders-ui/core-namespace-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a Namespace Editor on a [Kubernetes](http://kubernetes.io) cl
 To install/upgrade the chart with the release name `core-namespace-editor`:
 
 ```bash
-$ helm upgrade -i core-namespace-editor bytebuilders-ui/core-namespace-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i core-namespace-editor bytebuilders-ui/core-namespace-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a Namespace Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `core-namespace-edi
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i core-namespace-editor bytebuilders-ui/core-namespace-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=v1
+$ helm upgrade -i core-namespace-editor bytebuilders-ui/core-namespace-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=v1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i core-namespace-editor bytebuilders-ui/core-namespace-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i core-namespace-editor bytebuilders-ui/core-namespace-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/core-node-editor/Chart.yaml
+++ b/charts/core-node-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"","version":"v1","resource":"nodes"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: Node Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: core-node-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/core-node-editor/README.md
+++ b/charts/core-node-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/core-node-editor --version=v0.4.8
-$ helm upgrade -i core-node-editor bytebuilders-ui/core-node-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/core-node-editor --version=v0.4.9
+$ helm upgrade -i core-node-editor bytebuilders-ui/core-node-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a Node Editor on a [Kubernetes](http://kubernetes.io) cluster
 To install/upgrade the chart with the release name `core-node-editor`:
 
 ```bash
-$ helm upgrade -i core-node-editor bytebuilders-ui/core-node-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i core-node-editor bytebuilders-ui/core-node-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a Node Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `core-node-editor` 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i core-node-editor bytebuilders-ui/core-node-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=v1
+$ helm upgrade -i core-node-editor bytebuilders-ui/core-node-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=v1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i core-node-editor bytebuilders-ui/core-node-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i core-node-editor bytebuilders-ui/core-node-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/core-persistentvolume-editor/Chart.yaml
+++ b/charts/core-persistentvolume-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"","version":"v1","resource":"persistentvolumes"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: PersistentVolume Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: core-persistentvolume-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/core-persistentvolume-editor/README.md
+++ b/charts/core-persistentvolume-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/core-persistentvolume-editor --version=v0.4.8
-$ helm upgrade -i core-persistentvolume-editor bytebuilders-ui/core-persistentvolume-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/core-persistentvolume-editor --version=v0.4.9
+$ helm upgrade -i core-persistentvolume-editor bytebuilders-ui/core-persistentvolume-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a PersistentVolume Editor on a [Kubernetes](http://kubernetes
 To install/upgrade the chart with the release name `core-persistentvolume-editor`:
 
 ```bash
-$ helm upgrade -i core-persistentvolume-editor bytebuilders-ui/core-persistentvolume-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i core-persistentvolume-editor bytebuilders-ui/core-persistentvolume-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a PersistentVolume Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `core-persistentvol
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i core-persistentvolume-editor bytebuilders-ui/core-persistentvolume-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=v1
+$ helm upgrade -i core-persistentvolume-editor bytebuilders-ui/core-persistentvolume-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=v1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i core-persistentvolume-editor bytebuilders-ui/core-persistentvolume-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i core-persistentvolume-editor bytebuilders-ui/core-persistentvolume-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/core-persistentvolumeclaim-editor/Chart.yaml
+++ b/charts/core-persistentvolumeclaim-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"","version":"v1","resource":"persistentvolumeclaims"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: PersistentVolumeClaim Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: core-persistentvolumeclaim-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/core-persistentvolumeclaim-editor/README.md
+++ b/charts/core-persistentvolumeclaim-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/core-persistentvolumeclaim-editor --version=v0.4.8
-$ helm upgrade -i core-persistentvolumeclaim-editor bytebuilders-ui/core-persistentvolumeclaim-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/core-persistentvolumeclaim-editor --version=v0.4.9
+$ helm upgrade -i core-persistentvolumeclaim-editor bytebuilders-ui/core-persistentvolumeclaim-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a PersistentVolumeClaim Editor on a [Kubernetes](http://kuber
 To install/upgrade the chart with the release name `core-persistentvolumeclaim-editor`:
 
 ```bash
-$ helm upgrade -i core-persistentvolumeclaim-editor bytebuilders-ui/core-persistentvolumeclaim-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i core-persistentvolumeclaim-editor bytebuilders-ui/core-persistentvolumeclaim-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a PersistentVolumeClaim Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `core-persistentvol
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i core-persistentvolumeclaim-editor bytebuilders-ui/core-persistentvolumeclaim-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=v1
+$ helm upgrade -i core-persistentvolumeclaim-editor bytebuilders-ui/core-persistentvolumeclaim-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=v1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i core-persistentvolumeclaim-editor bytebuilders-ui/core-persistentvolumeclaim-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i core-persistentvolumeclaim-editor bytebuilders-ui/core-persistentvolumeclaim-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/core-pod-editor/Chart.yaml
+++ b/charts/core-pod-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"","version":"v1","resource":"pods"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: Pod Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: core-pod-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/core-pod-editor/README.md
+++ b/charts/core-pod-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/core-pod-editor --version=v0.4.8
-$ helm upgrade -i core-pod-editor bytebuilders-ui/core-pod-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/core-pod-editor --version=v0.4.9
+$ helm upgrade -i core-pod-editor bytebuilders-ui/core-pod-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a Pod Editor on a [Kubernetes](http://kubernetes.io) cluster 
 To install/upgrade the chart with the release name `core-pod-editor`:
 
 ```bash
-$ helm upgrade -i core-pod-editor bytebuilders-ui/core-pod-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i core-pod-editor bytebuilders-ui/core-pod-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a Pod Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `core-pod-editor` c
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i core-pod-editor bytebuilders-ui/core-pod-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=v1
+$ helm upgrade -i core-pod-editor bytebuilders-ui/core-pod-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=v1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i core-pod-editor bytebuilders-ui/core-pod-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i core-pod-editor bytebuilders-ui/core-pod-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/core-podstatusresult-editor/Chart.yaml
+++ b/charts/core-podstatusresult-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"","version":"v1","resource":"podstatusresults"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: PodStatusResult Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: core-podstatusresult-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/core-podstatusresult-editor/README.md
+++ b/charts/core-podstatusresult-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/core-podstatusresult-editor --version=v0.4.8
-$ helm upgrade -i core-podstatusresult-editor bytebuilders-ui/core-podstatusresult-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/core-podstatusresult-editor --version=v0.4.9
+$ helm upgrade -i core-podstatusresult-editor bytebuilders-ui/core-podstatusresult-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a PodStatusResult Editor on a [Kubernetes](http://kubernetes.
 To install/upgrade the chart with the release name `core-podstatusresult-editor`:
 
 ```bash
-$ helm upgrade -i core-podstatusresult-editor bytebuilders-ui/core-podstatusresult-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i core-podstatusresult-editor bytebuilders-ui/core-podstatusresult-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a PodStatusResult Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `core-podstatusresu
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i core-podstatusresult-editor bytebuilders-ui/core-podstatusresult-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=v1
+$ helm upgrade -i core-podstatusresult-editor bytebuilders-ui/core-podstatusresult-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=v1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i core-podstatusresult-editor bytebuilders-ui/core-podstatusresult-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i core-podstatusresult-editor bytebuilders-ui/core-podstatusresult-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/core-podtemplate-editor/Chart.yaml
+++ b/charts/core-podtemplate-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"core","version":"v1","resource":"podtemplates"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: PodTemplate Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: core-podtemplate-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/core-podtemplate-editor/README.md
+++ b/charts/core-podtemplate-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/core-podtemplate-editor --version=v0.4.8
-$ helm upgrade -i core-podtemplate-editor bytebuilders-ui/core-podtemplate-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/core-podtemplate-editor --version=v0.4.9
+$ helm upgrade -i core-podtemplate-editor bytebuilders-ui/core-podtemplate-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a PodTemplate Editor on a [Kubernetes](http://kubernetes.io) 
 To install/upgrade the chart with the release name `core-podtemplate-editor`:
 
 ```bash
-$ helm upgrade -i core-podtemplate-editor bytebuilders-ui/core-podtemplate-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i core-podtemplate-editor bytebuilders-ui/core-podtemplate-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a PodTemplate Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `core-podtemplate-e
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i core-podtemplate-editor bytebuilders-ui/core-podtemplate-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=core/v1
+$ helm upgrade -i core-podtemplate-editor bytebuilders-ui/core-podtemplate-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=core/v1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i core-podtemplate-editor bytebuilders-ui/core-podtemplate-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i core-podtemplate-editor bytebuilders-ui/core-podtemplate-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/core-rangeallocation-editor/Chart.yaml
+++ b/charts/core-rangeallocation-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"","version":"v1","resource":"rangeallocations"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: RangeAllocation Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: core-rangeallocation-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/core-rangeallocation-editor/README.md
+++ b/charts/core-rangeallocation-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/core-rangeallocation-editor --version=v0.4.8
-$ helm upgrade -i core-rangeallocation-editor bytebuilders-ui/core-rangeallocation-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/core-rangeallocation-editor --version=v0.4.9
+$ helm upgrade -i core-rangeallocation-editor bytebuilders-ui/core-rangeallocation-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a RangeAllocation Editor on a [Kubernetes](http://kubernetes.
 To install/upgrade the chart with the release name `core-rangeallocation-editor`:
 
 ```bash
-$ helm upgrade -i core-rangeallocation-editor bytebuilders-ui/core-rangeallocation-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i core-rangeallocation-editor bytebuilders-ui/core-rangeallocation-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a RangeAllocation Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `core-rangeallocati
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i core-rangeallocation-editor bytebuilders-ui/core-rangeallocation-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=v1
+$ helm upgrade -i core-rangeallocation-editor bytebuilders-ui/core-rangeallocation-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=v1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i core-rangeallocation-editor bytebuilders-ui/core-rangeallocation-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i core-rangeallocation-editor bytebuilders-ui/core-rangeallocation-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/core-replicationcontroller-editor/Chart.yaml
+++ b/charts/core-replicationcontroller-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"","version":"v1","resource":"replicationcontrollers"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: ReplicationController Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: core-replicationcontroller-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/core-replicationcontroller-editor/README.md
+++ b/charts/core-replicationcontroller-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/core-replicationcontroller-editor --version=v0.4.8
-$ helm upgrade -i core-replicationcontroller-editor bytebuilders-ui/core-replicationcontroller-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/core-replicationcontroller-editor --version=v0.4.9
+$ helm upgrade -i core-replicationcontroller-editor bytebuilders-ui/core-replicationcontroller-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a ReplicationController Editor on a [Kubernetes](http://kuber
 To install/upgrade the chart with the release name `core-replicationcontroller-editor`:
 
 ```bash
-$ helm upgrade -i core-replicationcontroller-editor bytebuilders-ui/core-replicationcontroller-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i core-replicationcontroller-editor bytebuilders-ui/core-replicationcontroller-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a ReplicationController Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `core-replicationco
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i core-replicationcontroller-editor bytebuilders-ui/core-replicationcontroller-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=v1
+$ helm upgrade -i core-replicationcontroller-editor bytebuilders-ui/core-replicationcontroller-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=v1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i core-replicationcontroller-editor bytebuilders-ui/core-replicationcontroller-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i core-replicationcontroller-editor bytebuilders-ui/core-replicationcontroller-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/core-resourcequota-editor/Chart.yaml
+++ b/charts/core-resourcequota-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"","version":"v1","resource":"resourcequotas"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: ResourceQuota Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: core-resourcequota-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/core-resourcequota-editor/README.md
+++ b/charts/core-resourcequota-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/core-resourcequota-editor --version=v0.4.8
-$ helm upgrade -i core-resourcequota-editor bytebuilders-ui/core-resourcequota-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/core-resourcequota-editor --version=v0.4.9
+$ helm upgrade -i core-resourcequota-editor bytebuilders-ui/core-resourcequota-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a ResourceQuota Editor on a [Kubernetes](http://kubernetes.io
 To install/upgrade the chart with the release name `core-resourcequota-editor`:
 
 ```bash
-$ helm upgrade -i core-resourcequota-editor bytebuilders-ui/core-resourcequota-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i core-resourcequota-editor bytebuilders-ui/core-resourcequota-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a ResourceQuota Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `core-resourcequota
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i core-resourcequota-editor bytebuilders-ui/core-resourcequota-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=v1
+$ helm upgrade -i core-resourcequota-editor bytebuilders-ui/core-resourcequota-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=v1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i core-resourcequota-editor bytebuilders-ui/core-resourcequota-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i core-resourcequota-editor bytebuilders-ui/core-resourcequota-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/core-secret-editor/Chart.yaml
+++ b/charts/core-secret-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"","version":"v1","resource":"secrets"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: Secret Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: core-secret-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/core-secret-editor/README.md
+++ b/charts/core-secret-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/core-secret-editor --version=v0.4.8
-$ helm upgrade -i core-secret-editor bytebuilders-ui/core-secret-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/core-secret-editor --version=v0.4.9
+$ helm upgrade -i core-secret-editor bytebuilders-ui/core-secret-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a Secret Editor on a [Kubernetes](http://kubernetes.io) clust
 To install/upgrade the chart with the release name `core-secret-editor`:
 
 ```bash
-$ helm upgrade -i core-secret-editor bytebuilders-ui/core-secret-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i core-secret-editor bytebuilders-ui/core-secret-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a Secret Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `core-secret-editor
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i core-secret-editor bytebuilders-ui/core-secret-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=v1
+$ helm upgrade -i core-secret-editor bytebuilders-ui/core-secret-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=v1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i core-secret-editor bytebuilders-ui/core-secret-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i core-secret-editor bytebuilders-ui/core-secret-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/core-service-editor/Chart.yaml
+++ b/charts/core-service-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"","version":"v1","resource":"services"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: Service Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: core-service-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/core-service-editor/README.md
+++ b/charts/core-service-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/core-service-editor --version=v0.4.8
-$ helm upgrade -i core-service-editor bytebuilders-ui/core-service-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/core-service-editor --version=v0.4.9
+$ helm upgrade -i core-service-editor bytebuilders-ui/core-service-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a Service Editor on a [Kubernetes](http://kubernetes.io) clus
 To install/upgrade the chart with the release name `core-service-editor`:
 
 ```bash
-$ helm upgrade -i core-service-editor bytebuilders-ui/core-service-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i core-service-editor bytebuilders-ui/core-service-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a Service Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `core-service-edito
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i core-service-editor bytebuilders-ui/core-service-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=v1
+$ helm upgrade -i core-service-editor bytebuilders-ui/core-service-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=v1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i core-service-editor bytebuilders-ui/core-service-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i core-service-editor bytebuilders-ui/core-service-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/core-serviceaccount-editor/Chart.yaml
+++ b/charts/core-serviceaccount-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"","version":"v1","resource":"serviceaccounts"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: ServiceAccount Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: core-serviceaccount-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/core-serviceaccount-editor/README.md
+++ b/charts/core-serviceaccount-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/core-serviceaccount-editor --version=v0.4.8
-$ helm upgrade -i core-serviceaccount-editor bytebuilders-ui/core-serviceaccount-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/core-serviceaccount-editor --version=v0.4.9
+$ helm upgrade -i core-serviceaccount-editor bytebuilders-ui/core-serviceaccount-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a ServiceAccount Editor on a [Kubernetes](http://kubernetes.i
 To install/upgrade the chart with the release name `core-serviceaccount-editor`:
 
 ```bash
-$ helm upgrade -i core-serviceaccount-editor bytebuilders-ui/core-serviceaccount-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i core-serviceaccount-editor bytebuilders-ui/core-serviceaccount-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a ServiceAccount Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `core-serviceaccoun
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i core-serviceaccount-editor bytebuilders-ui/core-serviceaccount-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=v1
+$ helm upgrade -i core-serviceaccount-editor bytebuilders-ui/core-serviceaccount-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=v1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i core-serviceaccount-editor bytebuilders-ui/core-serviceaccount-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i core-serviceaccount-editor bytebuilders-ui/core-serviceaccount-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/corek8sappscodecom-genericresource-editor/Chart.yaml
+++ b/charts/corek8sappscodecom-genericresource-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"core.k8s.appscode.com","version":"v1alpha1","resource":"genericresources"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: GenericResource Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: corek8sappscodecom-genericresource-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/corek8sappscodecom-genericresource-editor/README.md
+++ b/charts/corek8sappscodecom-genericresource-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/corek8sappscodecom-genericresource-editor --version=v0.4.8
-$ helm upgrade -i corek8sappscodecom-genericresource-editor bytebuilders-ui/corek8sappscodecom-genericresource-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/corek8sappscodecom-genericresource-editor --version=v0.4.9
+$ helm upgrade -i corek8sappscodecom-genericresource-editor bytebuilders-ui/corek8sappscodecom-genericresource-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a GenericResource Editor on a [Kubernetes](http://kubernetes.
 To install/upgrade the chart with the release name `corek8sappscodecom-genericresource-editor`:
 
 ```bash
-$ helm upgrade -i corek8sappscodecom-genericresource-editor bytebuilders-ui/corek8sappscodecom-genericresource-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i corek8sappscodecom-genericresource-editor bytebuilders-ui/corek8sappscodecom-genericresource-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a GenericResource Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `corek8sappscodecom
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i corek8sappscodecom-genericresource-editor bytebuilders-ui/corek8sappscodecom-genericresource-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=core.k8s.appscode.com/v1alpha1
+$ helm upgrade -i corek8sappscodecom-genericresource-editor bytebuilders-ui/corek8sappscodecom-genericresource-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=core.k8s.appscode.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i corek8sappscodecom-genericresource-editor bytebuilders-ui/corek8sappscodecom-genericresource-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i corek8sappscodecom-genericresource-editor bytebuilders-ui/corek8sappscodecom-genericresource-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/corek8sappscodecom-genericresourceservice-editor/Chart.yaml
+++ b/charts/corek8sappscodecom-genericresourceservice-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"core.k8s.appscode.com","version":"v1alpha1","resource":"genericresourceservices"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: GenericResourceService Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: corek8sappscodecom-genericresourceservice-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/corek8sappscodecom-genericresourceservice-editor/README.md
+++ b/charts/corek8sappscodecom-genericresourceservice-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/corek8sappscodecom-genericresourceservice-editor --version=v0.4.8
-$ helm upgrade -i corek8sappscodecom-genericresourceservice-editor bytebuilders-ui/corek8sappscodecom-genericresourceservice-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/corek8sappscodecom-genericresourceservice-editor --version=v0.4.9
+$ helm upgrade -i corek8sappscodecom-genericresourceservice-editor bytebuilders-ui/corek8sappscodecom-genericresourceservice-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a GenericResourceService Editor on a [Kubernetes](http://kube
 To install/upgrade the chart with the release name `corek8sappscodecom-genericresourceservice-editor`:
 
 ```bash
-$ helm upgrade -i corek8sappscodecom-genericresourceservice-editor bytebuilders-ui/corek8sappscodecom-genericresourceservice-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i corek8sappscodecom-genericresourceservice-editor bytebuilders-ui/corek8sappscodecom-genericresourceservice-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a GenericResourceService Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `corek8sappscodecom
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i corek8sappscodecom-genericresourceservice-editor bytebuilders-ui/corek8sappscodecom-genericresourceservice-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=core.k8s.appscode.com/v1alpha1
+$ helm upgrade -i corek8sappscodecom-genericresourceservice-editor bytebuilders-ui/corek8sappscodecom-genericresourceservice-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=core.k8s.appscode.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i corek8sappscodecom-genericresourceservice-editor bytebuilders-ui/corek8sappscodecom-genericresourceservice-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i corek8sappscodecom-genericresourceservice-editor bytebuilders-ui/corek8sappscodecom-genericresourceservice-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/corek8sappscodecom-podview-editor/Chart.yaml
+++ b/charts/corek8sappscodecom-podview-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"core.k8s.appscode.com","version":"v1alpha1","resource":"podviews"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: PodView Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: corek8sappscodecom-podview-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/corek8sappscodecom-podview-editor/README.md
+++ b/charts/corek8sappscodecom-podview-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/corek8sappscodecom-podview-editor --version=v0.4.8
-$ helm upgrade -i corek8sappscodecom-podview-editor bytebuilders-ui/corek8sappscodecom-podview-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/corek8sappscodecom-podview-editor --version=v0.4.9
+$ helm upgrade -i corek8sappscodecom-podview-editor bytebuilders-ui/corek8sappscodecom-podview-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a PodView Editor on a [Kubernetes](http://kubernetes.io) clus
 To install/upgrade the chart with the release name `corek8sappscodecom-podview-editor`:
 
 ```bash
-$ helm upgrade -i corek8sappscodecom-podview-editor bytebuilders-ui/corek8sappscodecom-podview-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i corek8sappscodecom-podview-editor bytebuilders-ui/corek8sappscodecom-podview-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a PodView Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `corek8sappscodecom
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i corek8sappscodecom-podview-editor bytebuilders-ui/corek8sappscodecom-podview-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=core.k8s.appscode.com/v1alpha1
+$ helm upgrade -i corek8sappscodecom-podview-editor bytebuilders-ui/corek8sappscodecom-podview-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=core.k8s.appscode.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i corek8sappscodecom-podview-editor bytebuilders-ui/corek8sappscodecom-podview-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i corek8sappscodecom-podview-editor bytebuilders-ui/corek8sappscodecom-podview-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/corek8sappscodecom-resourcesummary-editor/Chart.yaml
+++ b/charts/corek8sappscodecom-resourcesummary-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"core.k8s.appscode.com","version":"v1alpha1","resource":"resourcesummaries"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: ResourceSummary Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: corek8sappscodecom-resourcesummary-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/corek8sappscodecom-resourcesummary-editor/README.md
+++ b/charts/corek8sappscodecom-resourcesummary-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/corek8sappscodecom-resourcesummary-editor --version=v0.4.8
-$ helm upgrade -i corek8sappscodecom-resourcesummary-editor bytebuilders-ui/corek8sappscodecom-resourcesummary-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/corek8sappscodecom-resourcesummary-editor --version=v0.4.9
+$ helm upgrade -i corek8sappscodecom-resourcesummary-editor bytebuilders-ui/corek8sappscodecom-resourcesummary-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a ResourceSummary Editor on a [Kubernetes](http://kubernetes.
 To install/upgrade the chart with the release name `corek8sappscodecom-resourcesummary-editor`:
 
 ```bash
-$ helm upgrade -i corek8sappscodecom-resourcesummary-editor bytebuilders-ui/corek8sappscodecom-resourcesummary-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i corek8sappscodecom-resourcesummary-editor bytebuilders-ui/corek8sappscodecom-resourcesummary-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a ResourceSummary Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `corek8sappscodecom
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i corek8sappscodecom-resourcesummary-editor bytebuilders-ui/corek8sappscodecom-resourcesummary-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=core.k8s.appscode.com/v1alpha1
+$ helm upgrade -i corek8sappscodecom-resourcesummary-editor bytebuilders-ui/corek8sappscodecom-resourcesummary-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=core.k8s.appscode.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i corek8sappscodecom-resourcesummary-editor bytebuilders-ui/corek8sappscodecom-resourcesummary-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i corek8sappscodecom-resourcesummary-editor bytebuilders-ui/corek8sappscodecom-resourcesummary-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/dashboardkubedbcom-elasticsearchdashboard-editor/Chart.yaml
+++ b/charts/dashboardkubedbcom-elasticsearchdashboard-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"dashboard.kubedb.com","version":"v1alpha1","resource":"elasticsearchdashboards"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: ElasticsearchDashboard Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: dashboardkubedbcom-elasticsearchdashboard-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/dashboardkubedbcom-elasticsearchdashboard-editor/README.md
+++ b/charts/dashboardkubedbcom-elasticsearchdashboard-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/dashboardkubedbcom-elasticsearchdashboard-editor --version=v0.4.8
-$ helm upgrade -i dashboardkubedbcom-elasticsearchdashboard-editor bytebuilders-ui/dashboardkubedbcom-elasticsearchdashboard-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/dashboardkubedbcom-elasticsearchdashboard-editor --version=v0.4.9
+$ helm upgrade -i dashboardkubedbcom-elasticsearchdashboard-editor bytebuilders-ui/dashboardkubedbcom-elasticsearchdashboard-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a ElasticsearchDashboard Editor on a [Kubernetes](http://kube
 To install/upgrade the chart with the release name `dashboardkubedbcom-elasticsearchdashboard-editor`:
 
 ```bash
-$ helm upgrade -i dashboardkubedbcom-elasticsearchdashboard-editor bytebuilders-ui/dashboardkubedbcom-elasticsearchdashboard-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i dashboardkubedbcom-elasticsearchdashboard-editor bytebuilders-ui/dashboardkubedbcom-elasticsearchdashboard-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a ElasticsearchDashboard Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `dashboardkubedbcom
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i dashboardkubedbcom-elasticsearchdashboard-editor bytebuilders-ui/dashboardkubedbcom-elasticsearchdashboard-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=dashboard.kubedb.com/v1alpha1
+$ helm upgrade -i dashboardkubedbcom-elasticsearchdashboard-editor bytebuilders-ui/dashboardkubedbcom-elasticsearchdashboard-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=dashboard.kubedb.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i dashboardkubedbcom-elasticsearchdashboard-editor bytebuilders-ui/dashboardkubedbcom-elasticsearchdashboard-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i dashboardkubedbcom-elasticsearchdashboard-editor bytebuilders-ui/dashboardkubedbcom-elasticsearchdashboard-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/discoveryk8sio-endpointslice-editor/Chart.yaml
+++ b/charts/discoveryk8sio-endpointslice-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"discovery.k8s.io","version":"v1","resource":"endpointslice"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: EndpointSlice Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: discoveryk8sio-endpointslice-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/discoveryk8sio-endpointslice-editor/README.md
+++ b/charts/discoveryk8sio-endpointslice-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/discoveryk8sio-endpointslice-editor --version=v0.4.8
-$ helm upgrade -i discoveryk8sio-endpointslice-editor bytebuilders-ui/discoveryk8sio-endpointslice-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/discoveryk8sio-endpointslice-editor --version=v0.4.9
+$ helm upgrade -i discoveryk8sio-endpointslice-editor bytebuilders-ui/discoveryk8sio-endpointslice-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a EndpointSlice Editor on a [Kubernetes](http://kubernetes.io
 To install/upgrade the chart with the release name `discoveryk8sio-endpointslice-editor`:
 
 ```bash
-$ helm upgrade -i discoveryk8sio-endpointslice-editor bytebuilders-ui/discoveryk8sio-endpointslice-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i discoveryk8sio-endpointslice-editor bytebuilders-ui/discoveryk8sio-endpointslice-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a EndpointSlice Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `discoveryk8sio-end
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i discoveryk8sio-endpointslice-editor bytebuilders-ui/discoveryk8sio-endpointslice-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=discovery.k8s.io/v1
+$ helm upgrade -i discoveryk8sio-endpointslice-editor bytebuilders-ui/discoveryk8sio-endpointslice-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=discovery.k8s.io/v1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i discoveryk8sio-endpointslice-editor bytebuilders-ui/discoveryk8sio-endpointslice-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i discoveryk8sio-endpointslice-editor bytebuilders-ui/discoveryk8sio-endpointslice-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/enginekubevaultcom-awsrole-editor/Chart.yaml
+++ b/charts/enginekubevaultcom-awsrole-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"engine.kubevault.com","version":"v1alpha1","resource":"awsroles"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: AWSRole Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: enginekubevaultcom-awsrole-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/enginekubevaultcom-awsrole-editor/README.md
+++ b/charts/enginekubevaultcom-awsrole-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/enginekubevaultcom-awsrole-editor --version=v0.4.8
-$ helm upgrade -i enginekubevaultcom-awsrole-editor bytebuilders-ui/enginekubevaultcom-awsrole-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/enginekubevaultcom-awsrole-editor --version=v0.4.9
+$ helm upgrade -i enginekubevaultcom-awsrole-editor bytebuilders-ui/enginekubevaultcom-awsrole-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a AWSRole Editor on a [Kubernetes](http://kubernetes.io) clus
 To install/upgrade the chart with the release name `enginekubevaultcom-awsrole-editor`:
 
 ```bash
-$ helm upgrade -i enginekubevaultcom-awsrole-editor bytebuilders-ui/enginekubevaultcom-awsrole-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i enginekubevaultcom-awsrole-editor bytebuilders-ui/enginekubevaultcom-awsrole-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a AWSRole Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `enginekubevaultcom
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i enginekubevaultcom-awsrole-editor bytebuilders-ui/enginekubevaultcom-awsrole-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=engine.kubevault.com/v1alpha1
+$ helm upgrade -i enginekubevaultcom-awsrole-editor bytebuilders-ui/enginekubevaultcom-awsrole-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=engine.kubevault.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i enginekubevaultcom-awsrole-editor bytebuilders-ui/enginekubevaultcom-awsrole-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i enginekubevaultcom-awsrole-editor bytebuilders-ui/enginekubevaultcom-awsrole-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/enginekubevaultcom-azurerole-editor/Chart.yaml
+++ b/charts/enginekubevaultcom-azurerole-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"engine.kubevault.com","version":"v1alpha1","resource":"azureroles"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: AzureRole Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: enginekubevaultcom-azurerole-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/enginekubevaultcom-azurerole-editor/README.md
+++ b/charts/enginekubevaultcom-azurerole-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/enginekubevaultcom-azurerole-editor --version=v0.4.8
-$ helm upgrade -i enginekubevaultcom-azurerole-editor bytebuilders-ui/enginekubevaultcom-azurerole-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/enginekubevaultcom-azurerole-editor --version=v0.4.9
+$ helm upgrade -i enginekubevaultcom-azurerole-editor bytebuilders-ui/enginekubevaultcom-azurerole-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a AzureRole Editor on a [Kubernetes](http://kubernetes.io) cl
 To install/upgrade the chart with the release name `enginekubevaultcom-azurerole-editor`:
 
 ```bash
-$ helm upgrade -i enginekubevaultcom-azurerole-editor bytebuilders-ui/enginekubevaultcom-azurerole-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i enginekubevaultcom-azurerole-editor bytebuilders-ui/enginekubevaultcom-azurerole-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a AzureRole Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `enginekubevaultcom
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i enginekubevaultcom-azurerole-editor bytebuilders-ui/enginekubevaultcom-azurerole-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=engine.kubevault.com/v1alpha1
+$ helm upgrade -i enginekubevaultcom-azurerole-editor bytebuilders-ui/enginekubevaultcom-azurerole-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=engine.kubevault.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i enginekubevaultcom-azurerole-editor bytebuilders-ui/enginekubevaultcom-azurerole-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i enginekubevaultcom-azurerole-editor bytebuilders-ui/enginekubevaultcom-azurerole-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/enginekubevaultcom-elasticsearchrole-editor/Chart.yaml
+++ b/charts/enginekubevaultcom-elasticsearchrole-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"engine.kubevault.com","version":"v1alpha1","resource":"elasticsearchroles"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: ElasticsearchRole Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: enginekubevaultcom-elasticsearchrole-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/enginekubevaultcom-elasticsearchrole-editor/README.md
+++ b/charts/enginekubevaultcom-elasticsearchrole-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/enginekubevaultcom-elasticsearchrole-editor --version=v0.4.8
-$ helm upgrade -i enginekubevaultcom-elasticsearchrole-editor bytebuilders-ui/enginekubevaultcom-elasticsearchrole-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/enginekubevaultcom-elasticsearchrole-editor --version=v0.4.9
+$ helm upgrade -i enginekubevaultcom-elasticsearchrole-editor bytebuilders-ui/enginekubevaultcom-elasticsearchrole-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a ElasticsearchRole Editor on a [Kubernetes](http://kubernete
 To install/upgrade the chart with the release name `enginekubevaultcom-elasticsearchrole-editor`:
 
 ```bash
-$ helm upgrade -i enginekubevaultcom-elasticsearchrole-editor bytebuilders-ui/enginekubevaultcom-elasticsearchrole-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i enginekubevaultcom-elasticsearchrole-editor bytebuilders-ui/enginekubevaultcom-elasticsearchrole-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a ElasticsearchRole Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `enginekubevaultcom
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i enginekubevaultcom-elasticsearchrole-editor bytebuilders-ui/enginekubevaultcom-elasticsearchrole-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=engine.kubevault.com/v1alpha1
+$ helm upgrade -i enginekubevaultcom-elasticsearchrole-editor bytebuilders-ui/enginekubevaultcom-elasticsearchrole-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=engine.kubevault.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i enginekubevaultcom-elasticsearchrole-editor bytebuilders-ui/enginekubevaultcom-elasticsearchrole-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i enginekubevaultcom-elasticsearchrole-editor bytebuilders-ui/enginekubevaultcom-elasticsearchrole-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/enginekubevaultcom-gcprole-editor/Chart.yaml
+++ b/charts/enginekubevaultcom-gcprole-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"engine.kubevault.com","version":"v1alpha1","resource":"gcproles"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: GCPRole Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: enginekubevaultcom-gcprole-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/enginekubevaultcom-gcprole-editor/README.md
+++ b/charts/enginekubevaultcom-gcprole-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/enginekubevaultcom-gcprole-editor --version=v0.4.8
-$ helm upgrade -i enginekubevaultcom-gcprole-editor bytebuilders-ui/enginekubevaultcom-gcprole-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/enginekubevaultcom-gcprole-editor --version=v0.4.9
+$ helm upgrade -i enginekubevaultcom-gcprole-editor bytebuilders-ui/enginekubevaultcom-gcprole-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a GCPRole Editor on a [Kubernetes](http://kubernetes.io) clus
 To install/upgrade the chart with the release name `enginekubevaultcom-gcprole-editor`:
 
 ```bash
-$ helm upgrade -i enginekubevaultcom-gcprole-editor bytebuilders-ui/enginekubevaultcom-gcprole-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i enginekubevaultcom-gcprole-editor bytebuilders-ui/enginekubevaultcom-gcprole-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a GCPRole Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `enginekubevaultcom
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i enginekubevaultcom-gcprole-editor bytebuilders-ui/enginekubevaultcom-gcprole-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=engine.kubevault.com/v1alpha1
+$ helm upgrade -i enginekubevaultcom-gcprole-editor bytebuilders-ui/enginekubevaultcom-gcprole-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=engine.kubevault.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i enginekubevaultcom-gcprole-editor bytebuilders-ui/enginekubevaultcom-gcprole-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i enginekubevaultcom-gcprole-editor bytebuilders-ui/enginekubevaultcom-gcprole-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/enginekubevaultcom-mongodbrole-editor/Chart.yaml
+++ b/charts/enginekubevaultcom-mongodbrole-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"engine.kubevault.com","version":"v1alpha1","resource":"mongodbroles"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: MongoDBRole Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: enginekubevaultcom-mongodbrole-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/enginekubevaultcom-mongodbrole-editor/README.md
+++ b/charts/enginekubevaultcom-mongodbrole-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/enginekubevaultcom-mongodbrole-editor --version=v0.4.8
-$ helm upgrade -i enginekubevaultcom-mongodbrole-editor bytebuilders-ui/enginekubevaultcom-mongodbrole-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/enginekubevaultcom-mongodbrole-editor --version=v0.4.9
+$ helm upgrade -i enginekubevaultcom-mongodbrole-editor bytebuilders-ui/enginekubevaultcom-mongodbrole-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a MongoDBRole Editor on a [Kubernetes](http://kubernetes.io) 
 To install/upgrade the chart with the release name `enginekubevaultcom-mongodbrole-editor`:
 
 ```bash
-$ helm upgrade -i enginekubevaultcom-mongodbrole-editor bytebuilders-ui/enginekubevaultcom-mongodbrole-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i enginekubevaultcom-mongodbrole-editor bytebuilders-ui/enginekubevaultcom-mongodbrole-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a MongoDBRole Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `enginekubevaultcom
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i enginekubevaultcom-mongodbrole-editor bytebuilders-ui/enginekubevaultcom-mongodbrole-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=engine.kubevault.com/v1alpha1
+$ helm upgrade -i enginekubevaultcom-mongodbrole-editor bytebuilders-ui/enginekubevaultcom-mongodbrole-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=engine.kubevault.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i enginekubevaultcom-mongodbrole-editor bytebuilders-ui/enginekubevaultcom-mongodbrole-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i enginekubevaultcom-mongodbrole-editor bytebuilders-ui/enginekubevaultcom-mongodbrole-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/enginekubevaultcom-mysqlrole-editor/Chart.yaml
+++ b/charts/enginekubevaultcom-mysqlrole-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"engine.kubevault.com","version":"v1alpha1","resource":"mysqlroles"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: MySQLRole Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: enginekubevaultcom-mysqlrole-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/enginekubevaultcom-mysqlrole-editor/README.md
+++ b/charts/enginekubevaultcom-mysqlrole-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/enginekubevaultcom-mysqlrole-editor --version=v0.4.8
-$ helm upgrade -i enginekubevaultcom-mysqlrole-editor bytebuilders-ui/enginekubevaultcom-mysqlrole-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/enginekubevaultcom-mysqlrole-editor --version=v0.4.9
+$ helm upgrade -i enginekubevaultcom-mysqlrole-editor bytebuilders-ui/enginekubevaultcom-mysqlrole-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a MySQLRole Editor on a [Kubernetes](http://kubernetes.io) cl
 To install/upgrade the chart with the release name `enginekubevaultcom-mysqlrole-editor`:
 
 ```bash
-$ helm upgrade -i enginekubevaultcom-mysqlrole-editor bytebuilders-ui/enginekubevaultcom-mysqlrole-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i enginekubevaultcom-mysqlrole-editor bytebuilders-ui/enginekubevaultcom-mysqlrole-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a MySQLRole Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `enginekubevaultcom
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i enginekubevaultcom-mysqlrole-editor bytebuilders-ui/enginekubevaultcom-mysqlrole-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=engine.kubevault.com/v1alpha1
+$ helm upgrade -i enginekubevaultcom-mysqlrole-editor bytebuilders-ui/enginekubevaultcom-mysqlrole-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=engine.kubevault.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i enginekubevaultcom-mysqlrole-editor bytebuilders-ui/enginekubevaultcom-mysqlrole-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i enginekubevaultcom-mysqlrole-editor bytebuilders-ui/enginekubevaultcom-mysqlrole-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/enginekubevaultcom-postgresrole-editor/Chart.yaml
+++ b/charts/enginekubevaultcom-postgresrole-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"engine.kubevault.com","version":"v1alpha1","resource":"postgresroles"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: PostgresRole Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: enginekubevaultcom-postgresrole-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/enginekubevaultcom-postgresrole-editor/README.md
+++ b/charts/enginekubevaultcom-postgresrole-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/enginekubevaultcom-postgresrole-editor --version=v0.4.8
-$ helm upgrade -i enginekubevaultcom-postgresrole-editor bytebuilders-ui/enginekubevaultcom-postgresrole-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/enginekubevaultcom-postgresrole-editor --version=v0.4.9
+$ helm upgrade -i enginekubevaultcom-postgresrole-editor bytebuilders-ui/enginekubevaultcom-postgresrole-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a PostgresRole Editor on a [Kubernetes](http://kubernetes.io)
 To install/upgrade the chart with the release name `enginekubevaultcom-postgresrole-editor`:
 
 ```bash
-$ helm upgrade -i enginekubevaultcom-postgresrole-editor bytebuilders-ui/enginekubevaultcom-postgresrole-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i enginekubevaultcom-postgresrole-editor bytebuilders-ui/enginekubevaultcom-postgresrole-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a PostgresRole Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `enginekubevaultcom
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i enginekubevaultcom-postgresrole-editor bytebuilders-ui/enginekubevaultcom-postgresrole-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=engine.kubevault.com/v1alpha1
+$ helm upgrade -i enginekubevaultcom-postgresrole-editor bytebuilders-ui/enginekubevaultcom-postgresrole-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=engine.kubevault.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i enginekubevaultcom-postgresrole-editor bytebuilders-ui/enginekubevaultcom-postgresrole-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i enginekubevaultcom-postgresrole-editor bytebuilders-ui/enginekubevaultcom-postgresrole-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/enginekubevaultcom-secretaccessrequest-editor/Chart.yaml
+++ b/charts/enginekubevaultcom-secretaccessrequest-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"engine.kubevault.com","version":"v1alpha1","resource":"secretaccessrequests"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: SecretAccessRequest Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: enginekubevaultcom-secretaccessrequest-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/enginekubevaultcom-secretaccessrequest-editor/README.md
+++ b/charts/enginekubevaultcom-secretaccessrequest-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/enginekubevaultcom-secretaccessrequest-editor --version=v0.4.8
-$ helm upgrade -i enginekubevaultcom-secretaccessrequest-editor bytebuilders-ui/enginekubevaultcom-secretaccessrequest-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/enginekubevaultcom-secretaccessrequest-editor --version=v0.4.9
+$ helm upgrade -i enginekubevaultcom-secretaccessrequest-editor bytebuilders-ui/enginekubevaultcom-secretaccessrequest-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a SecretAccessRequest Editor on a [Kubernetes](http://kuberne
 To install/upgrade the chart with the release name `enginekubevaultcom-secretaccessrequest-editor`:
 
 ```bash
-$ helm upgrade -i enginekubevaultcom-secretaccessrequest-editor bytebuilders-ui/enginekubevaultcom-secretaccessrequest-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i enginekubevaultcom-secretaccessrequest-editor bytebuilders-ui/enginekubevaultcom-secretaccessrequest-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a SecretAccessRequest Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `enginekubevaultcom
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i enginekubevaultcom-secretaccessrequest-editor bytebuilders-ui/enginekubevaultcom-secretaccessrequest-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=engine.kubevault.com/v1alpha1
+$ helm upgrade -i enginekubevaultcom-secretaccessrequest-editor bytebuilders-ui/enginekubevaultcom-secretaccessrequest-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=engine.kubevault.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i enginekubevaultcom-secretaccessrequest-editor bytebuilders-ui/enginekubevaultcom-secretaccessrequest-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i enginekubevaultcom-secretaccessrequest-editor bytebuilders-ui/enginekubevaultcom-secretaccessrequest-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/enginekubevaultcom-secretengine-editor/Chart.yaml
+++ b/charts/enginekubevaultcom-secretengine-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"engine.kubevault.com","version":"v1alpha1","resource":"secretengines"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: SecretEngine Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: enginekubevaultcom-secretengine-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/enginekubevaultcom-secretengine-editor/README.md
+++ b/charts/enginekubevaultcom-secretengine-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/enginekubevaultcom-secretengine-editor --version=v0.4.8
-$ helm upgrade -i enginekubevaultcom-secretengine-editor bytebuilders-ui/enginekubevaultcom-secretengine-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/enginekubevaultcom-secretengine-editor --version=v0.4.9
+$ helm upgrade -i enginekubevaultcom-secretengine-editor bytebuilders-ui/enginekubevaultcom-secretengine-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a SecretEngine Editor on a [Kubernetes](http://kubernetes.io)
 To install/upgrade the chart with the release name `enginekubevaultcom-secretengine-editor`:
 
 ```bash
-$ helm upgrade -i enginekubevaultcom-secretengine-editor bytebuilders-ui/enginekubevaultcom-secretengine-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i enginekubevaultcom-secretengine-editor bytebuilders-ui/enginekubevaultcom-secretengine-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a SecretEngine Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `enginekubevaultcom
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i enginekubevaultcom-secretengine-editor bytebuilders-ui/enginekubevaultcom-secretengine-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=engine.kubevault.com/v1alpha1
+$ helm upgrade -i enginekubevaultcom-secretengine-editor bytebuilders-ui/enginekubevaultcom-secretengine-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=engine.kubevault.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i enginekubevaultcom-secretengine-editor bytebuilders-ui/enginekubevaultcom-secretengine-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i enginekubevaultcom-secretengine-editor bytebuilders-ui/enginekubevaultcom-secretengine-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/enginekubevaultcom-secretrolebinding-editor/Chart.yaml
+++ b/charts/enginekubevaultcom-secretrolebinding-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"engine.kubevault.com","version":"v1alpha1","resource":"secretrolebindings"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: SecretRoleBinding Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: enginekubevaultcom-secretrolebinding-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/enginekubevaultcom-secretrolebinding-editor/README.md
+++ b/charts/enginekubevaultcom-secretrolebinding-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/enginekubevaultcom-secretrolebinding-editor --version=v0.4.8
-$ helm upgrade -i enginekubevaultcom-secretrolebinding-editor bytebuilders-ui/enginekubevaultcom-secretrolebinding-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/enginekubevaultcom-secretrolebinding-editor --version=v0.4.9
+$ helm upgrade -i enginekubevaultcom-secretrolebinding-editor bytebuilders-ui/enginekubevaultcom-secretrolebinding-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a SecretRoleBinding Editor on a [Kubernetes](http://kubernete
 To install/upgrade the chart with the release name `enginekubevaultcom-secretrolebinding-editor`:
 
 ```bash
-$ helm upgrade -i enginekubevaultcom-secretrolebinding-editor bytebuilders-ui/enginekubevaultcom-secretrolebinding-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i enginekubevaultcom-secretrolebinding-editor bytebuilders-ui/enginekubevaultcom-secretrolebinding-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a SecretRoleBinding Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `enginekubevaultcom
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i enginekubevaultcom-secretrolebinding-editor bytebuilders-ui/enginekubevaultcom-secretrolebinding-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=engine.kubevault.com/v1alpha1
+$ helm upgrade -i enginekubevaultcom-secretrolebinding-editor bytebuilders-ui/enginekubevaultcom-secretrolebinding-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=engine.kubevault.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i enginekubevaultcom-secretrolebinding-editor bytebuilders-ui/enginekubevaultcom-secretrolebinding-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i enginekubevaultcom-secretrolebinding-editor bytebuilders-ui/enginekubevaultcom-secretrolebinding-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/eventsk8sio-event-editor/Chart.yaml
+++ b/charts/eventsk8sio-event-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"events.k8s.io","version":"v1","resource":"events"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: Event Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: eventsk8sio-event-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/eventsk8sio-event-editor/README.md
+++ b/charts/eventsk8sio-event-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/eventsk8sio-event-editor --version=v0.4.8
-$ helm upgrade -i eventsk8sio-event-editor bytebuilders-ui/eventsk8sio-event-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/eventsk8sio-event-editor --version=v0.4.9
+$ helm upgrade -i eventsk8sio-event-editor bytebuilders-ui/eventsk8sio-event-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a Event Editor on a [Kubernetes](http://kubernetes.io) cluste
 To install/upgrade the chart with the release name `eventsk8sio-event-editor`:
 
 ```bash
-$ helm upgrade -i eventsk8sio-event-editor bytebuilders-ui/eventsk8sio-event-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i eventsk8sio-event-editor bytebuilders-ui/eventsk8sio-event-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a Event Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `eventsk8sio-event-
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i eventsk8sio-event-editor bytebuilders-ui/eventsk8sio-event-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=events.k8s.io/v1
+$ helm upgrade -i eventsk8sio-event-editor bytebuilders-ui/eventsk8sio-event-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=events.k8s.io/v1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i eventsk8sio-event-editor bytebuilders-ui/eventsk8sio-event-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i eventsk8sio-event-editor bytebuilders-ui/eventsk8sio-event-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/extensions-daemonset-editor/Chart.yaml
+++ b/charts/extensions-daemonset-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"extensions","version":"v1beta1","resource":"daemonsets"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: DaemonSet Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: extensions-daemonset-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/extensions-daemonset-editor/README.md
+++ b/charts/extensions-daemonset-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/extensions-daemonset-editor --version=v0.4.8
-$ helm upgrade -i extensions-daemonset-editor bytebuilders-ui/extensions-daemonset-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/extensions-daemonset-editor --version=v0.4.9
+$ helm upgrade -i extensions-daemonset-editor bytebuilders-ui/extensions-daemonset-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a DaemonSet Editor on a [Kubernetes](http://kubernetes.io) cl
 To install/upgrade the chart with the release name `extensions-daemonset-editor`:
 
 ```bash
-$ helm upgrade -i extensions-daemonset-editor bytebuilders-ui/extensions-daemonset-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i extensions-daemonset-editor bytebuilders-ui/extensions-daemonset-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a DaemonSet Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `extensions-daemons
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i extensions-daemonset-editor bytebuilders-ui/extensions-daemonset-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=extensions/v1beta1
+$ helm upgrade -i extensions-daemonset-editor bytebuilders-ui/extensions-daemonset-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=extensions/v1beta1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i extensions-daemonset-editor bytebuilders-ui/extensions-daemonset-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i extensions-daemonset-editor bytebuilders-ui/extensions-daemonset-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/extensions-deployment-editor/Chart.yaml
+++ b/charts/extensions-deployment-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"extensions","version":"v1beta1","resource":"deployments"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: Deployment Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: extensions-deployment-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/extensions-deployment-editor/README.md
+++ b/charts/extensions-deployment-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/extensions-deployment-editor --version=v0.4.8
-$ helm upgrade -i extensions-deployment-editor bytebuilders-ui/extensions-deployment-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/extensions-deployment-editor --version=v0.4.9
+$ helm upgrade -i extensions-deployment-editor bytebuilders-ui/extensions-deployment-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a Deployment Editor on a [Kubernetes](http://kubernetes.io) c
 To install/upgrade the chart with the release name `extensions-deployment-editor`:
 
 ```bash
-$ helm upgrade -i extensions-deployment-editor bytebuilders-ui/extensions-deployment-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i extensions-deployment-editor bytebuilders-ui/extensions-deployment-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a Deployment Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `extensions-deploym
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i extensions-deployment-editor bytebuilders-ui/extensions-deployment-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=extensions/v1beta1
+$ helm upgrade -i extensions-deployment-editor bytebuilders-ui/extensions-deployment-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=extensions/v1beta1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i extensions-deployment-editor bytebuilders-ui/extensions-deployment-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i extensions-deployment-editor bytebuilders-ui/extensions-deployment-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/extensions-ingress-editor/Chart.yaml
+++ b/charts/extensions-ingress-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"extensions","version":"v1beta1","resource":"ingresses"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: Ingress Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: extensions-ingress-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/extensions-ingress-editor/README.md
+++ b/charts/extensions-ingress-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/extensions-ingress-editor --version=v0.4.8
-$ helm upgrade -i extensions-ingress-editor bytebuilders-ui/extensions-ingress-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/extensions-ingress-editor --version=v0.4.9
+$ helm upgrade -i extensions-ingress-editor bytebuilders-ui/extensions-ingress-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a Ingress Editor on a [Kubernetes](http://kubernetes.io) clus
 To install/upgrade the chart with the release name `extensions-ingress-editor`:
 
 ```bash
-$ helm upgrade -i extensions-ingress-editor bytebuilders-ui/extensions-ingress-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i extensions-ingress-editor bytebuilders-ui/extensions-ingress-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a Ingress Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `extensions-ingress
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i extensions-ingress-editor bytebuilders-ui/extensions-ingress-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=extensions/v1beta1
+$ helm upgrade -i extensions-ingress-editor bytebuilders-ui/extensions-ingress-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=extensions/v1beta1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i extensions-ingress-editor bytebuilders-ui/extensions-ingress-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i extensions-ingress-editor bytebuilders-ui/extensions-ingress-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/extensions-networkpolicy-editor/Chart.yaml
+++ b/charts/extensions-networkpolicy-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"extensions","version":"v1beta1","resource":"networkpolicies"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: NetworkPolicy Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: extensions-networkpolicy-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/extensions-networkpolicy-editor/README.md
+++ b/charts/extensions-networkpolicy-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/extensions-networkpolicy-editor --version=v0.4.8
-$ helm upgrade -i extensions-networkpolicy-editor bytebuilders-ui/extensions-networkpolicy-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/extensions-networkpolicy-editor --version=v0.4.9
+$ helm upgrade -i extensions-networkpolicy-editor bytebuilders-ui/extensions-networkpolicy-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a NetworkPolicy Editor on a [Kubernetes](http://kubernetes.io
 To install/upgrade the chart with the release name `extensions-networkpolicy-editor`:
 
 ```bash
-$ helm upgrade -i extensions-networkpolicy-editor bytebuilders-ui/extensions-networkpolicy-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i extensions-networkpolicy-editor bytebuilders-ui/extensions-networkpolicy-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a NetworkPolicy Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `extensions-network
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i extensions-networkpolicy-editor bytebuilders-ui/extensions-networkpolicy-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=extensions/v1beta1
+$ helm upgrade -i extensions-networkpolicy-editor bytebuilders-ui/extensions-networkpolicy-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=extensions/v1beta1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i extensions-networkpolicy-editor bytebuilders-ui/extensions-networkpolicy-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i extensions-networkpolicy-editor bytebuilders-ui/extensions-networkpolicy-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/extensions-podsecuritypolicy-editor/Chart.yaml
+++ b/charts/extensions-podsecuritypolicy-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"extensions","version":"v1beta1","resource":"podsecuritypolicies"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: PodSecurityPolicy Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: extensions-podsecuritypolicy-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/extensions-podsecuritypolicy-editor/README.md
+++ b/charts/extensions-podsecuritypolicy-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/extensions-podsecuritypolicy-editor --version=v0.4.8
-$ helm upgrade -i extensions-podsecuritypolicy-editor bytebuilders-ui/extensions-podsecuritypolicy-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/extensions-podsecuritypolicy-editor --version=v0.4.9
+$ helm upgrade -i extensions-podsecuritypolicy-editor bytebuilders-ui/extensions-podsecuritypolicy-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a PodSecurityPolicy Editor on a [Kubernetes](http://kubernete
 To install/upgrade the chart with the release name `extensions-podsecuritypolicy-editor`:
 
 ```bash
-$ helm upgrade -i extensions-podsecuritypolicy-editor bytebuilders-ui/extensions-podsecuritypolicy-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i extensions-podsecuritypolicy-editor bytebuilders-ui/extensions-podsecuritypolicy-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a PodSecurityPolicy Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `extensions-podsecu
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i extensions-podsecuritypolicy-editor bytebuilders-ui/extensions-podsecuritypolicy-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=extensions/v1beta1
+$ helm upgrade -i extensions-podsecuritypolicy-editor bytebuilders-ui/extensions-podsecuritypolicy-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=extensions/v1beta1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i extensions-podsecuritypolicy-editor bytebuilders-ui/extensions-podsecuritypolicy-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i extensions-podsecuritypolicy-editor bytebuilders-ui/extensions-podsecuritypolicy-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/extensions-replicaset-editor/Chart.yaml
+++ b/charts/extensions-replicaset-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"extensions","version":"v1beta1","resource":"replicasets"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: ReplicaSet Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: extensions-replicaset-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/extensions-replicaset-editor/README.md
+++ b/charts/extensions-replicaset-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/extensions-replicaset-editor --version=v0.4.8
-$ helm upgrade -i extensions-replicaset-editor bytebuilders-ui/extensions-replicaset-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/extensions-replicaset-editor --version=v0.4.9
+$ helm upgrade -i extensions-replicaset-editor bytebuilders-ui/extensions-replicaset-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a ReplicaSet Editor on a [Kubernetes](http://kubernetes.io) c
 To install/upgrade the chart with the release name `extensions-replicaset-editor`:
 
 ```bash
-$ helm upgrade -i extensions-replicaset-editor bytebuilders-ui/extensions-replicaset-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i extensions-replicaset-editor bytebuilders-ui/extensions-replicaset-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a ReplicaSet Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `extensions-replica
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i extensions-replicaset-editor bytebuilders-ui/extensions-replicaset-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=extensions/v1beta1
+$ helm upgrade -i extensions-replicaset-editor bytebuilders-ui/extensions-replicaset-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=extensions/v1beta1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i extensions-replicaset-editor bytebuilders-ui/extensions-replicaset-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i extensions-replicaset-editor bytebuilders-ui/extensions-replicaset-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/extensions-scale-editor/Chart.yaml
+++ b/charts/extensions-scale-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"extensions","version":"v1beta1","resource":"scales"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: Scale Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: extensions-scale-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/extensions-scale-editor/README.md
+++ b/charts/extensions-scale-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/extensions-scale-editor --version=v0.4.8
-$ helm upgrade -i extensions-scale-editor bytebuilders-ui/extensions-scale-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/extensions-scale-editor --version=v0.4.9
+$ helm upgrade -i extensions-scale-editor bytebuilders-ui/extensions-scale-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a Scale Editor on a [Kubernetes](http://kubernetes.io) cluste
 To install/upgrade the chart with the release name `extensions-scale-editor`:
 
 ```bash
-$ helm upgrade -i extensions-scale-editor bytebuilders-ui/extensions-scale-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i extensions-scale-editor bytebuilders-ui/extensions-scale-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a Scale Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `extensions-scale-e
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i extensions-scale-editor bytebuilders-ui/extensions-scale-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=extensions/v1beta1
+$ helm upgrade -i extensions-scale-editor bytebuilders-ui/extensions-scale-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=extensions/v1beta1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i extensions-scale-editor bytebuilders-ui/extensions-scale-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i extensions-scale-editor bytebuilders-ui/extensions-scale-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/flowcontrolapiserverk8sio-flowschema-editor/Chart.yaml
+++ b/charts/flowcontrolapiserverk8sio-flowschema-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"flowcontrol.apiserver.k8s.io","version":"v1beta1","resource":"flowschemas"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: FlowSchema Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: flowcontrolapiserverk8sio-flowschema-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/flowcontrolapiserverk8sio-flowschema-editor/README.md
+++ b/charts/flowcontrolapiserverk8sio-flowschema-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/flowcontrolapiserverk8sio-flowschema-editor --version=v0.4.8
-$ helm upgrade -i flowcontrolapiserverk8sio-flowschema-editor bytebuilders-ui/flowcontrolapiserverk8sio-flowschema-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/flowcontrolapiserverk8sio-flowschema-editor --version=v0.4.9
+$ helm upgrade -i flowcontrolapiserverk8sio-flowschema-editor bytebuilders-ui/flowcontrolapiserverk8sio-flowschema-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a FlowSchema Editor on a [Kubernetes](http://kubernetes.io) c
 To install/upgrade the chart with the release name `flowcontrolapiserverk8sio-flowschema-editor`:
 
 ```bash
-$ helm upgrade -i flowcontrolapiserverk8sio-flowschema-editor bytebuilders-ui/flowcontrolapiserverk8sio-flowschema-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i flowcontrolapiserverk8sio-flowschema-editor bytebuilders-ui/flowcontrolapiserverk8sio-flowschema-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a FlowSchema Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `flowcontrolapiserv
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i flowcontrolapiserverk8sio-flowschema-editor bytebuilders-ui/flowcontrolapiserverk8sio-flowschema-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=flowcontrol.apiserver.k8s.io/v1beta1
+$ helm upgrade -i flowcontrolapiserverk8sio-flowschema-editor bytebuilders-ui/flowcontrolapiserverk8sio-flowschema-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=flowcontrol.apiserver.k8s.io/v1beta1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i flowcontrolapiserverk8sio-flowschema-editor bytebuilders-ui/flowcontrolapiserverk8sio-flowschema-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i flowcontrolapiserverk8sio-flowschema-editor bytebuilders-ui/flowcontrolapiserverk8sio-flowschema-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/flowcontrolapiserverk8sio-prioritylevelconfiguration-editor/Chart.yaml
+++ b/charts/flowcontrolapiserverk8sio-prioritylevelconfiguration-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"flowcontrol.apiserver.k8s.io","version":"v1beta1","resource":"prioritylevelconfigurations"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: PriorityLevelConfiguration Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: flowcontrolapiserverk8sio-prioritylevelconfiguration-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/flowcontrolapiserverk8sio-prioritylevelconfiguration-editor/README.md
+++ b/charts/flowcontrolapiserverk8sio-prioritylevelconfiguration-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/flowcontrolapiserverk8sio-prioritylevelconfiguration-editor --version=v0.4.8
-$ helm upgrade -i flowcontrolapiserverk8sio-prioritylevelconfiguration-editor bytebuilders-ui/flowcontrolapiserverk8sio-prioritylevelconfiguration-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/flowcontrolapiserverk8sio-prioritylevelconfiguration-editor --version=v0.4.9
+$ helm upgrade -i flowcontrolapiserverk8sio-prioritylevelconfiguration-editor bytebuilders-ui/flowcontrolapiserverk8sio-prioritylevelconfiguration-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a PriorityLevelConfiguration Editor on a [Kubernetes](http://
 To install/upgrade the chart with the release name `flowcontrolapiserverk8sio-prioritylevelconfiguration-editor`:
 
 ```bash
-$ helm upgrade -i flowcontrolapiserverk8sio-prioritylevelconfiguration-editor bytebuilders-ui/flowcontrolapiserverk8sio-prioritylevelconfiguration-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i flowcontrolapiserverk8sio-prioritylevelconfiguration-editor bytebuilders-ui/flowcontrolapiserverk8sio-prioritylevelconfiguration-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a PriorityLevelConfiguration Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `flowcontrolapiserv
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i flowcontrolapiserverk8sio-prioritylevelconfiguration-editor bytebuilders-ui/flowcontrolapiserverk8sio-prioritylevelconfiguration-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=flowcontrol.apiserver.k8s.io/v1beta1
+$ helm upgrade -i flowcontrolapiserverk8sio-prioritylevelconfiguration-editor bytebuilders-ui/flowcontrolapiserverk8sio-prioritylevelconfiguration-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=flowcontrol.apiserver.k8s.io/v1beta1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i flowcontrolapiserverk8sio-prioritylevelconfiguration-editor bytebuilders-ui/flowcontrolapiserverk8sio-prioritylevelconfiguration-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i flowcontrolapiserverk8sio-prioritylevelconfiguration-editor bytebuilders-ui/flowcontrolapiserverk8sio-prioritylevelconfiguration-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/grafanasearchlightdev-dashboard-editor/Chart.yaml
+++ b/charts/grafanasearchlightdev-dashboard-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"grafana.searchlight.dev","version":"v1alpha1","resource":"dashboards"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: Dashboard Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: grafanasearchlightdev-dashboard-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/grafanasearchlightdev-dashboard-editor/README.md
+++ b/charts/grafanasearchlightdev-dashboard-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/grafanasearchlightdev-dashboard-editor --version=v0.4.8
-$ helm upgrade -i grafanasearchlightdev-dashboard-editor bytebuilders-ui/grafanasearchlightdev-dashboard-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/grafanasearchlightdev-dashboard-editor --version=v0.4.9
+$ helm upgrade -i grafanasearchlightdev-dashboard-editor bytebuilders-ui/grafanasearchlightdev-dashboard-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a Dashboard Editor on a [Kubernetes](http://kubernetes.io) cl
 To install/upgrade the chart with the release name `grafanasearchlightdev-dashboard-editor`:
 
 ```bash
-$ helm upgrade -i grafanasearchlightdev-dashboard-editor bytebuilders-ui/grafanasearchlightdev-dashboard-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i grafanasearchlightdev-dashboard-editor bytebuilders-ui/grafanasearchlightdev-dashboard-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a Dashboard Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `grafanasearchlight
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i grafanasearchlightdev-dashboard-editor bytebuilders-ui/grafanasearchlightdev-dashboard-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=grafana.searchlight.dev/v1alpha1
+$ helm upgrade -i grafanasearchlightdev-dashboard-editor bytebuilders-ui/grafanasearchlightdev-dashboard-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=grafana.searchlight.dev/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i grafanasearchlightdev-dashboard-editor bytebuilders-ui/grafanasearchlightdev-dashboard-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i grafanasearchlightdev-dashboard-editor bytebuilders-ui/grafanasearchlightdev-dashboard-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/grafanasearchlightdev-dashboardtemplate-editor/Chart.yaml
+++ b/charts/grafanasearchlightdev-dashboardtemplate-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"grafana.searchlight.dev","version":"v1alpha1","resource":"dashboardtemplates"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: DashboardTemplate Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: grafanasearchlightdev-dashboardtemplate-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/grafanasearchlightdev-dashboardtemplate-editor/README.md
+++ b/charts/grafanasearchlightdev-dashboardtemplate-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/grafanasearchlightdev-dashboardtemplate-editor --version=v0.4.8
-$ helm upgrade -i grafanasearchlightdev-dashboardtemplate-editor bytebuilders-ui/grafanasearchlightdev-dashboardtemplate-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/grafanasearchlightdev-dashboardtemplate-editor --version=v0.4.9
+$ helm upgrade -i grafanasearchlightdev-dashboardtemplate-editor bytebuilders-ui/grafanasearchlightdev-dashboardtemplate-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a DashboardTemplate Editor on a [Kubernetes](http://kubernete
 To install/upgrade the chart with the release name `grafanasearchlightdev-dashboardtemplate-editor`:
 
 ```bash
-$ helm upgrade -i grafanasearchlightdev-dashboardtemplate-editor bytebuilders-ui/grafanasearchlightdev-dashboardtemplate-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i grafanasearchlightdev-dashboardtemplate-editor bytebuilders-ui/grafanasearchlightdev-dashboardtemplate-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a DashboardTemplate Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -55,12 +55,12 @@ The following table lists the configurable parameters of the `grafanasearchlight
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i grafanasearchlightdev-dashboardtemplate-editor bytebuilders-ui/grafanasearchlightdev-dashboardtemplate-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=grafana.searchlight.dev/v1alpha1
+$ helm upgrade -i grafanasearchlightdev-dashboardtemplate-editor bytebuilders-ui/grafanasearchlightdev-dashboardtemplate-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=grafana.searchlight.dev/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i grafanasearchlightdev-dashboardtemplate-editor bytebuilders-ui/grafanasearchlightdev-dashboardtemplate-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i grafanasearchlightdev-dashboardtemplate-editor bytebuilders-ui/grafanasearchlightdev-dashboardtemplate-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/grafanasearchlightdev-datasource-editor/Chart.yaml
+++ b/charts/grafanasearchlightdev-datasource-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"grafana.searchlight.dev","version":"v1alpha1","resource":"datasources"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: Datasource Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: grafanasearchlightdev-datasource-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/grafanasearchlightdev-datasource-editor/README.md
+++ b/charts/grafanasearchlightdev-datasource-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/grafanasearchlightdev-datasource-editor --version=v0.4.8
-$ helm upgrade -i grafanasearchlightdev-datasource-editor bytebuilders-ui/grafanasearchlightdev-datasource-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/grafanasearchlightdev-datasource-editor --version=v0.4.9
+$ helm upgrade -i grafanasearchlightdev-datasource-editor bytebuilders-ui/grafanasearchlightdev-datasource-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a Datasource Editor on a [Kubernetes](http://kubernetes.io) c
 To install/upgrade the chart with the release name `grafanasearchlightdev-datasource-editor`:
 
 ```bash
-$ helm upgrade -i grafanasearchlightdev-datasource-editor bytebuilders-ui/grafanasearchlightdev-datasource-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i grafanasearchlightdev-datasource-editor bytebuilders-ui/grafanasearchlightdev-datasource-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a Datasource Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `grafanasearchlight
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i grafanasearchlightdev-datasource-editor bytebuilders-ui/grafanasearchlightdev-datasource-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=grafana.searchlight.dev/v1alpha1
+$ helm upgrade -i grafanasearchlightdev-datasource-editor bytebuilders-ui/grafanasearchlightdev-datasource-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=grafana.searchlight.dev/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i grafanasearchlightdev-datasource-editor bytebuilders-ui/grafanasearchlightdev-datasource-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i grafanasearchlightdev-datasource-editor bytebuilders-ui/grafanasearchlightdev-datasource-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/imagepolicyk8sio-imagereview-editor/Chart.yaml
+++ b/charts/imagepolicyk8sio-imagereview-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"imagepolicy.k8s.io","version":"v1alpha1","resource":"imagereviews"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: ImageReview Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: imagepolicyk8sio-imagereview-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/imagepolicyk8sio-imagereview-editor/README.md
+++ b/charts/imagepolicyk8sio-imagereview-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/imagepolicyk8sio-imagereview-editor --version=v0.4.8
-$ helm upgrade -i imagepolicyk8sio-imagereview-editor bytebuilders-ui/imagepolicyk8sio-imagereview-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/imagepolicyk8sio-imagereview-editor --version=v0.4.9
+$ helm upgrade -i imagepolicyk8sio-imagereview-editor bytebuilders-ui/imagepolicyk8sio-imagereview-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a ImageReview Editor on a [Kubernetes](http://kubernetes.io) 
 To install/upgrade the chart with the release name `imagepolicyk8sio-imagereview-editor`:
 
 ```bash
-$ helm upgrade -i imagepolicyk8sio-imagereview-editor bytebuilders-ui/imagepolicyk8sio-imagereview-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i imagepolicyk8sio-imagereview-editor bytebuilders-ui/imagepolicyk8sio-imagereview-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a ImageReview Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `imagepolicyk8sio-i
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i imagepolicyk8sio-imagereview-editor bytebuilders-ui/imagepolicyk8sio-imagereview-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=imagepolicy.k8s.io/v1alpha1
+$ helm upgrade -i imagepolicyk8sio-imagereview-editor bytebuilders-ui/imagepolicyk8sio-imagereview-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=imagepolicy.k8s.io/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i imagepolicyk8sio-imagereview-editor bytebuilders-ui/imagepolicyk8sio-imagereview-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i imagepolicyk8sio-imagereview-editor bytebuilders-ui/imagepolicyk8sio-imagereview-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/internalapiserverk8sio-storageversion-editor/Chart.yaml
+++ b/charts/internalapiserverk8sio-storageversion-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"internal.apiserver.k8s.io","version":"v1alpha1","resource":"storageversions"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: StorageVersion Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: internalapiserverk8sio-storageversion-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/internalapiserverk8sio-storageversion-editor/README.md
+++ b/charts/internalapiserverk8sio-storageversion-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/internalapiserverk8sio-storageversion-editor --version=v0.4.8
-$ helm upgrade -i internalapiserverk8sio-storageversion-editor bytebuilders-ui/internalapiserverk8sio-storageversion-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/internalapiserverk8sio-storageversion-editor --version=v0.4.9
+$ helm upgrade -i internalapiserverk8sio-storageversion-editor bytebuilders-ui/internalapiserverk8sio-storageversion-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a StorageVersion Editor on a [Kubernetes](http://kubernetes.i
 To install/upgrade the chart with the release name `internalapiserverk8sio-storageversion-editor`:
 
 ```bash
-$ helm upgrade -i internalapiserverk8sio-storageversion-editor bytebuilders-ui/internalapiserverk8sio-storageversion-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i internalapiserverk8sio-storageversion-editor bytebuilders-ui/internalapiserverk8sio-storageversion-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a StorageVersion Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `internalapiserverk
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i internalapiserverk8sio-storageversion-editor bytebuilders-ui/internalapiserverk8sio-storageversion-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=internal.apiserver.k8s.io/v1alpha1
+$ helm upgrade -i internalapiserverk8sio-storageversion-editor bytebuilders-ui/internalapiserverk8sio-storageversion-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=internal.apiserver.k8s.io/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i internalapiserverk8sio-storageversion-editor bytebuilders-ui/internalapiserverk8sio-storageversion-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i internalapiserverk8sio-storageversion-editor bytebuilders-ui/internalapiserverk8sio-storageversion-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/kubedbcom-elasticsearch-editor-options/Chart.yaml
+++ b/charts/kubedbcom-elasticsearch-editor-options/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubedbcom-elasticsearch-editor-options
 description: Elasticsearch Editor UI Options
 type: application
-version: v0.4.8
-appVersion: v0.4.8
+version: v0.4.9
+appVersion: v0.4.9
 maintainers:
 - name: appscode
   email: support@appscode.com

--- a/charts/kubedbcom-elasticsearch-editor-options/README.md
+++ b/charts/kubedbcom-elasticsearch-editor-options/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/kubedbcom-elasticsearch-editor-options --version=v0.4.8
-$ helm upgrade -i kubedbcom-elasticsearch-editor-options bytebuilders-ui/kubedbcom-elasticsearch-editor-options -n kube-system --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/kubedbcom-elasticsearch-editor-options --version=v0.4.9
+$ helm upgrade -i kubedbcom-elasticsearch-editor-options bytebuilders-ui/kubedbcom-elasticsearch-editor-options -n kube-system --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a Elasticsearch Editor UI Options on a [Kubernetes](http://ku
 To install/upgrade the chart with the release name `kubedbcom-elasticsearch-editor-options`:
 
 ```bash
-$ helm upgrade -i kubedbcom-elasticsearch-editor-options bytebuilders-ui/kubedbcom-elasticsearch-editor-options -n kube-system --create-namespace --version=v0.4.8
+$ helm upgrade -i kubedbcom-elasticsearch-editor-options bytebuilders-ui/kubedbcom-elasticsearch-editor-options -n kube-system --create-namespace --version=v0.4.9
 ```
 
 The command deploys a Elasticsearch Editor UI Options on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -180,12 +180,12 @@ The following table lists the configurable parameters of the `kubedbcom-elastics
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i kubedbcom-elasticsearch-editor-options bytebuilders-ui/kubedbcom-elasticsearch-editor-options -n kube-system --create-namespace --version=v0.4.8 --set metadata.resource.group=kubedb.com
+$ helm upgrade -i kubedbcom-elasticsearch-editor-options bytebuilders-ui/kubedbcom-elasticsearch-editor-options -n kube-system --create-namespace --version=v0.4.9 --set metadata.resource.group=kubedb.com
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i kubedbcom-elasticsearch-editor-options bytebuilders-ui/kubedbcom-elasticsearch-editor-options -n kube-system --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i kubedbcom-elasticsearch-editor-options bytebuilders-ui/kubedbcom-elasticsearch-editor-options -n kube-system --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/kubedbcom-elasticsearch-editor/Chart.yaml
+++ b/charts/kubedbcom-elasticsearch-editor/Chart.yaml
@@ -6,7 +6,7 @@ annotations:
     - group: stash.appscode.com\n  kind: Repository\n- group: stash.appscode.com\n\
     \  kind: RestoreSession\n"
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: Elasticsearch Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -18,4 +18,4 @@ maintainers:
   name: appscode
 name: kubedbcom-elasticsearch-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/kubedbcom-elasticsearch-editor/README.md
+++ b/charts/kubedbcom-elasticsearch-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/kubedbcom-elasticsearch-editor --version=v0.4.8
-$ helm upgrade -i kubedbcom-elasticsearch-editor bytebuilders-ui/kubedbcom-elasticsearch-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/kubedbcom-elasticsearch-editor --version=v0.4.9
+$ helm upgrade -i kubedbcom-elasticsearch-editor bytebuilders-ui/kubedbcom-elasticsearch-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a Elasticsearch Editor on a [Kubernetes](http://kubernetes.io
 To install/upgrade the chart with the release name `kubedbcom-elasticsearch-editor`:
 
 ```bash
-$ helm upgrade -i kubedbcom-elasticsearch-editor bytebuilders-ui/kubedbcom-elasticsearch-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i kubedbcom-elasticsearch-editor bytebuilders-ui/kubedbcom-elasticsearch-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a Elasticsearch Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -169,12 +169,12 @@ The following table lists the configurable parameters of the `kubedbcom-elastics
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i kubedbcom-elasticsearch-editor bytebuilders-ui/kubedbcom-elasticsearch-editor -n default --create-namespace --version=v0.4.8 --set form.alert.groups.database.rules.elasticsearchClusterRed.duration=0m
+$ helm upgrade -i kubedbcom-elasticsearch-editor bytebuilders-ui/kubedbcom-elasticsearch-editor -n default --create-namespace --version=v0.4.9 --set form.alert.groups.database.rules.elasticsearchClusterRed.duration=0m
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i kubedbcom-elasticsearch-editor bytebuilders-ui/kubedbcom-elasticsearch-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i kubedbcom-elasticsearch-editor bytebuilders-ui/kubedbcom-elasticsearch-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/kubedbcom-etcd-editor/Chart.yaml
+++ b/charts/kubedbcom-etcd-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"kubedb.com","version":"v1alpha2","resource":"etcds"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: Etcd Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: kubedbcom-etcd-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/kubedbcom-etcd-editor/README.md
+++ b/charts/kubedbcom-etcd-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/kubedbcom-etcd-editor --version=v0.4.8
-$ helm upgrade -i kubedbcom-etcd-editor bytebuilders-ui/kubedbcom-etcd-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/kubedbcom-etcd-editor --version=v0.4.9
+$ helm upgrade -i kubedbcom-etcd-editor bytebuilders-ui/kubedbcom-etcd-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a Etcd Editor on a [Kubernetes](http://kubernetes.io) cluster
 To install/upgrade the chart with the release name `kubedbcom-etcd-editor`:
 
 ```bash
-$ helm upgrade -i kubedbcom-etcd-editor bytebuilders-ui/kubedbcom-etcd-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i kubedbcom-etcd-editor bytebuilders-ui/kubedbcom-etcd-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a Etcd Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `kubedbcom-etcd-edi
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i kubedbcom-etcd-editor bytebuilders-ui/kubedbcom-etcd-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=kubedb.com/v1alpha2
+$ helm upgrade -i kubedbcom-etcd-editor bytebuilders-ui/kubedbcom-etcd-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=kubedb.com/v1alpha2
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i kubedbcom-etcd-editor bytebuilders-ui/kubedbcom-etcd-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i kubedbcom-etcd-editor bytebuilders-ui/kubedbcom-etcd-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/kubedbcom-mariadb-editor-options/Chart.yaml
+++ b/charts/kubedbcom-mariadb-editor-options/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubedbcom-mariadb-editor-options
 description: MariaDB Editor UI Options
 type: application
-version: v0.4.8
-appVersion: v0.4.8
+version: v0.4.9
+appVersion: v0.4.9
 maintainers:
 - name: appscode
   email: support@appscode.com

--- a/charts/kubedbcom-mariadb-editor-options/README.md
+++ b/charts/kubedbcom-mariadb-editor-options/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/kubedbcom-mariadb-editor-options --version=v0.4.8
-$ helm upgrade -i kubedbcom-mariadb-editor-options bytebuilders-ui/kubedbcom-mariadb-editor-options -n kube-system --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/kubedbcom-mariadb-editor-options --version=v0.4.9
+$ helm upgrade -i kubedbcom-mariadb-editor-options bytebuilders-ui/kubedbcom-mariadb-editor-options -n kube-system --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a MariaDB Editor UI Options on a [Kubernetes](http://kubernet
 To install/upgrade the chart with the release name `kubedbcom-mariadb-editor-options`:
 
 ```bash
-$ helm upgrade -i kubedbcom-mariadb-editor-options bytebuilders-ui/kubedbcom-mariadb-editor-options -n kube-system --create-namespace --version=v0.4.8
+$ helm upgrade -i kubedbcom-mariadb-editor-options bytebuilders-ui/kubedbcom-mariadb-editor-options -n kube-system --create-namespace --version=v0.4.9
 ```
 
 The command deploys a MariaDB Editor UI Options on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -184,12 +184,12 @@ The following table lists the configurable parameters of the `kubedbcom-mariadb-
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i kubedbcom-mariadb-editor-options bytebuilders-ui/kubedbcom-mariadb-editor-options -n kube-system --create-namespace --version=v0.4.8 --set metadata.resource.group=kubedb.com
+$ helm upgrade -i kubedbcom-mariadb-editor-options bytebuilders-ui/kubedbcom-mariadb-editor-options -n kube-system --create-namespace --version=v0.4.9 --set metadata.resource.group=kubedb.com
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i kubedbcom-mariadb-editor-options bytebuilders-ui/kubedbcom-mariadb-editor-options -n kube-system --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i kubedbcom-mariadb-editor-options bytebuilders-ui/kubedbcom-mariadb-editor-options -n kube-system --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/kubedbcom-mariadb-editor/Chart.yaml
+++ b/charts/kubedbcom-mariadb-editor/Chart.yaml
@@ -6,7 +6,7 @@ annotations:
     - group: stash.appscode.com\n  kind: Repository\n- group: stash.appscode.com\n\
     \  kind: RestoreSession\n"
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: MariaDB Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -18,4 +18,4 @@ maintainers:
   name: appscode
 name: kubedbcom-mariadb-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/kubedbcom-mariadb-editor/README.md
+++ b/charts/kubedbcom-mariadb-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/kubedbcom-mariadb-editor --version=v0.4.8
-$ helm upgrade -i kubedbcom-mariadb-editor bytebuilders-ui/kubedbcom-mariadb-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/kubedbcom-mariadb-editor --version=v0.4.9
+$ helm upgrade -i kubedbcom-mariadb-editor bytebuilders-ui/kubedbcom-mariadb-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a MariaDB Editor on a [Kubernetes](http://kubernetes.io) clus
 To install/upgrade the chart with the release name `kubedbcom-mariadb-editor`:
 
 ```bash
-$ helm upgrade -i kubedbcom-mariadb-editor bytebuilders-ui/kubedbcom-mariadb-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i kubedbcom-mariadb-editor bytebuilders-ui/kubedbcom-mariadb-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a MariaDB Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -178,12 +178,12 @@ The following table lists the configurable parameters of the `kubedbcom-mariadb-
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i kubedbcom-mariadb-editor bytebuilders-ui/kubedbcom-mariadb-editor -n default --create-namespace --version=v0.4.8 --set form.alert.groups.cluster.rules.galeraReplicationLatencyTooLong.duration=5m
+$ helm upgrade -i kubedbcom-mariadb-editor bytebuilders-ui/kubedbcom-mariadb-editor -n default --create-namespace --version=v0.4.9 --set form.alert.groups.cluster.rules.galeraReplicationLatencyTooLong.duration=5m
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i kubedbcom-mariadb-editor bytebuilders-ui/kubedbcom-mariadb-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i kubedbcom-mariadb-editor bytebuilders-ui/kubedbcom-mariadb-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/kubedbcom-memcached-editor-options/Chart.yaml
+++ b/charts/kubedbcom-memcached-editor-options/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubedbcom-memcached-editor-options
 description: Memcached Editor UI Options
 type: application
-version: v0.4.8
-appVersion: v0.4.8
+version: v0.4.9
+appVersion: v0.4.9
 maintainers:
 - name: appscode
   email: support@appscode.com

--- a/charts/kubedbcom-memcached-editor-options/README.md
+++ b/charts/kubedbcom-memcached-editor-options/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/kubedbcom-memcached-editor-options --version=v0.4.8
-$ helm upgrade -i kubedbcom-memcached-editor-options bytebuilders-ui/kubedbcom-memcached-editor-options -n kube-system --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/kubedbcom-memcached-editor-options --version=v0.4.9
+$ helm upgrade -i kubedbcom-memcached-editor-options bytebuilders-ui/kubedbcom-memcached-editor-options -n kube-system --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a Memcached Editor UI Options on a [Kubernetes](http://kubern
 To install/upgrade the chart with the release name `kubedbcom-memcached-editor-options`:
 
 ```bash
-$ helm upgrade -i kubedbcom-memcached-editor-options bytebuilders-ui/kubedbcom-memcached-editor-options -n kube-system --create-namespace --version=v0.4.8
+$ helm upgrade -i kubedbcom-memcached-editor-options bytebuilders-ui/kubedbcom-memcached-editor-options -n kube-system --create-namespace --version=v0.4.9
 ```
 
 The command deploys a Memcached Editor UI Options on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -70,12 +70,12 @@ The following table lists the configurable parameters of the `kubedbcom-memcache
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i kubedbcom-memcached-editor-options bytebuilders-ui/kubedbcom-memcached-editor-options -n kube-system --create-namespace --version=v0.4.8 --set metadata.resource.group=kubedb.com
+$ helm upgrade -i kubedbcom-memcached-editor-options bytebuilders-ui/kubedbcom-memcached-editor-options -n kube-system --create-namespace --version=v0.4.9 --set metadata.resource.group=kubedb.com
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i kubedbcom-memcached-editor-options bytebuilders-ui/kubedbcom-memcached-editor-options -n kube-system --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i kubedbcom-memcached-editor-options bytebuilders-ui/kubedbcom-memcached-editor-options -n kube-system --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/kubedbcom-memcached-editor/Chart.yaml
+++ b/charts/kubedbcom-memcached-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"kubedb.com","version":"v1alpha2","resource":"memcacheds"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: Memcached Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: kubedbcom-memcached-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/kubedbcom-memcached-editor/README.md
+++ b/charts/kubedbcom-memcached-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/kubedbcom-memcached-editor --version=v0.4.8
-$ helm upgrade -i kubedbcom-memcached-editor bytebuilders-ui/kubedbcom-memcached-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/kubedbcom-memcached-editor --version=v0.4.9
+$ helm upgrade -i kubedbcom-memcached-editor bytebuilders-ui/kubedbcom-memcached-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a Memcached Editor on a [Kubernetes](http://kubernetes.io) cl
 To install/upgrade the chart with the release name `kubedbcom-memcached-editor`:
 
 ```bash
-$ helm upgrade -i kubedbcom-memcached-editor bytebuilders-ui/kubedbcom-memcached-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i kubedbcom-memcached-editor bytebuilders-ui/kubedbcom-memcached-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a Memcached Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `kubedbcom-memcache
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i kubedbcom-memcached-editor bytebuilders-ui/kubedbcom-memcached-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=kubedb.com/v1alpha2
+$ helm upgrade -i kubedbcom-memcached-editor bytebuilders-ui/kubedbcom-memcached-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=kubedb.com/v1alpha2
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i kubedbcom-memcached-editor bytebuilders-ui/kubedbcom-memcached-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i kubedbcom-memcached-editor bytebuilders-ui/kubedbcom-memcached-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/kubedbcom-mongodb-editor-options/Chart.yaml
+++ b/charts/kubedbcom-mongodb-editor-options/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubedbcom-mongodb-editor-options
 description: MongoDB Editor UI Options
 type: application
-version: v0.4.8
-appVersion: v0.4.8
+version: v0.4.9
+appVersion: v0.4.9
 maintainers:
 - name: appscode
   email: support@appscode.com

--- a/charts/kubedbcom-mongodb-editor-options/README.md
+++ b/charts/kubedbcom-mongodb-editor-options/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/kubedbcom-mongodb-editor-options --version=v0.4.8
-$ helm upgrade -i kubedbcom-mongodb-editor-options bytebuilders-ui/kubedbcom-mongodb-editor-options -n kube-system --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/kubedbcom-mongodb-editor-options --version=v0.4.9
+$ helm upgrade -i kubedbcom-mongodb-editor-options bytebuilders-ui/kubedbcom-mongodb-editor-options -n kube-system --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a MongoDB Editor UI Options on a [Kubernetes](http://kubernet
 To install/upgrade the chart with the release name `kubedbcom-mongodb-editor-options`:
 
 ```bash
-$ helm upgrade -i kubedbcom-mongodb-editor-options bytebuilders-ui/kubedbcom-mongodb-editor-options -n kube-system --create-namespace --version=v0.4.8
+$ helm upgrade -i kubedbcom-mongodb-editor-options bytebuilders-ui/kubedbcom-mongodb-editor-options -n kube-system --create-namespace --version=v0.4.9
 ```
 
 The command deploys a MongoDB Editor UI Options on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -190,12 +190,12 @@ The following table lists the configurable parameters of the `kubedbcom-mongodb-
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i kubedbcom-mongodb-editor-options bytebuilders-ui/kubedbcom-mongodb-editor-options -n kube-system --create-namespace --version=v0.4.8 --set metadata.resource.group=kubedb.com
+$ helm upgrade -i kubedbcom-mongodb-editor-options bytebuilders-ui/kubedbcom-mongodb-editor-options -n kube-system --create-namespace --version=v0.4.9 --set metadata.resource.group=kubedb.com
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i kubedbcom-mongodb-editor-options bytebuilders-ui/kubedbcom-mongodb-editor-options -n kube-system --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i kubedbcom-mongodb-editor-options bytebuilders-ui/kubedbcom-mongodb-editor-options -n kube-system --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/kubedbcom-mongodb-editor/Chart.yaml
+++ b/charts/kubedbcom-mongodb-editor/Chart.yaml
@@ -6,7 +6,7 @@ annotations:
     - group: stash.appscode.com\n  kind: Repository\n- group: stash.appscode.com\n\
     \  kind: RestoreSession\n"
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: MongoDB Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -18,4 +18,4 @@ maintainers:
   name: appscode
 name: kubedbcom-mongodb-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/kubedbcom-mongodb-editor/README.md
+++ b/charts/kubedbcom-mongodb-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/kubedbcom-mongodb-editor --version=v0.4.8
-$ helm upgrade -i kubedbcom-mongodb-editor bytebuilders-ui/kubedbcom-mongodb-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/kubedbcom-mongodb-editor --version=v0.4.9
+$ helm upgrade -i kubedbcom-mongodb-editor bytebuilders-ui/kubedbcom-mongodb-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a MongoDB Editor on a [Kubernetes](http://kubernetes.io) clus
 To install/upgrade the chart with the release name `kubedbcom-mongodb-editor`:
 
 ```bash
-$ helm upgrade -i kubedbcom-mongodb-editor bytebuilders-ui/kubedbcom-mongodb-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i kubedbcom-mongodb-editor bytebuilders-ui/kubedbcom-mongodb-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a MongoDB Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -177,12 +177,12 @@ The following table lists the configurable parameters of the `kubedbcom-mongodb-
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i kubedbcom-mongodb-editor bytebuilders-ui/kubedbcom-mongodb-editor -n default --create-namespace --version=v0.4.8 --set form.alert.groups.database.rules.mongoDBDown.duration=30s
+$ helm upgrade -i kubedbcom-mongodb-editor bytebuilders-ui/kubedbcom-mongodb-editor -n default --create-namespace --version=v0.4.9 --set form.alert.groups.database.rules.mongoDBDown.duration=30s
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i kubedbcom-mongodb-editor bytebuilders-ui/kubedbcom-mongodb-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i kubedbcom-mongodb-editor bytebuilders-ui/kubedbcom-mongodb-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/kubedbcom-mysql-editor-options/Chart.yaml
+++ b/charts/kubedbcom-mysql-editor-options/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubedbcom-mysql-editor-options
 description: MySQL Editor UI Options
 type: application
-version: v0.4.8
-appVersion: v0.4.8
+version: v0.4.9
+appVersion: v0.4.9
 maintainers:
 - name: appscode
   email: support@appscode.com

--- a/charts/kubedbcom-mysql-editor-options/README.md
+++ b/charts/kubedbcom-mysql-editor-options/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/kubedbcom-mysql-editor-options --version=v0.4.8
-$ helm upgrade -i kubedbcom-mysql-editor-options bytebuilders-ui/kubedbcom-mysql-editor-options -n kube-system --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/kubedbcom-mysql-editor-options --version=v0.4.9
+$ helm upgrade -i kubedbcom-mysql-editor-options bytebuilders-ui/kubedbcom-mysql-editor-options -n kube-system --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a MySQL Editor UI Options on a [Kubernetes](http://kubernetes
 To install/upgrade the chart with the release name `kubedbcom-mysql-editor-options`:
 
 ```bash
-$ helm upgrade -i kubedbcom-mysql-editor-options bytebuilders-ui/kubedbcom-mysql-editor-options -n kube-system --create-namespace --version=v0.4.8
+$ helm upgrade -i kubedbcom-mysql-editor-options bytebuilders-ui/kubedbcom-mysql-editor-options -n kube-system --create-namespace --version=v0.4.9
 ```
 
 The command deploys a MySQL Editor UI Options on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -198,12 +198,12 @@ The following table lists the configurable parameters of the `kubedbcom-mysql-ed
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i kubedbcom-mysql-editor-options bytebuilders-ui/kubedbcom-mysql-editor-options -n kube-system --create-namespace --version=v0.4.8 --set metadata.resource.group=kubedb.com
+$ helm upgrade -i kubedbcom-mysql-editor-options bytebuilders-ui/kubedbcom-mysql-editor-options -n kube-system --create-namespace --version=v0.4.9 --set metadata.resource.group=kubedb.com
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i kubedbcom-mysql-editor-options bytebuilders-ui/kubedbcom-mysql-editor-options -n kube-system --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i kubedbcom-mysql-editor-options bytebuilders-ui/kubedbcom-mysql-editor-options -n kube-system --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/kubedbcom-mysql-editor/Chart.yaml
+++ b/charts/kubedbcom-mysql-editor/Chart.yaml
@@ -6,7 +6,7 @@ annotations:
     - group: stash.appscode.com\n  kind: Repository\n- group: stash.appscode.com\n\
     \  kind: RestoreSession\n"
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: MySQL Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -18,4 +18,4 @@ maintainers:
   name: appscode
 name: kubedbcom-mysql-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/kubedbcom-mysql-editor/README.md
+++ b/charts/kubedbcom-mysql-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/kubedbcom-mysql-editor --version=v0.4.8
-$ helm upgrade -i kubedbcom-mysql-editor bytebuilders-ui/kubedbcom-mysql-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/kubedbcom-mysql-editor --version=v0.4.9
+$ helm upgrade -i kubedbcom-mysql-editor bytebuilders-ui/kubedbcom-mysql-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a MySQL Editor on a [Kubernetes](http://kubernetes.io) cluste
 To install/upgrade the chart with the release name `kubedbcom-mysql-editor`:
 
 ```bash
-$ helm upgrade -i kubedbcom-mysql-editor bytebuilders-ui/kubedbcom-mysql-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i kubedbcom-mysql-editor bytebuilders-ui/kubedbcom-mysql-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a MySQL Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -190,12 +190,12 @@ The following table lists the configurable parameters of the `kubedbcom-mysql-ed
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i kubedbcom-mysql-editor bytebuilders-ui/kubedbcom-mysql-editor -n default --create-namespace --version=v0.4.8 --set form.alert.groups.database.rules.mySQLHighIncomingBytes.duration=0m
+$ helm upgrade -i kubedbcom-mysql-editor bytebuilders-ui/kubedbcom-mysql-editor -n default --create-namespace --version=v0.4.9 --set form.alert.groups.database.rules.mySQLHighIncomingBytes.duration=0m
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i kubedbcom-mysql-editor bytebuilders-ui/kubedbcom-mysql-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i kubedbcom-mysql-editor bytebuilders-ui/kubedbcom-mysql-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/kubedbcom-perconaxtradb-editor/Chart.yaml
+++ b/charts/kubedbcom-perconaxtradb-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"kubedb.com","version":"v1alpha2","resource":"perconaxtradbs"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: PerconaXtraDB Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: kubedbcom-perconaxtradb-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/kubedbcom-perconaxtradb-editor/README.md
+++ b/charts/kubedbcom-perconaxtradb-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/kubedbcom-perconaxtradb-editor --version=v0.4.8
-$ helm upgrade -i kubedbcom-perconaxtradb-editor bytebuilders-ui/kubedbcom-perconaxtradb-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/kubedbcom-perconaxtradb-editor --version=v0.4.9
+$ helm upgrade -i kubedbcom-perconaxtradb-editor bytebuilders-ui/kubedbcom-perconaxtradb-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a PerconaXtraDB Editor on a [Kubernetes](http://kubernetes.io
 To install/upgrade the chart with the release name `kubedbcom-perconaxtradb-editor`:
 
 ```bash
-$ helm upgrade -i kubedbcom-perconaxtradb-editor bytebuilders-ui/kubedbcom-perconaxtradb-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i kubedbcom-perconaxtradb-editor bytebuilders-ui/kubedbcom-perconaxtradb-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a PerconaXtraDB Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `kubedbcom-perconax
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i kubedbcom-perconaxtradb-editor bytebuilders-ui/kubedbcom-perconaxtradb-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=kubedb.com/v1alpha2
+$ helm upgrade -i kubedbcom-perconaxtradb-editor bytebuilders-ui/kubedbcom-perconaxtradb-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=kubedb.com/v1alpha2
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i kubedbcom-perconaxtradb-editor bytebuilders-ui/kubedbcom-perconaxtradb-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i kubedbcom-perconaxtradb-editor bytebuilders-ui/kubedbcom-perconaxtradb-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/kubedbcom-pgbouncer-editor/Chart.yaml
+++ b/charts/kubedbcom-pgbouncer-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"kubedb.com","version":"v1alpha2","resource":"pgbouncers"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: PgBouncer Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: kubedbcom-pgbouncer-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/kubedbcom-pgbouncer-editor/README.md
+++ b/charts/kubedbcom-pgbouncer-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/kubedbcom-pgbouncer-editor --version=v0.4.8
-$ helm upgrade -i kubedbcom-pgbouncer-editor bytebuilders-ui/kubedbcom-pgbouncer-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/kubedbcom-pgbouncer-editor --version=v0.4.9
+$ helm upgrade -i kubedbcom-pgbouncer-editor bytebuilders-ui/kubedbcom-pgbouncer-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a PgBouncer Editor on a [Kubernetes](http://kubernetes.io) cl
 To install/upgrade the chart with the release name `kubedbcom-pgbouncer-editor`:
 
 ```bash
-$ helm upgrade -i kubedbcom-pgbouncer-editor bytebuilders-ui/kubedbcom-pgbouncer-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i kubedbcom-pgbouncer-editor bytebuilders-ui/kubedbcom-pgbouncer-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a PgBouncer Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `kubedbcom-pgbounce
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i kubedbcom-pgbouncer-editor bytebuilders-ui/kubedbcom-pgbouncer-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=kubedb.com/v1alpha2
+$ helm upgrade -i kubedbcom-pgbouncer-editor bytebuilders-ui/kubedbcom-pgbouncer-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=kubedb.com/v1alpha2
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i kubedbcom-pgbouncer-editor bytebuilders-ui/kubedbcom-pgbouncer-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i kubedbcom-pgbouncer-editor bytebuilders-ui/kubedbcom-pgbouncer-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/kubedbcom-postgres-editor-options/Chart.yaml
+++ b/charts/kubedbcom-postgres-editor-options/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubedbcom-postgres-editor-options
 description: Postgres Editor UI Options
 type: application
-version: v0.4.8
-appVersion: v0.4.8
+version: v0.4.9
+appVersion: v0.4.9
 maintainers:
 - name: appscode
   email: support@appscode.com

--- a/charts/kubedbcom-postgres-editor-options/README.md
+++ b/charts/kubedbcom-postgres-editor-options/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/kubedbcom-postgres-editor-options --version=v0.4.8
-$ helm upgrade -i kubedbcom-postgres-editor-options bytebuilders-ui/kubedbcom-postgres-editor-options -n kube-system --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/kubedbcom-postgres-editor-options --version=v0.4.9
+$ helm upgrade -i kubedbcom-postgres-editor-options bytebuilders-ui/kubedbcom-postgres-editor-options -n kube-system --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a Postgres Editor UI Options on a [Kubernetes](http://kuberne
 To install/upgrade the chart with the release name `kubedbcom-postgres-editor-options`:
 
 ```bash
-$ helm upgrade -i kubedbcom-postgres-editor-options bytebuilders-ui/kubedbcom-postgres-editor-options -n kube-system --create-namespace --version=v0.4.8
+$ helm upgrade -i kubedbcom-postgres-editor-options bytebuilders-ui/kubedbcom-postgres-editor-options -n kube-system --create-namespace --version=v0.4.9
 ```
 
 The command deploys a Postgres Editor UI Options on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -174,12 +174,12 @@ The following table lists the configurable parameters of the `kubedbcom-postgres
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i kubedbcom-postgres-editor-options bytebuilders-ui/kubedbcom-postgres-editor-options -n kube-system --create-namespace --version=v0.4.8 --set metadata.resource.group=kubedb.com
+$ helm upgrade -i kubedbcom-postgres-editor-options bytebuilders-ui/kubedbcom-postgres-editor-options -n kube-system --create-namespace --version=v0.4.9 --set metadata.resource.group=kubedb.com
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i kubedbcom-postgres-editor-options bytebuilders-ui/kubedbcom-postgres-editor-options -n kube-system --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i kubedbcom-postgres-editor-options bytebuilders-ui/kubedbcom-postgres-editor-options -n kube-system --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/kubedbcom-postgres-editor/Chart.yaml
+++ b/charts/kubedbcom-postgres-editor/Chart.yaml
@@ -6,7 +6,7 @@ annotations:
     - group: stash.appscode.com\n  kind: Repository\n- group: stash.appscode.com\n\
     \  kind: RestoreSession\n"
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: Postgres Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -18,4 +18,4 @@ maintainers:
   name: appscode
 name: kubedbcom-postgres-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/kubedbcom-postgres-editor/README.md
+++ b/charts/kubedbcom-postgres-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/kubedbcom-postgres-editor --version=v0.4.8
-$ helm upgrade -i kubedbcom-postgres-editor bytebuilders-ui/kubedbcom-postgres-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/kubedbcom-postgres-editor --version=v0.4.9
+$ helm upgrade -i kubedbcom-postgres-editor bytebuilders-ui/kubedbcom-postgres-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a Postgres Editor on a [Kubernetes](http://kubernetes.io) clu
 To install/upgrade the chart with the release name `kubedbcom-postgres-editor`:
 
 ```bash
-$ helm upgrade -i kubedbcom-postgres-editor bytebuilders-ui/kubedbcom-postgres-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i kubedbcom-postgres-editor bytebuilders-ui/kubedbcom-postgres-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a Postgres Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -168,12 +168,12 @@ The following table lists the configurable parameters of the `kubedbcom-postgres
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i kubedbcom-postgres-editor bytebuilders-ui/kubedbcom-postgres-editor -n default --create-namespace --version=v0.4.8 --set form.alert.groups.database.rules.postgresInstanceDown.duration=0m
+$ helm upgrade -i kubedbcom-postgres-editor bytebuilders-ui/kubedbcom-postgres-editor -n default --create-namespace --version=v0.4.9 --set form.alert.groups.database.rules.postgresInstanceDown.duration=0m
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i kubedbcom-postgres-editor bytebuilders-ui/kubedbcom-postgres-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i kubedbcom-postgres-editor bytebuilders-ui/kubedbcom-postgres-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/kubedbcom-proxysql-editor/Chart.yaml
+++ b/charts/kubedbcom-proxysql-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"kubedb.com","version":"v1alpha2","resource":"proxysqls"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: ProxySQL Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: kubedbcom-proxysql-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/kubedbcom-proxysql-editor/README.md
+++ b/charts/kubedbcom-proxysql-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/kubedbcom-proxysql-editor --version=v0.4.8
-$ helm upgrade -i kubedbcom-proxysql-editor bytebuilders-ui/kubedbcom-proxysql-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/kubedbcom-proxysql-editor --version=v0.4.9
+$ helm upgrade -i kubedbcom-proxysql-editor bytebuilders-ui/kubedbcom-proxysql-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a ProxySQL Editor on a [Kubernetes](http://kubernetes.io) clu
 To install/upgrade the chart with the release name `kubedbcom-proxysql-editor`:
 
 ```bash
-$ helm upgrade -i kubedbcom-proxysql-editor bytebuilders-ui/kubedbcom-proxysql-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i kubedbcom-proxysql-editor bytebuilders-ui/kubedbcom-proxysql-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a ProxySQL Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `kubedbcom-proxysql
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i kubedbcom-proxysql-editor bytebuilders-ui/kubedbcom-proxysql-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=kubedb.com/v1alpha2
+$ helm upgrade -i kubedbcom-proxysql-editor bytebuilders-ui/kubedbcom-proxysql-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=kubedb.com/v1alpha2
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i kubedbcom-proxysql-editor bytebuilders-ui/kubedbcom-proxysql-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i kubedbcom-proxysql-editor bytebuilders-ui/kubedbcom-proxysql-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/kubedbcom-redis-editor-options/Chart.yaml
+++ b/charts/kubedbcom-redis-editor-options/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubedbcom-redis-editor-options
 description: Redis Editor UI Options
 type: application
-version: v0.4.8
-appVersion: v0.4.8
+version: v0.4.9
+appVersion: v0.4.9
 maintainers:
 - name: appscode
   email: support@appscode.com

--- a/charts/kubedbcom-redis-editor-options/README.md
+++ b/charts/kubedbcom-redis-editor-options/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/kubedbcom-redis-editor-options --version=v0.4.8
-$ helm upgrade -i kubedbcom-redis-editor-options bytebuilders-ui/kubedbcom-redis-editor-options -n kube-system --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/kubedbcom-redis-editor-options --version=v0.4.9
+$ helm upgrade -i kubedbcom-redis-editor-options bytebuilders-ui/kubedbcom-redis-editor-options -n kube-system --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a Redis Editor UI Options on a [Kubernetes](http://kubernetes
 To install/upgrade the chart with the release name `kubedbcom-redis-editor-options`:
 
 ```bash
-$ helm upgrade -i kubedbcom-redis-editor-options bytebuilders-ui/kubedbcom-redis-editor-options -n kube-system --create-namespace --version=v0.4.8
+$ helm upgrade -i kubedbcom-redis-editor-options bytebuilders-ui/kubedbcom-redis-editor-options -n kube-system --create-namespace --version=v0.4.9
 ```
 
 The command deploys a Redis Editor UI Options on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -150,12 +150,12 @@ The following table lists the configurable parameters of the `kubedbcom-redis-ed
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i kubedbcom-redis-editor-options bytebuilders-ui/kubedbcom-redis-editor-options -n kube-system --create-namespace --version=v0.4.8 --set metadata.resource.group=kubedb.com
+$ helm upgrade -i kubedbcom-redis-editor-options bytebuilders-ui/kubedbcom-redis-editor-options -n kube-system --create-namespace --version=v0.4.9 --set metadata.resource.group=kubedb.com
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i kubedbcom-redis-editor-options bytebuilders-ui/kubedbcom-redis-editor-options -n kube-system --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i kubedbcom-redis-editor-options bytebuilders-ui/kubedbcom-redis-editor-options -n kube-system --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/kubedbcom-redis-editor/Chart.yaml
+++ b/charts/kubedbcom-redis-editor/Chart.yaml
@@ -6,7 +6,7 @@ annotations:
     \ stash.appscode.com\n  kind: BackupConfiguration\n- group: stash.appscode.com\n\
     \  kind: Repository\n- group: stash.appscode.com\n  kind: RestoreSession\n"
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: Redis Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -18,4 +18,4 @@ maintainers:
   name: appscode
 name: kubedbcom-redis-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/kubedbcom-redis-editor/README.md
+++ b/charts/kubedbcom-redis-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/kubedbcom-redis-editor --version=v0.4.8
-$ helm upgrade -i kubedbcom-redis-editor bytebuilders-ui/kubedbcom-redis-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/kubedbcom-redis-editor --version=v0.4.9
+$ helm upgrade -i kubedbcom-redis-editor bytebuilders-ui/kubedbcom-redis-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a Redis Editor on a [Kubernetes](http://kubernetes.io) cluste
 To install/upgrade the chart with the release name `kubedbcom-redis-editor`:
 
 ```bash
-$ helm upgrade -i kubedbcom-redis-editor bytebuilders-ui/kubedbcom-redis-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i kubedbcom-redis-editor bytebuilders-ui/kubedbcom-redis-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a Redis Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -140,12 +140,12 @@ The following table lists the configurable parameters of the `kubedbcom-redis-ed
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i kubedbcom-redis-editor bytebuilders-ui/kubedbcom-redis-editor -n default --create-namespace --version=v0.4.8 --set form.alert.groups.database.rules.redisDisconnectedSlaves.duration=2m
+$ helm upgrade -i kubedbcom-redis-editor bytebuilders-ui/kubedbcom-redis-editor -n default --create-namespace --version=v0.4.9 --set form.alert.groups.database.rules.redisDisconnectedSlaves.duration=2m
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i kubedbcom-redis-editor bytebuilders-ui/kubedbcom-redis-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i kubedbcom-redis-editor bytebuilders-ui/kubedbcom-redis-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/kubedbcom-redissentinel-editor/Chart.yaml
+++ b/charts/kubedbcom-redissentinel-editor/Chart.yaml
@@ -4,7 +4,7 @@ annotations:
     \  kind: Issuer\n- group: kubedb.com\n  kind: RedisSentinel\n- group: monitoring.coreos.com\n\
     \  kind: ServiceMonitor\n"
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: RedisSentinel Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -16,4 +16,4 @@ maintainers:
   name: appscode
 name: kubedbcom-redissentinel-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/kubedbcom-redissentinel-editor/README.md
+++ b/charts/kubedbcom-redissentinel-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/kubedbcom-redissentinel-editor --version=v0.4.8
-$ helm upgrade -i kubedbcom-redissentinel-editor bytebuilders-ui/kubedbcom-redissentinel-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/kubedbcom-redissentinel-editor --version=v0.4.9
+$ helm upgrade -i kubedbcom-redissentinel-editor bytebuilders-ui/kubedbcom-redissentinel-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a RedisSentinel Editor on a [Kubernetes](http://kubernetes.io
 To install/upgrade the chart with the release name `kubedbcom-redissentinel-editor`:
 
 ```bash
-$ helm upgrade -i kubedbcom-redissentinel-editor bytebuilders-ui/kubedbcom-redissentinel-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i kubedbcom-redissentinel-editor bytebuilders-ui/kubedbcom-redissentinel-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a RedisSentinel Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -63,12 +63,12 @@ The following table lists the configurable parameters of the `kubedbcom-redissen
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i kubedbcom-redissentinel-editor bytebuilders-ui/kubedbcom-redissentinel-editor -n default --create-namespace --version=v0.4.8 --set metadata.resource.group=kubedb.com
+$ helm upgrade -i kubedbcom-redissentinel-editor bytebuilders-ui/kubedbcom-redissentinel-editor -n default --create-namespace --version=v0.4.9 --set metadata.resource.group=kubedb.com
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i kubedbcom-redissentinel-editor bytebuilders-ui/kubedbcom-redissentinel-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i kubedbcom-redissentinel-editor bytebuilders-ui/kubedbcom-redissentinel-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/kubevaultcom-vaultserver-editor-options/Chart.yaml
+++ b/charts/kubevaultcom-vaultserver-editor-options/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubevaultcom-vaultserver-editor-options
 description: VaultServer Editor UI Options
 type: application
-version: v0.4.8
-appVersion: v0.4.8
+version: v0.4.9
+appVersion: v0.4.9
 maintainers:
 - name: appscode
   email: support@appscode.com

--- a/charts/kubevaultcom-vaultserver-editor-options/README.md
+++ b/charts/kubevaultcom-vaultserver-editor-options/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/kubevaultcom-vaultserver-editor-options --version=v0.4.8
-$ helm upgrade -i kubevaultcom-vaultserver-editor-options bytebuilders-ui/kubevaultcom-vaultserver-editor-options -n kube-system --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/kubevaultcom-vaultserver-editor-options --version=v0.4.9
+$ helm upgrade -i kubevaultcom-vaultserver-editor-options bytebuilders-ui/kubevaultcom-vaultserver-editor-options -n kube-system --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a VaultServer Editor UI Options on a [Kubernetes](http://kube
 To install/upgrade the chart with the release name `kubevaultcom-vaultserver-editor-options`:
 
 ```bash
-$ helm upgrade -i kubevaultcom-vaultserver-editor-options bytebuilders-ui/kubevaultcom-vaultserver-editor-options -n kube-system --create-namespace --version=v0.4.8
+$ helm upgrade -i kubevaultcom-vaultserver-editor-options bytebuilders-ui/kubevaultcom-vaultserver-editor-options -n kube-system --create-namespace --version=v0.4.9
 ```
 
 The command deploys a VaultServer Editor UI Options on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -122,12 +122,12 @@ The following table lists the configurable parameters of the `kubevaultcom-vault
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i kubevaultcom-vaultserver-editor-options bytebuilders-ui/kubevaultcom-vaultserver-editor-options -n kube-system --create-namespace --version=v0.4.8 --set metadata.resource.group=kubevault.com
+$ helm upgrade -i kubevaultcom-vaultserver-editor-options bytebuilders-ui/kubevaultcom-vaultserver-editor-options -n kube-system --create-namespace --version=v0.4.9 --set metadata.resource.group=kubevault.com
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i kubevaultcom-vaultserver-editor-options bytebuilders-ui/kubevaultcom-vaultserver-editor-options -n kube-system --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i kubevaultcom-vaultserver-editor-options bytebuilders-ui/kubevaultcom-vaultserver-editor-options -n kube-system --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/kubevaultcom-vaultserver-editor/Chart.yaml
+++ b/charts/kubevaultcom-vaultserver-editor/Chart.yaml
@@ -3,7 +3,7 @@ annotations:
   meta.x-helm.dev/resources: "- group: \"\"\n  kind: Secret\n- group: kubevault.com\n\
     \  kind: VaultServer\n"
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: VaultServer Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -15,4 +15,4 @@ maintainers:
   name: appscode
 name: kubevaultcom-vaultserver-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/kubevaultcom-vaultserver-editor/README.md
+++ b/charts/kubevaultcom-vaultserver-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/kubevaultcom-vaultserver-editor --version=v0.4.8
-$ helm upgrade -i kubevaultcom-vaultserver-editor bytebuilders-ui/kubevaultcom-vaultserver-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/kubevaultcom-vaultserver-editor --version=v0.4.9
+$ helm upgrade -i kubevaultcom-vaultserver-editor bytebuilders-ui/kubevaultcom-vaultserver-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a VaultServer Editor on a [Kubernetes](http://kubernetes.io) 
 To install/upgrade the chart with the release name `kubevaultcom-vaultserver-editor`:
 
 ```bash
-$ helm upgrade -i kubevaultcom-vaultserver-editor bytebuilders-ui/kubevaultcom-vaultserver-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i kubevaultcom-vaultserver-editor bytebuilders-ui/kubevaultcom-vaultserver-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a VaultServer Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -64,12 +64,12 @@ The following table lists the configurable parameters of the `kubevaultcom-vault
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i kubevaultcom-vaultserver-editor bytebuilders-ui/kubevaultcom-vaultserver-editor -n default --create-namespace --version=v0.4.8 --set metadata.resource.group=kubevault.com
+$ helm upgrade -i kubevaultcom-vaultserver-editor bytebuilders-ui/kubevaultcom-vaultserver-editor -n default --create-namespace --version=v0.4.9 --set metadata.resource.group=kubevault.com
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i kubevaultcom-vaultserver-editor bytebuilders-ui/kubevaultcom-vaultserver-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i kubevaultcom-vaultserver-editor bytebuilders-ui/kubevaultcom-vaultserver-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/metaappscodecom-resourcedescriptor-editor/Chart.yaml
+++ b/charts/metaappscodecom-resourcedescriptor-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"meta.appscode.com","version":"v1alpha1","resource":"resourcedescriptors"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: ResourceDescriptor Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: metaappscodecom-resourcedescriptor-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/metaappscodecom-resourcedescriptor-editor/README.md
+++ b/charts/metaappscodecom-resourcedescriptor-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/metaappscodecom-resourcedescriptor-editor --version=v0.4.8
-$ helm upgrade -i metaappscodecom-resourcedescriptor-editor bytebuilders-ui/metaappscodecom-resourcedescriptor-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/metaappscodecom-resourcedescriptor-editor --version=v0.4.9
+$ helm upgrade -i metaappscodecom-resourcedescriptor-editor bytebuilders-ui/metaappscodecom-resourcedescriptor-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a ResourceDescriptor Editor on a [Kubernetes](http://kubernet
 To install/upgrade the chart with the release name `metaappscodecom-resourcedescriptor-editor`:
 
 ```bash
-$ helm upgrade -i metaappscodecom-resourcedescriptor-editor bytebuilders-ui/metaappscodecom-resourcedescriptor-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i metaappscodecom-resourcedescriptor-editor bytebuilders-ui/metaappscodecom-resourcedescriptor-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a ResourceDescriptor Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `metaappscodecom-re
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i metaappscodecom-resourcedescriptor-editor bytebuilders-ui/metaappscodecom-resourcedescriptor-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=meta.appscode.com/v1alpha1
+$ helm upgrade -i metaappscodecom-resourcedescriptor-editor bytebuilders-ui/metaappscodecom-resourcedescriptor-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=meta.appscode.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i metaappscodecom-resourcedescriptor-editor bytebuilders-ui/metaappscodecom-resourcedescriptor-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i metaappscodecom-resourcedescriptor-editor bytebuilders-ui/metaappscodecom-resourcedescriptor-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/metak8sappscodecom-menu-editor/Chart.yaml
+++ b/charts/metak8sappscodecom-menu-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"meta.k8s.appscode.com","version":"v1alpha1","resource":"menus"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: Menu Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: metak8sappscodecom-menu-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/metak8sappscodecom-menu-editor/README.md
+++ b/charts/metak8sappscodecom-menu-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/metak8sappscodecom-menu-editor --version=v0.4.8
-$ helm upgrade -i metak8sappscodecom-menu-editor bytebuilders-ui/metak8sappscodecom-menu-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/metak8sappscodecom-menu-editor --version=v0.4.9
+$ helm upgrade -i metak8sappscodecom-menu-editor bytebuilders-ui/metak8sappscodecom-menu-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a Menu Editor on a [Kubernetes](http://kubernetes.io) cluster
 To install/upgrade the chart with the release name `metak8sappscodecom-menu-editor`:
 
 ```bash
-$ helm upgrade -i metak8sappscodecom-menu-editor bytebuilders-ui/metak8sappscodecom-menu-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i metak8sappscodecom-menu-editor bytebuilders-ui/metak8sappscodecom-menu-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a Menu Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `metak8sappscodecom
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i metak8sappscodecom-menu-editor bytebuilders-ui/metak8sappscodecom-menu-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=meta.k8s.appscode.com/v1alpha1
+$ helm upgrade -i metak8sappscodecom-menu-editor bytebuilders-ui/metak8sappscodecom-menu-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=meta.k8s.appscode.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i metak8sappscodecom-menu-editor bytebuilders-ui/metak8sappscodecom-menu-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i metak8sappscodecom-menu-editor bytebuilders-ui/metak8sappscodecom-menu-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/metak8sappscodecom-menuoutline-editor/Chart.yaml
+++ b/charts/metak8sappscodecom-menuoutline-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"meta.k8s.appscode.com","version":"v1alpha1","resource":"menuoutlines"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: MenuOutline Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: metak8sappscodecom-menuoutline-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/metak8sappscodecom-menuoutline-editor/README.md
+++ b/charts/metak8sappscodecom-menuoutline-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/metak8sappscodecom-menuoutline-editor --version=v0.4.8
-$ helm upgrade -i metak8sappscodecom-menuoutline-editor bytebuilders-ui/metak8sappscodecom-menuoutline-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/metak8sappscodecom-menuoutline-editor --version=v0.4.9
+$ helm upgrade -i metak8sappscodecom-menuoutline-editor bytebuilders-ui/metak8sappscodecom-menuoutline-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a MenuOutline Editor on a [Kubernetes](http://kubernetes.io) 
 To install/upgrade the chart with the release name `metak8sappscodecom-menuoutline-editor`:
 
 ```bash
-$ helm upgrade -i metak8sappscodecom-menuoutline-editor bytebuilders-ui/metak8sappscodecom-menuoutline-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i metak8sappscodecom-menuoutline-editor bytebuilders-ui/metak8sappscodecom-menuoutline-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a MenuOutline Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `metak8sappscodecom
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i metak8sappscodecom-menuoutline-editor bytebuilders-ui/metak8sappscodecom-menuoutline-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=meta.k8s.appscode.com/v1alpha1
+$ helm upgrade -i metak8sappscodecom-menuoutline-editor bytebuilders-ui/metak8sappscodecom-menuoutline-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=meta.k8s.appscode.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i metak8sappscodecom-menuoutline-editor bytebuilders-ui/metak8sappscodecom-menuoutline-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i metak8sappscodecom-menuoutline-editor bytebuilders-ui/metak8sappscodecom-menuoutline-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/metak8sappscodecom-resourceblockdefinition-editor/Chart.yaml
+++ b/charts/metak8sappscodecom-resourceblockdefinition-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"meta.k8s.appscode.com","version":"v1alpha1","resource":"resourceblockdefinitions"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: ResourceBlockDefinition Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: metak8sappscodecom-resourceblockdefinition-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/metak8sappscodecom-resourceblockdefinition-editor/README.md
+++ b/charts/metak8sappscodecom-resourceblockdefinition-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/metak8sappscodecom-resourceblockdefinition-editor --version=v0.4.8
-$ helm upgrade -i metak8sappscodecom-resourceblockdefinition-editor bytebuilders-ui/metak8sappscodecom-resourceblockdefinition-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/metak8sappscodecom-resourceblockdefinition-editor --version=v0.4.9
+$ helm upgrade -i metak8sappscodecom-resourceblockdefinition-editor bytebuilders-ui/metak8sappscodecom-resourceblockdefinition-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a ResourceBlockDefinition Editor on a [Kubernetes](http://kub
 To install/upgrade the chart with the release name `metak8sappscodecom-resourceblockdefinition-editor`:
 
 ```bash
-$ helm upgrade -i metak8sappscodecom-resourceblockdefinition-editor bytebuilders-ui/metak8sappscodecom-resourceblockdefinition-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i metak8sappscodecom-resourceblockdefinition-editor bytebuilders-ui/metak8sappscodecom-resourceblockdefinition-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a ResourceBlockDefinition Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `metak8sappscodecom
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i metak8sappscodecom-resourceblockdefinition-editor bytebuilders-ui/metak8sappscodecom-resourceblockdefinition-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=meta.k8s.appscode.com/v1alpha1
+$ helm upgrade -i metak8sappscodecom-resourceblockdefinition-editor bytebuilders-ui/metak8sappscodecom-resourceblockdefinition-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=meta.k8s.appscode.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i metak8sappscodecom-resourceblockdefinition-editor bytebuilders-ui/metak8sappscodecom-resourceblockdefinition-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i metak8sappscodecom-resourceblockdefinition-editor bytebuilders-ui/metak8sappscodecom-resourceblockdefinition-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/metak8sappscodecom-resourcedashboard-editor/Chart.yaml
+++ b/charts/metak8sappscodecom-resourcedashboard-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"meta.k8s.appscode.com","version":"v1alpha1","resource":"resourcedashboards"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: ResourceDashboard Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: metak8sappscodecom-resourcedashboard-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/metak8sappscodecom-resourcedashboard-editor/README.md
+++ b/charts/metak8sappscodecom-resourcedashboard-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/metak8sappscodecom-resourcedashboard-editor --version=v0.4.8
-$ helm upgrade -i metak8sappscodecom-resourcedashboard-editor bytebuilders-ui/metak8sappscodecom-resourcedashboard-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/metak8sappscodecom-resourcedashboard-editor --version=v0.4.9
+$ helm upgrade -i metak8sappscodecom-resourcedashboard-editor bytebuilders-ui/metak8sappscodecom-resourcedashboard-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a ResourceDashboard Editor on a [Kubernetes](http://kubernete
 To install/upgrade the chart with the release name `metak8sappscodecom-resourcedashboard-editor`:
 
 ```bash
-$ helm upgrade -i metak8sappscodecom-resourcedashboard-editor bytebuilders-ui/metak8sappscodecom-resourcedashboard-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i metak8sappscodecom-resourcedashboard-editor bytebuilders-ui/metak8sappscodecom-resourcedashboard-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a ResourceDashboard Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `metak8sappscodecom
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i metak8sappscodecom-resourcedashboard-editor bytebuilders-ui/metak8sappscodecom-resourcedashboard-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=meta.k8s.appscode.com/v1alpha1
+$ helm upgrade -i metak8sappscodecom-resourcedashboard-editor bytebuilders-ui/metak8sappscodecom-resourcedashboard-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=meta.k8s.appscode.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i metak8sappscodecom-resourcedashboard-editor bytebuilders-ui/metak8sappscodecom-resourcedashboard-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i metak8sappscodecom-resourcedashboard-editor bytebuilders-ui/metak8sappscodecom-resourcedashboard-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/metak8sappscodecom-resourcedescriptor-editor/Chart.yaml
+++ b/charts/metak8sappscodecom-resourcedescriptor-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"meta.k8s.appscode.com","version":"v1alpha1","resource":"resourcedescriptors"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: ResourceDescriptor Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: metak8sappscodecom-resourcedescriptor-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/metak8sappscodecom-resourcedescriptor-editor/README.md
+++ b/charts/metak8sappscodecom-resourcedescriptor-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/metak8sappscodecom-resourcedescriptor-editor --version=v0.4.8
-$ helm upgrade -i metak8sappscodecom-resourcedescriptor-editor bytebuilders-ui/metak8sappscodecom-resourcedescriptor-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/metak8sappscodecom-resourcedescriptor-editor --version=v0.4.9
+$ helm upgrade -i metak8sappscodecom-resourcedescriptor-editor bytebuilders-ui/metak8sappscodecom-resourcedescriptor-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a ResourceDescriptor Editor on a [Kubernetes](http://kubernet
 To install/upgrade the chart with the release name `metak8sappscodecom-resourcedescriptor-editor`:
 
 ```bash
-$ helm upgrade -i metak8sappscodecom-resourcedescriptor-editor bytebuilders-ui/metak8sappscodecom-resourcedescriptor-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i metak8sappscodecom-resourcedescriptor-editor bytebuilders-ui/metak8sappscodecom-resourcedescriptor-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a ResourceDescriptor Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `metak8sappscodecom
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i metak8sappscodecom-resourcedescriptor-editor bytebuilders-ui/metak8sappscodecom-resourcedescriptor-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=meta.k8s.appscode.com/v1alpha1
+$ helm upgrade -i metak8sappscodecom-resourcedescriptor-editor bytebuilders-ui/metak8sappscodecom-resourcedescriptor-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=meta.k8s.appscode.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i metak8sappscodecom-resourcedescriptor-editor bytebuilders-ui/metak8sappscodecom-resourcedescriptor-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i metak8sappscodecom-resourcedescriptor-editor bytebuilders-ui/metak8sappscodecom-resourcedescriptor-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/metak8sappscodecom-resourceeditor-editor/Chart.yaml
+++ b/charts/metak8sappscodecom-resourceeditor-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"meta.k8s.appscode.com","version":"v1alpha1","resource":"resourceeditors"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: ResourceEditor Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: metak8sappscodecom-resourceeditor-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/metak8sappscodecom-resourceeditor-editor/README.md
+++ b/charts/metak8sappscodecom-resourceeditor-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/metak8sappscodecom-resourceeditor-editor --version=v0.4.8
-$ helm upgrade -i metak8sappscodecom-resourceeditor-editor bytebuilders-ui/metak8sappscodecom-resourceeditor-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/metak8sappscodecom-resourceeditor-editor --version=v0.4.9
+$ helm upgrade -i metak8sappscodecom-resourceeditor-editor bytebuilders-ui/metak8sappscodecom-resourceeditor-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a ResourceEditor Editor on a [Kubernetes](http://kubernetes.i
 To install/upgrade the chart with the release name `metak8sappscodecom-resourceeditor-editor`:
 
 ```bash
-$ helm upgrade -i metak8sappscodecom-resourceeditor-editor bytebuilders-ui/metak8sappscodecom-resourceeditor-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i metak8sappscodecom-resourceeditor-editor bytebuilders-ui/metak8sappscodecom-resourceeditor-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a ResourceEditor Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `metak8sappscodecom
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i metak8sappscodecom-resourceeditor-editor bytebuilders-ui/metak8sappscodecom-resourceeditor-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=meta.k8s.appscode.com/v1alpha1
+$ helm upgrade -i metak8sappscodecom-resourceeditor-editor bytebuilders-ui/metak8sappscodecom-resourceeditor-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=meta.k8s.appscode.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i metak8sappscodecom-resourceeditor-editor bytebuilders-ui/metak8sappscodecom-resourceeditor-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i metak8sappscodecom-resourceeditor-editor bytebuilders-ui/metak8sappscodecom-resourceeditor-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/metak8sappscodecom-resourcelayout-editor/Chart.yaml
+++ b/charts/metak8sappscodecom-resourcelayout-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"meta.k8s.appscode.com","version":"v1alpha1","resource":"resourcelayouts"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: ResourceLayout Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: metak8sappscodecom-resourcelayout-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/metak8sappscodecom-resourcelayout-editor/README.md
+++ b/charts/metak8sappscodecom-resourcelayout-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/metak8sappscodecom-resourcelayout-editor --version=v0.4.8
-$ helm upgrade -i metak8sappscodecom-resourcelayout-editor bytebuilders-ui/metak8sappscodecom-resourcelayout-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/metak8sappscodecom-resourcelayout-editor --version=v0.4.9
+$ helm upgrade -i metak8sappscodecom-resourcelayout-editor bytebuilders-ui/metak8sappscodecom-resourcelayout-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a ResourceLayout Editor on a [Kubernetes](http://kubernetes.i
 To install/upgrade the chart with the release name `metak8sappscodecom-resourcelayout-editor`:
 
 ```bash
-$ helm upgrade -i metak8sappscodecom-resourcelayout-editor bytebuilders-ui/metak8sappscodecom-resourcelayout-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i metak8sappscodecom-resourcelayout-editor bytebuilders-ui/metak8sappscodecom-resourcelayout-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a ResourceLayout Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `metak8sappscodecom
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i metak8sappscodecom-resourcelayout-editor bytebuilders-ui/metak8sappscodecom-resourcelayout-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=meta.k8s.appscode.com/v1alpha1
+$ helm upgrade -i metak8sappscodecom-resourcelayout-editor bytebuilders-ui/metak8sappscodecom-resourcelayout-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=meta.k8s.appscode.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i metak8sappscodecom-resourcelayout-editor bytebuilders-ui/metak8sappscodecom-resourcelayout-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i metak8sappscodecom-resourcelayout-editor bytebuilders-ui/metak8sappscodecom-resourcelayout-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/metak8sappscodecom-resourceoutline-editor/Chart.yaml
+++ b/charts/metak8sappscodecom-resourceoutline-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"meta.k8s.appscode.com","version":"v1alpha1","resource":"resourceoutlines"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: ResourceOutline Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: metak8sappscodecom-resourceoutline-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/metak8sappscodecom-resourceoutline-editor/README.md
+++ b/charts/metak8sappscodecom-resourceoutline-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/metak8sappscodecom-resourceoutline-editor --version=v0.4.8
-$ helm upgrade -i metak8sappscodecom-resourceoutline-editor bytebuilders-ui/metak8sappscodecom-resourceoutline-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/metak8sappscodecom-resourceoutline-editor --version=v0.4.9
+$ helm upgrade -i metak8sappscodecom-resourceoutline-editor bytebuilders-ui/metak8sappscodecom-resourceoutline-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a ResourceOutline Editor on a [Kubernetes](http://kubernetes.
 To install/upgrade the chart with the release name `metak8sappscodecom-resourceoutline-editor`:
 
 ```bash
-$ helm upgrade -i metak8sappscodecom-resourceoutline-editor bytebuilders-ui/metak8sappscodecom-resourceoutline-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i metak8sappscodecom-resourceoutline-editor bytebuilders-ui/metak8sappscodecom-resourceoutline-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a ResourceOutline Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `metak8sappscodecom
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i metak8sappscodecom-resourceoutline-editor bytebuilders-ui/metak8sappscodecom-resourceoutline-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=meta.k8s.appscode.com/v1alpha1
+$ helm upgrade -i metak8sappscodecom-resourceoutline-editor bytebuilders-ui/metak8sappscodecom-resourceoutline-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=meta.k8s.appscode.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i metak8sappscodecom-resourceoutline-editor bytebuilders-ui/metak8sappscodecom-resourceoutline-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i metak8sappscodecom-resourceoutline-editor bytebuilders-ui/metak8sappscodecom-resourceoutline-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/metak8sappscodecom-resourcetabledefinition-editor/Chart.yaml
+++ b/charts/metak8sappscodecom-resourcetabledefinition-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"meta.k8s.appscode.com","version":"v1alpha1","resource":"resourcetabledefinitions"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: ResourceTableDefinition Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: metak8sappscodecom-resourcetabledefinition-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/metak8sappscodecom-resourcetabledefinition-editor/README.md
+++ b/charts/metak8sappscodecom-resourcetabledefinition-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/metak8sappscodecom-resourcetabledefinition-editor --version=v0.4.8
-$ helm upgrade -i metak8sappscodecom-resourcetabledefinition-editor bytebuilders-ui/metak8sappscodecom-resourcetabledefinition-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/metak8sappscodecom-resourcetabledefinition-editor --version=v0.4.9
+$ helm upgrade -i metak8sappscodecom-resourcetabledefinition-editor bytebuilders-ui/metak8sappscodecom-resourcetabledefinition-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a ResourceTableDefinition Editor on a [Kubernetes](http://kub
 To install/upgrade the chart with the release name `metak8sappscodecom-resourcetabledefinition-editor`:
 
 ```bash
-$ helm upgrade -i metak8sappscodecom-resourcetabledefinition-editor bytebuilders-ui/metak8sappscodecom-resourcetabledefinition-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i metak8sappscodecom-resourcetabledefinition-editor bytebuilders-ui/metak8sappscodecom-resourcetabledefinition-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a ResourceTableDefinition Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `metak8sappscodecom
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i metak8sappscodecom-resourcetabledefinition-editor bytebuilders-ui/metak8sappscodecom-resourcetabledefinition-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=meta.k8s.appscode.com/v1alpha1
+$ helm upgrade -i metak8sappscodecom-resourcetabledefinition-editor bytebuilders-ui/metak8sappscodecom-resourcetabledefinition-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=meta.k8s.appscode.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i metak8sappscodecom-resourcetabledefinition-editor bytebuilders-ui/metak8sappscodecom-resourcetabledefinition-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i metak8sappscodecom-resourcetabledefinition-editor bytebuilders-ui/metak8sappscodecom-resourcetabledefinition-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/metricsappscodecom-metricsconfiguration-editor/Chart.yaml
+++ b/charts/metricsappscodecom-metricsconfiguration-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"metrics.appscode.com","version":"v1alpha1","resource":"metricsconfigurations"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: MetricsConfiguration Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: metricsappscodecom-metricsconfiguration-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/metricsappscodecom-metricsconfiguration-editor/README.md
+++ b/charts/metricsappscodecom-metricsconfiguration-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/metricsappscodecom-metricsconfiguration-editor --version=v0.4.8
-$ helm upgrade -i metricsappscodecom-metricsconfiguration-editor bytebuilders-ui/metricsappscodecom-metricsconfiguration-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/metricsappscodecom-metricsconfiguration-editor --version=v0.4.9
+$ helm upgrade -i metricsappscodecom-metricsconfiguration-editor bytebuilders-ui/metricsappscodecom-metricsconfiguration-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a MetricsConfiguration Editor on a [Kubernetes](http://kubern
 To install/upgrade the chart with the release name `metricsappscodecom-metricsconfiguration-editor`:
 
 ```bash
-$ helm upgrade -i metricsappscodecom-metricsconfiguration-editor bytebuilders-ui/metricsappscodecom-metricsconfiguration-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i metricsappscodecom-metricsconfiguration-editor bytebuilders-ui/metricsappscodecom-metricsconfiguration-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a MetricsConfiguration Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `metricsappscodecom
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i metricsappscodecom-metricsconfiguration-editor bytebuilders-ui/metricsappscodecom-metricsconfiguration-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=metrics.appscode.com/v1alpha1
+$ helm upgrade -i metricsappscodecom-metricsconfiguration-editor bytebuilders-ui/metricsappscodecom-metricsconfiguration-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=metrics.appscode.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i metricsappscodecom-metricsconfiguration-editor bytebuilders-ui/metricsappscodecom-metricsconfiguration-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i metricsappscodecom-metricsconfiguration-editor bytebuilders-ui/metricsappscodecom-metricsconfiguration-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/monitoringcoreoscom-alertmanager-editor/Chart.yaml
+++ b/charts/monitoringcoreoscom-alertmanager-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"monitoring.coreos.com","version":"v1","resource":"alertmanagers"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: Alertmanager Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: monitoringcoreoscom-alertmanager-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/monitoringcoreoscom-alertmanager-editor/README.md
+++ b/charts/monitoringcoreoscom-alertmanager-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/monitoringcoreoscom-alertmanager-editor --version=v0.4.8
-$ helm upgrade -i monitoringcoreoscom-alertmanager-editor bytebuilders-ui/monitoringcoreoscom-alertmanager-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/monitoringcoreoscom-alertmanager-editor --version=v0.4.9
+$ helm upgrade -i monitoringcoreoscom-alertmanager-editor bytebuilders-ui/monitoringcoreoscom-alertmanager-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a Alertmanager Editor on a [Kubernetes](http://kubernetes.io)
 To install/upgrade the chart with the release name `monitoringcoreoscom-alertmanager-editor`:
 
 ```bash
-$ helm upgrade -i monitoringcoreoscom-alertmanager-editor bytebuilders-ui/monitoringcoreoscom-alertmanager-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i monitoringcoreoscom-alertmanager-editor bytebuilders-ui/monitoringcoreoscom-alertmanager-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a Alertmanager Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `monitoringcoreosco
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i monitoringcoreoscom-alertmanager-editor bytebuilders-ui/monitoringcoreoscom-alertmanager-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=monitoring.coreos.com/v1
+$ helm upgrade -i monitoringcoreoscom-alertmanager-editor bytebuilders-ui/monitoringcoreoscom-alertmanager-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=monitoring.coreos.com/v1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i monitoringcoreoscom-alertmanager-editor bytebuilders-ui/monitoringcoreoscom-alertmanager-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i monitoringcoreoscom-alertmanager-editor bytebuilders-ui/monitoringcoreoscom-alertmanager-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/monitoringcoreoscom-alertmanagerconfig-editor/Chart.yaml
+++ b/charts/monitoringcoreoscom-alertmanagerconfig-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"monitoring.coreos.com","version":"v1alpha1","resource":"alertmanagerconfigs"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: AlertmanagerConfig Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: monitoringcoreoscom-alertmanagerconfig-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/monitoringcoreoscom-alertmanagerconfig-editor/README.md
+++ b/charts/monitoringcoreoscom-alertmanagerconfig-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/monitoringcoreoscom-alertmanagerconfig-editor --version=v0.4.8
-$ helm upgrade -i monitoringcoreoscom-alertmanagerconfig-editor bytebuilders-ui/monitoringcoreoscom-alertmanagerconfig-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/monitoringcoreoscom-alertmanagerconfig-editor --version=v0.4.9
+$ helm upgrade -i monitoringcoreoscom-alertmanagerconfig-editor bytebuilders-ui/monitoringcoreoscom-alertmanagerconfig-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a AlertmanagerConfig Editor on a [Kubernetes](http://kubernet
 To install/upgrade the chart with the release name `monitoringcoreoscom-alertmanagerconfig-editor`:
 
 ```bash
-$ helm upgrade -i monitoringcoreoscom-alertmanagerconfig-editor bytebuilders-ui/monitoringcoreoscom-alertmanagerconfig-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i monitoringcoreoscom-alertmanagerconfig-editor bytebuilders-ui/monitoringcoreoscom-alertmanagerconfig-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a AlertmanagerConfig Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `monitoringcoreosco
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i monitoringcoreoscom-alertmanagerconfig-editor bytebuilders-ui/monitoringcoreoscom-alertmanagerconfig-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=monitoring.coreos.com/v1alpha1
+$ helm upgrade -i monitoringcoreoscom-alertmanagerconfig-editor bytebuilders-ui/monitoringcoreoscom-alertmanagerconfig-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=monitoring.coreos.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i monitoringcoreoscom-alertmanagerconfig-editor bytebuilders-ui/monitoringcoreoscom-alertmanagerconfig-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i monitoringcoreoscom-alertmanagerconfig-editor bytebuilders-ui/monitoringcoreoscom-alertmanagerconfig-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/monitoringcoreoscom-podmonitor-editor/Chart.yaml
+++ b/charts/monitoringcoreoscom-podmonitor-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"monitoring.coreos.com","version":"v1","resource":"podmonitors"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: PodMonitor Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: monitoringcoreoscom-podmonitor-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/monitoringcoreoscom-podmonitor-editor/README.md
+++ b/charts/monitoringcoreoscom-podmonitor-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/monitoringcoreoscom-podmonitor-editor --version=v0.4.8
-$ helm upgrade -i monitoringcoreoscom-podmonitor-editor bytebuilders-ui/monitoringcoreoscom-podmonitor-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/monitoringcoreoscom-podmonitor-editor --version=v0.4.9
+$ helm upgrade -i monitoringcoreoscom-podmonitor-editor bytebuilders-ui/monitoringcoreoscom-podmonitor-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a PodMonitor Editor on a [Kubernetes](http://kubernetes.io) c
 To install/upgrade the chart with the release name `monitoringcoreoscom-podmonitor-editor`:
 
 ```bash
-$ helm upgrade -i monitoringcoreoscom-podmonitor-editor bytebuilders-ui/monitoringcoreoscom-podmonitor-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i monitoringcoreoscom-podmonitor-editor bytebuilders-ui/monitoringcoreoscom-podmonitor-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a PodMonitor Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `monitoringcoreosco
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i monitoringcoreoscom-podmonitor-editor bytebuilders-ui/monitoringcoreoscom-podmonitor-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=monitoring.coreos.com/v1
+$ helm upgrade -i monitoringcoreoscom-podmonitor-editor bytebuilders-ui/monitoringcoreoscom-podmonitor-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=monitoring.coreos.com/v1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i monitoringcoreoscom-podmonitor-editor bytebuilders-ui/monitoringcoreoscom-podmonitor-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i monitoringcoreoscom-podmonitor-editor bytebuilders-ui/monitoringcoreoscom-podmonitor-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/monitoringcoreoscom-probe-editor/Chart.yaml
+++ b/charts/monitoringcoreoscom-probe-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"monitoring.coreos.com","version":"v1","resource":"probes"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: Probe Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: monitoringcoreoscom-probe-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/monitoringcoreoscom-probe-editor/README.md
+++ b/charts/monitoringcoreoscom-probe-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/monitoringcoreoscom-probe-editor --version=v0.4.8
-$ helm upgrade -i monitoringcoreoscom-probe-editor bytebuilders-ui/monitoringcoreoscom-probe-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/monitoringcoreoscom-probe-editor --version=v0.4.9
+$ helm upgrade -i monitoringcoreoscom-probe-editor bytebuilders-ui/monitoringcoreoscom-probe-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a Probe Editor on a [Kubernetes](http://kubernetes.io) cluste
 To install/upgrade the chart with the release name `monitoringcoreoscom-probe-editor`:
 
 ```bash
-$ helm upgrade -i monitoringcoreoscom-probe-editor bytebuilders-ui/monitoringcoreoscom-probe-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i monitoringcoreoscom-probe-editor bytebuilders-ui/monitoringcoreoscom-probe-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a Probe Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `monitoringcoreosco
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i monitoringcoreoscom-probe-editor bytebuilders-ui/monitoringcoreoscom-probe-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=monitoring.coreos.com/v1
+$ helm upgrade -i monitoringcoreoscom-probe-editor bytebuilders-ui/monitoringcoreoscom-probe-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=monitoring.coreos.com/v1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i monitoringcoreoscom-probe-editor bytebuilders-ui/monitoringcoreoscom-probe-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i monitoringcoreoscom-probe-editor bytebuilders-ui/monitoringcoreoscom-probe-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/monitoringcoreoscom-prometheus-editor/Chart.yaml
+++ b/charts/monitoringcoreoscom-prometheus-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"monitoring.coreos.com","version":"v1","resource":"prometheuses"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: Prometheus Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: monitoringcoreoscom-prometheus-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/monitoringcoreoscom-prometheus-editor/README.md
+++ b/charts/monitoringcoreoscom-prometheus-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/monitoringcoreoscom-prometheus-editor --version=v0.4.8
-$ helm upgrade -i monitoringcoreoscom-prometheus-editor bytebuilders-ui/monitoringcoreoscom-prometheus-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/monitoringcoreoscom-prometheus-editor --version=v0.4.9
+$ helm upgrade -i monitoringcoreoscom-prometheus-editor bytebuilders-ui/monitoringcoreoscom-prometheus-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a Prometheus Editor on a [Kubernetes](http://kubernetes.io) c
 To install/upgrade the chart with the release name `monitoringcoreoscom-prometheus-editor`:
 
 ```bash
-$ helm upgrade -i monitoringcoreoscom-prometheus-editor bytebuilders-ui/monitoringcoreoscom-prometheus-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i monitoringcoreoscom-prometheus-editor bytebuilders-ui/monitoringcoreoscom-prometheus-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a Prometheus Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `monitoringcoreosco
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i monitoringcoreoscom-prometheus-editor bytebuilders-ui/monitoringcoreoscom-prometheus-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=monitoring.coreos.com/v1
+$ helm upgrade -i monitoringcoreoscom-prometheus-editor bytebuilders-ui/monitoringcoreoscom-prometheus-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=monitoring.coreos.com/v1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i monitoringcoreoscom-prometheus-editor bytebuilders-ui/monitoringcoreoscom-prometheus-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i monitoringcoreoscom-prometheus-editor bytebuilders-ui/monitoringcoreoscom-prometheus-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/monitoringcoreoscom-prometheusrule-editor/Chart.yaml
+++ b/charts/monitoringcoreoscom-prometheusrule-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"monitoring.coreos.com","version":"v1","resource":"prometheusrules"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: PrometheusRule Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: monitoringcoreoscom-prometheusrule-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/monitoringcoreoscom-prometheusrule-editor/README.md
+++ b/charts/monitoringcoreoscom-prometheusrule-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/monitoringcoreoscom-prometheusrule-editor --version=v0.4.8
-$ helm upgrade -i monitoringcoreoscom-prometheusrule-editor bytebuilders-ui/monitoringcoreoscom-prometheusrule-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/monitoringcoreoscom-prometheusrule-editor --version=v0.4.9
+$ helm upgrade -i monitoringcoreoscom-prometheusrule-editor bytebuilders-ui/monitoringcoreoscom-prometheusrule-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a PrometheusRule Editor on a [Kubernetes](http://kubernetes.i
 To install/upgrade the chart with the release name `monitoringcoreoscom-prometheusrule-editor`:
 
 ```bash
-$ helm upgrade -i monitoringcoreoscom-prometheusrule-editor bytebuilders-ui/monitoringcoreoscom-prometheusrule-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i monitoringcoreoscom-prometheusrule-editor bytebuilders-ui/monitoringcoreoscom-prometheusrule-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a PrometheusRule Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `monitoringcoreosco
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i monitoringcoreoscom-prometheusrule-editor bytebuilders-ui/monitoringcoreoscom-prometheusrule-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=monitoring.coreos.com/v1
+$ helm upgrade -i monitoringcoreoscom-prometheusrule-editor bytebuilders-ui/monitoringcoreoscom-prometheusrule-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=monitoring.coreos.com/v1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i monitoringcoreoscom-prometheusrule-editor bytebuilders-ui/monitoringcoreoscom-prometheusrule-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i monitoringcoreoscom-prometheusrule-editor bytebuilders-ui/monitoringcoreoscom-prometheusrule-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/monitoringcoreoscom-servicemonitor-editor/Chart.yaml
+++ b/charts/monitoringcoreoscom-servicemonitor-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"monitoring.coreos.com","version":"v1","resource":"servicemonitors"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: ServiceMonitor Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: monitoringcoreoscom-servicemonitor-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/monitoringcoreoscom-servicemonitor-editor/README.md
+++ b/charts/monitoringcoreoscom-servicemonitor-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/monitoringcoreoscom-servicemonitor-editor --version=v0.4.8
-$ helm upgrade -i monitoringcoreoscom-servicemonitor-editor bytebuilders-ui/monitoringcoreoscom-servicemonitor-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/monitoringcoreoscom-servicemonitor-editor --version=v0.4.9
+$ helm upgrade -i monitoringcoreoscom-servicemonitor-editor bytebuilders-ui/monitoringcoreoscom-servicemonitor-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a ServiceMonitor Editor on a [Kubernetes](http://kubernetes.i
 To install/upgrade the chart with the release name `monitoringcoreoscom-servicemonitor-editor`:
 
 ```bash
-$ helm upgrade -i monitoringcoreoscom-servicemonitor-editor bytebuilders-ui/monitoringcoreoscom-servicemonitor-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i monitoringcoreoscom-servicemonitor-editor bytebuilders-ui/monitoringcoreoscom-servicemonitor-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a ServiceMonitor Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `monitoringcoreosco
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i monitoringcoreoscom-servicemonitor-editor bytebuilders-ui/monitoringcoreoscom-servicemonitor-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=monitoring.coreos.com/v1
+$ helm upgrade -i monitoringcoreoscom-servicemonitor-editor bytebuilders-ui/monitoringcoreoscom-servicemonitor-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=monitoring.coreos.com/v1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i monitoringcoreoscom-servicemonitor-editor bytebuilders-ui/monitoringcoreoscom-servicemonitor-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i monitoringcoreoscom-servicemonitor-editor bytebuilders-ui/monitoringcoreoscom-servicemonitor-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/monitoringcoreoscom-thanosruler-editor/Chart.yaml
+++ b/charts/monitoringcoreoscom-thanosruler-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"monitoring.coreos.com","version":"v1","resource":"thanosrulers"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: ThanosRuler Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: monitoringcoreoscom-thanosruler-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/monitoringcoreoscom-thanosruler-editor/README.md
+++ b/charts/monitoringcoreoscom-thanosruler-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/monitoringcoreoscom-thanosruler-editor --version=v0.4.8
-$ helm upgrade -i monitoringcoreoscom-thanosruler-editor bytebuilders-ui/monitoringcoreoscom-thanosruler-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/monitoringcoreoscom-thanosruler-editor --version=v0.4.9
+$ helm upgrade -i monitoringcoreoscom-thanosruler-editor bytebuilders-ui/monitoringcoreoscom-thanosruler-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a ThanosRuler Editor on a [Kubernetes](http://kubernetes.io) 
 To install/upgrade the chart with the release name `monitoringcoreoscom-thanosruler-editor`:
 
 ```bash
-$ helm upgrade -i monitoringcoreoscom-thanosruler-editor bytebuilders-ui/monitoringcoreoscom-thanosruler-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i monitoringcoreoscom-thanosruler-editor bytebuilders-ui/monitoringcoreoscom-thanosruler-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a ThanosRuler Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `monitoringcoreosco
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i monitoringcoreoscom-thanosruler-editor bytebuilders-ui/monitoringcoreoscom-thanosruler-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=monitoring.coreos.com/v1
+$ helm upgrade -i monitoringcoreoscom-thanosruler-editor bytebuilders-ui/monitoringcoreoscom-thanosruler-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=monitoring.coreos.com/v1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i monitoringcoreoscom-thanosruler-editor bytebuilders-ui/monitoringcoreoscom-thanosruler-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i monitoringcoreoscom-thanosruler-editor bytebuilders-ui/monitoringcoreoscom-thanosruler-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/networkingk8sio-ingress-editor/Chart.yaml
+++ b/charts/networkingk8sio-ingress-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"networking.k8s.io","version":"v1","resource":"ingresses"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: Ingress Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: networkingk8sio-ingress-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/networkingk8sio-ingress-editor/README.md
+++ b/charts/networkingk8sio-ingress-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/networkingk8sio-ingress-editor --version=v0.4.8
-$ helm upgrade -i networkingk8sio-ingress-editor bytebuilders-ui/networkingk8sio-ingress-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/networkingk8sio-ingress-editor --version=v0.4.9
+$ helm upgrade -i networkingk8sio-ingress-editor bytebuilders-ui/networkingk8sio-ingress-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a Ingress Editor on a [Kubernetes](http://kubernetes.io) clus
 To install/upgrade the chart with the release name `networkingk8sio-ingress-editor`:
 
 ```bash
-$ helm upgrade -i networkingk8sio-ingress-editor bytebuilders-ui/networkingk8sio-ingress-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i networkingk8sio-ingress-editor bytebuilders-ui/networkingk8sio-ingress-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a Ingress Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `networkingk8sio-in
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i networkingk8sio-ingress-editor bytebuilders-ui/networkingk8sio-ingress-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=networking.k8s.io/v1
+$ helm upgrade -i networkingk8sio-ingress-editor bytebuilders-ui/networkingk8sio-ingress-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=networking.k8s.io/v1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i networkingk8sio-ingress-editor bytebuilders-ui/networkingk8sio-ingress-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i networkingk8sio-ingress-editor bytebuilders-ui/networkingk8sio-ingress-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/networkingk8sio-ingressclass-editor/Chart.yaml
+++ b/charts/networkingk8sio-ingressclass-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"networking.k8s.io","version":"v1","resource":"ingressclasses"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: IngressClass Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: networkingk8sio-ingressclass-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/networkingk8sio-ingressclass-editor/README.md
+++ b/charts/networkingk8sio-ingressclass-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/networkingk8sio-ingressclass-editor --version=v0.4.8
-$ helm upgrade -i networkingk8sio-ingressclass-editor bytebuilders-ui/networkingk8sio-ingressclass-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/networkingk8sio-ingressclass-editor --version=v0.4.9
+$ helm upgrade -i networkingk8sio-ingressclass-editor bytebuilders-ui/networkingk8sio-ingressclass-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a IngressClass Editor on a [Kubernetes](http://kubernetes.io)
 To install/upgrade the chart with the release name `networkingk8sio-ingressclass-editor`:
 
 ```bash
-$ helm upgrade -i networkingk8sio-ingressclass-editor bytebuilders-ui/networkingk8sio-ingressclass-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i networkingk8sio-ingressclass-editor bytebuilders-ui/networkingk8sio-ingressclass-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a IngressClass Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `networkingk8sio-in
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i networkingk8sio-ingressclass-editor bytebuilders-ui/networkingk8sio-ingressclass-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=networking.k8s.io/v1
+$ helm upgrade -i networkingk8sio-ingressclass-editor bytebuilders-ui/networkingk8sio-ingressclass-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=networking.k8s.io/v1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i networkingk8sio-ingressclass-editor bytebuilders-ui/networkingk8sio-ingressclass-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i networkingk8sio-ingressclass-editor bytebuilders-ui/networkingk8sio-ingressclass-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/networkingk8sio-networkpolicy-editor/Chart.yaml
+++ b/charts/networkingk8sio-networkpolicy-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"networking.k8s.io","version":"v1","resource":"networkpolicies"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: NetworkPolicy Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: networkingk8sio-networkpolicy-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/networkingk8sio-networkpolicy-editor/README.md
+++ b/charts/networkingk8sio-networkpolicy-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/networkingk8sio-networkpolicy-editor --version=v0.4.8
-$ helm upgrade -i networkingk8sio-networkpolicy-editor bytebuilders-ui/networkingk8sio-networkpolicy-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/networkingk8sio-networkpolicy-editor --version=v0.4.9
+$ helm upgrade -i networkingk8sio-networkpolicy-editor bytebuilders-ui/networkingk8sio-networkpolicy-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a NetworkPolicy Editor on a [Kubernetes](http://kubernetes.io
 To install/upgrade the chart with the release name `networkingk8sio-networkpolicy-editor`:
 
 ```bash
-$ helm upgrade -i networkingk8sio-networkpolicy-editor bytebuilders-ui/networkingk8sio-networkpolicy-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i networkingk8sio-networkpolicy-editor bytebuilders-ui/networkingk8sio-networkpolicy-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a NetworkPolicy Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `networkingk8sio-ne
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i networkingk8sio-networkpolicy-editor bytebuilders-ui/networkingk8sio-networkpolicy-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=networking.k8s.io/v1
+$ helm upgrade -i networkingk8sio-networkpolicy-editor bytebuilders-ui/networkingk8sio-networkpolicy-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=networking.k8s.io/v1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i networkingk8sio-networkpolicy-editor bytebuilders-ui/networkingk8sio-networkpolicy-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i networkingk8sio-networkpolicy-editor bytebuilders-ui/networkingk8sio-networkpolicy-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/nodek8sio-runtimeclass-editor/Chart.yaml
+++ b/charts/nodek8sio-runtimeclass-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"node.k8s.io","version":"v1","resource":"runtimeclasses"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: RuntimeClass Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: nodek8sio-runtimeclass-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/nodek8sio-runtimeclass-editor/README.md
+++ b/charts/nodek8sio-runtimeclass-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/nodek8sio-runtimeclass-editor --version=v0.4.8
-$ helm upgrade -i nodek8sio-runtimeclass-editor bytebuilders-ui/nodek8sio-runtimeclass-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/nodek8sio-runtimeclass-editor --version=v0.4.9
+$ helm upgrade -i nodek8sio-runtimeclass-editor bytebuilders-ui/nodek8sio-runtimeclass-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a RuntimeClass Editor on a [Kubernetes](http://kubernetes.io)
 To install/upgrade the chart with the release name `nodek8sio-runtimeclass-editor`:
 
 ```bash
-$ helm upgrade -i nodek8sio-runtimeclass-editor bytebuilders-ui/nodek8sio-runtimeclass-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i nodek8sio-runtimeclass-editor bytebuilders-ui/nodek8sio-runtimeclass-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a RuntimeClass Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `nodek8sio-runtimec
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i nodek8sio-runtimeclass-editor bytebuilders-ui/nodek8sio-runtimeclass-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=node.k8s.io/v1
+$ helm upgrade -i nodek8sio-runtimeclass-editor bytebuilders-ui/nodek8sio-runtimeclass-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=node.k8s.io/v1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i nodek8sio-runtimeclass-editor bytebuilders-ui/nodek8sio-runtimeclass-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i nodek8sio-runtimeclass-editor bytebuilders-ui/nodek8sio-runtimeclass-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/openvizdev-grafanadashboard-editor/Chart.yaml
+++ b/charts/openvizdev-grafanadashboard-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"openviz.dev","version":"v1alpha1","resource":"grafanadashboards"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: GrafanaDashboard Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: openvizdev-grafanadashboard-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/openvizdev-grafanadashboard-editor/README.md
+++ b/charts/openvizdev-grafanadashboard-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/openvizdev-grafanadashboard-editor --version=v0.4.8
-$ helm upgrade -i openvizdev-grafanadashboard-editor bytebuilders-ui/openvizdev-grafanadashboard-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/openvizdev-grafanadashboard-editor --version=v0.4.9
+$ helm upgrade -i openvizdev-grafanadashboard-editor bytebuilders-ui/openvizdev-grafanadashboard-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a GrafanaDashboard Editor on a [Kubernetes](http://kubernetes
 To install/upgrade the chart with the release name `openvizdev-grafanadashboard-editor`:
 
 ```bash
-$ helm upgrade -i openvizdev-grafanadashboard-editor bytebuilders-ui/openvizdev-grafanadashboard-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i openvizdev-grafanadashboard-editor bytebuilders-ui/openvizdev-grafanadashboard-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a GrafanaDashboard Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `openvizdev-grafana
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i openvizdev-grafanadashboard-editor bytebuilders-ui/openvizdev-grafanadashboard-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=openviz.dev/v1alpha1
+$ helm upgrade -i openvizdev-grafanadashboard-editor bytebuilders-ui/openvizdev-grafanadashboard-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=openviz.dev/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i openvizdev-grafanadashboard-editor bytebuilders-ui/openvizdev-grafanadashboard-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i openvizdev-grafanadashboard-editor bytebuilders-ui/openvizdev-grafanadashboard-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/openvizdev-grafanadashboardtemplate-editor/Chart.yaml
+++ b/charts/openvizdev-grafanadashboardtemplate-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"openviz.dev","version":"v1alpha1","resource":"grafanadashboardtemplates"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: GrafanaDashboardTemplate Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: openvizdev-grafanadashboardtemplate-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/openvizdev-grafanadashboardtemplate-editor/README.md
+++ b/charts/openvizdev-grafanadashboardtemplate-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/openvizdev-grafanadashboardtemplate-editor --version=v0.4.8
-$ helm upgrade -i openvizdev-grafanadashboardtemplate-editor bytebuilders-ui/openvizdev-grafanadashboardtemplate-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/openvizdev-grafanadashboardtemplate-editor --version=v0.4.9
+$ helm upgrade -i openvizdev-grafanadashboardtemplate-editor bytebuilders-ui/openvizdev-grafanadashboardtemplate-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a GrafanaDashboardTemplate Editor on a [Kubernetes](http://ku
 To install/upgrade the chart with the release name `openvizdev-grafanadashboardtemplate-editor`:
 
 ```bash
-$ helm upgrade -i openvizdev-grafanadashboardtemplate-editor bytebuilders-ui/openvizdev-grafanadashboardtemplate-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i openvizdev-grafanadashboardtemplate-editor bytebuilders-ui/openvizdev-grafanadashboardtemplate-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a GrafanaDashboardTemplate Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `openvizdev-grafana
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i openvizdev-grafanadashboardtemplate-editor bytebuilders-ui/openvizdev-grafanadashboardtemplate-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=openviz.dev/v1alpha1
+$ helm upgrade -i openvizdev-grafanadashboardtemplate-editor bytebuilders-ui/openvizdev-grafanadashboardtemplate-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=openviz.dev/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i openvizdev-grafanadashboardtemplate-editor bytebuilders-ui/openvizdev-grafanadashboardtemplate-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i openvizdev-grafanadashboardtemplate-editor bytebuilders-ui/openvizdev-grafanadashboardtemplate-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/openvizdev-grafanadatasource-editor/Chart.yaml
+++ b/charts/openvizdev-grafanadatasource-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"openviz.dev","version":"v1alpha1","resource":"grafanadatasources"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: GrafanaDatasource Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: openvizdev-grafanadatasource-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/openvizdev-grafanadatasource-editor/README.md
+++ b/charts/openvizdev-grafanadatasource-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/openvizdev-grafanadatasource-editor --version=v0.4.8
-$ helm upgrade -i openvizdev-grafanadatasource-editor bytebuilders-ui/openvizdev-grafanadatasource-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/openvizdev-grafanadatasource-editor --version=v0.4.9
+$ helm upgrade -i openvizdev-grafanadatasource-editor bytebuilders-ui/openvizdev-grafanadatasource-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a GrafanaDatasource Editor on a [Kubernetes](http://kubernete
 To install/upgrade the chart with the release name `openvizdev-grafanadatasource-editor`:
 
 ```bash
-$ helm upgrade -i openvizdev-grafanadatasource-editor bytebuilders-ui/openvizdev-grafanadatasource-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i openvizdev-grafanadatasource-editor bytebuilders-ui/openvizdev-grafanadatasource-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a GrafanaDatasource Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `openvizdev-grafana
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i openvizdev-grafanadatasource-editor bytebuilders-ui/openvizdev-grafanadatasource-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=openviz.dev/v1alpha1
+$ helm upgrade -i openvizdev-grafanadatasource-editor bytebuilders-ui/openvizdev-grafanadatasource-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=openviz.dev/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i openvizdev-grafanadatasource-editor bytebuilders-ui/openvizdev-grafanadatasource-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i openvizdev-grafanadatasource-editor bytebuilders-ui/openvizdev-grafanadatasource-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/opskubedbcom-elasticsearchopsrequest-editor/Chart.yaml
+++ b/charts/opskubedbcom-elasticsearchopsrequest-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"ops.kubedb.com","version":"v1alpha1","resource":"elasticsearchopsrequests"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: ElasticsearchOpsRequest Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: opskubedbcom-elasticsearchopsrequest-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/opskubedbcom-elasticsearchopsrequest-editor/README.md
+++ b/charts/opskubedbcom-elasticsearchopsrequest-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/opskubedbcom-elasticsearchopsrequest-editor --version=v0.4.8
-$ helm upgrade -i opskubedbcom-elasticsearchopsrequest-editor bytebuilders-ui/opskubedbcom-elasticsearchopsrequest-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/opskubedbcom-elasticsearchopsrequest-editor --version=v0.4.9
+$ helm upgrade -i opskubedbcom-elasticsearchopsrequest-editor bytebuilders-ui/opskubedbcom-elasticsearchopsrequest-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a ElasticsearchOpsRequest Editor on a [Kubernetes](http://kub
 To install/upgrade the chart with the release name `opskubedbcom-elasticsearchopsrequest-editor`:
 
 ```bash
-$ helm upgrade -i opskubedbcom-elasticsearchopsrequest-editor bytebuilders-ui/opskubedbcom-elasticsearchopsrequest-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i opskubedbcom-elasticsearchopsrequest-editor bytebuilders-ui/opskubedbcom-elasticsearchopsrequest-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a ElasticsearchOpsRequest Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `opskubedbcom-elast
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i opskubedbcom-elasticsearchopsrequest-editor bytebuilders-ui/opskubedbcom-elasticsearchopsrequest-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=ops.kubedb.com/v1alpha1
+$ helm upgrade -i opskubedbcom-elasticsearchopsrequest-editor bytebuilders-ui/opskubedbcom-elasticsearchopsrequest-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=ops.kubedb.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i opskubedbcom-elasticsearchopsrequest-editor bytebuilders-ui/opskubedbcom-elasticsearchopsrequest-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i opskubedbcom-elasticsearchopsrequest-editor bytebuilders-ui/opskubedbcom-elasticsearchopsrequest-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/opskubedbcom-etcdopsrequest-editor/Chart.yaml
+++ b/charts/opskubedbcom-etcdopsrequest-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"ops.kubedb.com","version":"v1alpha1","resource":"etcdopsrequests"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: EtcdOpsRequest Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: opskubedbcom-etcdopsrequest-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/opskubedbcom-etcdopsrequest-editor/README.md
+++ b/charts/opskubedbcom-etcdopsrequest-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/opskubedbcom-etcdopsrequest-editor --version=v0.4.8
-$ helm upgrade -i opskubedbcom-etcdopsrequest-editor bytebuilders-ui/opskubedbcom-etcdopsrequest-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/opskubedbcom-etcdopsrequest-editor --version=v0.4.9
+$ helm upgrade -i opskubedbcom-etcdopsrequest-editor bytebuilders-ui/opskubedbcom-etcdopsrequest-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a EtcdOpsRequest Editor on a [Kubernetes](http://kubernetes.i
 To install/upgrade the chart with the release name `opskubedbcom-etcdopsrequest-editor`:
 
 ```bash
-$ helm upgrade -i opskubedbcom-etcdopsrequest-editor bytebuilders-ui/opskubedbcom-etcdopsrequest-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i opskubedbcom-etcdopsrequest-editor bytebuilders-ui/opskubedbcom-etcdopsrequest-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a EtcdOpsRequest Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `opskubedbcom-etcdo
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i opskubedbcom-etcdopsrequest-editor bytebuilders-ui/opskubedbcom-etcdopsrequest-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=ops.kubedb.com/v1alpha1
+$ helm upgrade -i opskubedbcom-etcdopsrequest-editor bytebuilders-ui/opskubedbcom-etcdopsrequest-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=ops.kubedb.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i opskubedbcom-etcdopsrequest-editor bytebuilders-ui/opskubedbcom-etcdopsrequest-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i opskubedbcom-etcdopsrequest-editor bytebuilders-ui/opskubedbcom-etcdopsrequest-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/opskubedbcom-mariadbopsrequest-editor/Chart.yaml
+++ b/charts/opskubedbcom-mariadbopsrequest-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"ops.kubedb.com","version":"v1alpha1","resource":"mariadbopsrequests"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: MariaDBOpsRequest Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: opskubedbcom-mariadbopsrequest-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/opskubedbcom-mariadbopsrequest-editor/README.md
+++ b/charts/opskubedbcom-mariadbopsrequest-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/opskubedbcom-mariadbopsrequest-editor --version=v0.4.8
-$ helm upgrade -i opskubedbcom-mariadbopsrequest-editor bytebuilders-ui/opskubedbcom-mariadbopsrequest-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/opskubedbcom-mariadbopsrequest-editor --version=v0.4.9
+$ helm upgrade -i opskubedbcom-mariadbopsrequest-editor bytebuilders-ui/opskubedbcom-mariadbopsrequest-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a MariaDBOpsRequest Editor on a [Kubernetes](http://kubernete
 To install/upgrade the chart with the release name `opskubedbcom-mariadbopsrequest-editor`:
 
 ```bash
-$ helm upgrade -i opskubedbcom-mariadbopsrequest-editor bytebuilders-ui/opskubedbcom-mariadbopsrequest-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i opskubedbcom-mariadbopsrequest-editor bytebuilders-ui/opskubedbcom-mariadbopsrequest-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a MariaDBOpsRequest Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `opskubedbcom-maria
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i opskubedbcom-mariadbopsrequest-editor bytebuilders-ui/opskubedbcom-mariadbopsrequest-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=ops.kubedb.com/v1alpha1
+$ helm upgrade -i opskubedbcom-mariadbopsrequest-editor bytebuilders-ui/opskubedbcom-mariadbopsrequest-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=ops.kubedb.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i opskubedbcom-mariadbopsrequest-editor bytebuilders-ui/opskubedbcom-mariadbopsrequest-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i opskubedbcom-mariadbopsrequest-editor bytebuilders-ui/opskubedbcom-mariadbopsrequest-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/opskubedbcom-memcachedopsrequest-editor/Chart.yaml
+++ b/charts/opskubedbcom-memcachedopsrequest-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"ops.kubedb.com","version":"v1alpha1","resource":"memcachedopsrequests"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: MemcachedOpsRequest Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: opskubedbcom-memcachedopsrequest-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/opskubedbcom-memcachedopsrequest-editor/README.md
+++ b/charts/opskubedbcom-memcachedopsrequest-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/opskubedbcom-memcachedopsrequest-editor --version=v0.4.8
-$ helm upgrade -i opskubedbcom-memcachedopsrequest-editor bytebuilders-ui/opskubedbcom-memcachedopsrequest-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/opskubedbcom-memcachedopsrequest-editor --version=v0.4.9
+$ helm upgrade -i opskubedbcom-memcachedopsrequest-editor bytebuilders-ui/opskubedbcom-memcachedopsrequest-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a MemcachedOpsRequest Editor on a [Kubernetes](http://kuberne
 To install/upgrade the chart with the release name `opskubedbcom-memcachedopsrequest-editor`:
 
 ```bash
-$ helm upgrade -i opskubedbcom-memcachedopsrequest-editor bytebuilders-ui/opskubedbcom-memcachedopsrequest-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i opskubedbcom-memcachedopsrequest-editor bytebuilders-ui/opskubedbcom-memcachedopsrequest-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a MemcachedOpsRequest Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `opskubedbcom-memca
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i opskubedbcom-memcachedopsrequest-editor bytebuilders-ui/opskubedbcom-memcachedopsrequest-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=ops.kubedb.com/v1alpha1
+$ helm upgrade -i opskubedbcom-memcachedopsrequest-editor bytebuilders-ui/opskubedbcom-memcachedopsrequest-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=ops.kubedb.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i opskubedbcom-memcachedopsrequest-editor bytebuilders-ui/opskubedbcom-memcachedopsrequest-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i opskubedbcom-memcachedopsrequest-editor bytebuilders-ui/opskubedbcom-memcachedopsrequest-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/opskubedbcom-mongodbopsrequest-editor/Chart.yaml
+++ b/charts/opskubedbcom-mongodbopsrequest-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"ops.kubedb.com","version":"v1alpha1","resource":"mongodbopsrequests"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: MongoDBOpsRequest Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: opskubedbcom-mongodbopsrequest-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/opskubedbcom-mongodbopsrequest-editor/README.md
+++ b/charts/opskubedbcom-mongodbopsrequest-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/opskubedbcom-mongodbopsrequest-editor --version=v0.4.8
-$ helm upgrade -i opskubedbcom-mongodbopsrequest-editor bytebuilders-ui/opskubedbcom-mongodbopsrequest-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/opskubedbcom-mongodbopsrequest-editor --version=v0.4.9
+$ helm upgrade -i opskubedbcom-mongodbopsrequest-editor bytebuilders-ui/opskubedbcom-mongodbopsrequest-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a MongoDBOpsRequest Editor on a [Kubernetes](http://kubernete
 To install/upgrade the chart with the release name `opskubedbcom-mongodbopsrequest-editor`:
 
 ```bash
-$ helm upgrade -i opskubedbcom-mongodbopsrequest-editor bytebuilders-ui/opskubedbcom-mongodbopsrequest-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i opskubedbcom-mongodbopsrequest-editor bytebuilders-ui/opskubedbcom-mongodbopsrequest-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a MongoDBOpsRequest Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `opskubedbcom-mongo
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i opskubedbcom-mongodbopsrequest-editor bytebuilders-ui/opskubedbcom-mongodbopsrequest-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=ops.kubedb.com/v1alpha1
+$ helm upgrade -i opskubedbcom-mongodbopsrequest-editor bytebuilders-ui/opskubedbcom-mongodbopsrequest-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=ops.kubedb.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i opskubedbcom-mongodbopsrequest-editor bytebuilders-ui/opskubedbcom-mongodbopsrequest-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i opskubedbcom-mongodbopsrequest-editor bytebuilders-ui/opskubedbcom-mongodbopsrequest-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/opskubedbcom-mysqlopsrequest-editor/Chart.yaml
+++ b/charts/opskubedbcom-mysqlopsrequest-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"ops.kubedb.com","version":"v1alpha1","resource":"mysqlopsrequests"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: MySQLOpsRequest Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: opskubedbcom-mysqlopsrequest-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/opskubedbcom-mysqlopsrequest-editor/README.md
+++ b/charts/opskubedbcom-mysqlopsrequest-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/opskubedbcom-mysqlopsrequest-editor --version=v0.4.8
-$ helm upgrade -i opskubedbcom-mysqlopsrequest-editor bytebuilders-ui/opskubedbcom-mysqlopsrequest-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/opskubedbcom-mysqlopsrequest-editor --version=v0.4.9
+$ helm upgrade -i opskubedbcom-mysqlopsrequest-editor bytebuilders-ui/opskubedbcom-mysqlopsrequest-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a MySQLOpsRequest Editor on a [Kubernetes](http://kubernetes.
 To install/upgrade the chart with the release name `opskubedbcom-mysqlopsrequest-editor`:
 
 ```bash
-$ helm upgrade -i opskubedbcom-mysqlopsrequest-editor bytebuilders-ui/opskubedbcom-mysqlopsrequest-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i opskubedbcom-mysqlopsrequest-editor bytebuilders-ui/opskubedbcom-mysqlopsrequest-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a MySQLOpsRequest Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `opskubedbcom-mysql
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i opskubedbcom-mysqlopsrequest-editor bytebuilders-ui/opskubedbcom-mysqlopsrequest-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=ops.kubedb.com/v1alpha1
+$ helm upgrade -i opskubedbcom-mysqlopsrequest-editor bytebuilders-ui/opskubedbcom-mysqlopsrequest-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=ops.kubedb.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i opskubedbcom-mysqlopsrequest-editor bytebuilders-ui/opskubedbcom-mysqlopsrequest-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i opskubedbcom-mysqlopsrequest-editor bytebuilders-ui/opskubedbcom-mysqlopsrequest-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/opskubedbcom-perconaxtradbopsrequest-editor/Chart.yaml
+++ b/charts/opskubedbcom-perconaxtradbopsrequest-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"ops.kubedb.com","version":"v1alpha1","resource":"perconaxtradbopsrequests"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: PerconaXtraDBOpsRequest Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: opskubedbcom-perconaxtradbopsrequest-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/opskubedbcom-perconaxtradbopsrequest-editor/README.md
+++ b/charts/opskubedbcom-perconaxtradbopsrequest-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/opskubedbcom-perconaxtradbopsrequest-editor --version=v0.4.8
-$ helm upgrade -i opskubedbcom-perconaxtradbopsrequest-editor bytebuilders-ui/opskubedbcom-perconaxtradbopsrequest-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/opskubedbcom-perconaxtradbopsrequest-editor --version=v0.4.9
+$ helm upgrade -i opskubedbcom-perconaxtradbopsrequest-editor bytebuilders-ui/opskubedbcom-perconaxtradbopsrequest-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a PerconaXtraDBOpsRequest Editor on a [Kubernetes](http://kub
 To install/upgrade the chart with the release name `opskubedbcom-perconaxtradbopsrequest-editor`:
 
 ```bash
-$ helm upgrade -i opskubedbcom-perconaxtradbopsrequest-editor bytebuilders-ui/opskubedbcom-perconaxtradbopsrequest-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i opskubedbcom-perconaxtradbopsrequest-editor bytebuilders-ui/opskubedbcom-perconaxtradbopsrequest-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a PerconaXtraDBOpsRequest Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `opskubedbcom-perco
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i opskubedbcom-perconaxtradbopsrequest-editor bytebuilders-ui/opskubedbcom-perconaxtradbopsrequest-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=ops.kubedb.com/v1alpha1
+$ helm upgrade -i opskubedbcom-perconaxtradbopsrequest-editor bytebuilders-ui/opskubedbcom-perconaxtradbopsrequest-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=ops.kubedb.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i opskubedbcom-perconaxtradbopsrequest-editor bytebuilders-ui/opskubedbcom-perconaxtradbopsrequest-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i opskubedbcom-perconaxtradbopsrequest-editor bytebuilders-ui/opskubedbcom-perconaxtradbopsrequest-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/opskubedbcom-pgbounceropsrequest-editor/Chart.yaml
+++ b/charts/opskubedbcom-pgbounceropsrequest-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"ops.kubedb.com","version":"v1alpha1","resource":"pgbounceropsrequests"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: PgBouncerOpsRequest Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: opskubedbcom-pgbounceropsrequest-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/opskubedbcom-pgbounceropsrequest-editor/README.md
+++ b/charts/opskubedbcom-pgbounceropsrequest-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/opskubedbcom-pgbounceropsrequest-editor --version=v0.4.8
-$ helm upgrade -i opskubedbcom-pgbounceropsrequest-editor bytebuilders-ui/opskubedbcom-pgbounceropsrequest-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/opskubedbcom-pgbounceropsrequest-editor --version=v0.4.9
+$ helm upgrade -i opskubedbcom-pgbounceropsrequest-editor bytebuilders-ui/opskubedbcom-pgbounceropsrequest-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a PgBouncerOpsRequest Editor on a [Kubernetes](http://kuberne
 To install/upgrade the chart with the release name `opskubedbcom-pgbounceropsrequest-editor`:
 
 ```bash
-$ helm upgrade -i opskubedbcom-pgbounceropsrequest-editor bytebuilders-ui/opskubedbcom-pgbounceropsrequest-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i opskubedbcom-pgbounceropsrequest-editor bytebuilders-ui/opskubedbcom-pgbounceropsrequest-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a PgBouncerOpsRequest Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `opskubedbcom-pgbou
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i opskubedbcom-pgbounceropsrequest-editor bytebuilders-ui/opskubedbcom-pgbounceropsrequest-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=ops.kubedb.com/v1alpha1
+$ helm upgrade -i opskubedbcom-pgbounceropsrequest-editor bytebuilders-ui/opskubedbcom-pgbounceropsrequest-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=ops.kubedb.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i opskubedbcom-pgbounceropsrequest-editor bytebuilders-ui/opskubedbcom-pgbounceropsrequest-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i opskubedbcom-pgbounceropsrequest-editor bytebuilders-ui/opskubedbcom-pgbounceropsrequest-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/opskubedbcom-postgresopsrequest-editor/Chart.yaml
+++ b/charts/opskubedbcom-postgresopsrequest-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"ops.kubedb.com","version":"v1alpha1","resource":"postgresopsrequests"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: PostgresOpsRequest Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: opskubedbcom-postgresopsrequest-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/opskubedbcom-postgresopsrequest-editor/README.md
+++ b/charts/opskubedbcom-postgresopsrequest-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/opskubedbcom-postgresopsrequest-editor --version=v0.4.8
-$ helm upgrade -i opskubedbcom-postgresopsrequest-editor bytebuilders-ui/opskubedbcom-postgresopsrequest-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/opskubedbcom-postgresopsrequest-editor --version=v0.4.9
+$ helm upgrade -i opskubedbcom-postgresopsrequest-editor bytebuilders-ui/opskubedbcom-postgresopsrequest-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a PostgresOpsRequest Editor on a [Kubernetes](http://kubernet
 To install/upgrade the chart with the release name `opskubedbcom-postgresopsrequest-editor`:
 
 ```bash
-$ helm upgrade -i opskubedbcom-postgresopsrequest-editor bytebuilders-ui/opskubedbcom-postgresopsrequest-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i opskubedbcom-postgresopsrequest-editor bytebuilders-ui/opskubedbcom-postgresopsrequest-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a PostgresOpsRequest Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `opskubedbcom-postg
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i opskubedbcom-postgresopsrequest-editor bytebuilders-ui/opskubedbcom-postgresopsrequest-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=ops.kubedb.com/v1alpha1
+$ helm upgrade -i opskubedbcom-postgresopsrequest-editor bytebuilders-ui/opskubedbcom-postgresopsrequest-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=ops.kubedb.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i opskubedbcom-postgresopsrequest-editor bytebuilders-ui/opskubedbcom-postgresopsrequest-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i opskubedbcom-postgresopsrequest-editor bytebuilders-ui/opskubedbcom-postgresopsrequest-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/opskubedbcom-proxysqlopsrequest-editor/Chart.yaml
+++ b/charts/opskubedbcom-proxysqlopsrequest-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"ops.kubedb.com","version":"v1alpha1","resource":"proxysqlopsrequests"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: ProxySQLOpsRequest Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: opskubedbcom-proxysqlopsrequest-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/opskubedbcom-proxysqlopsrequest-editor/README.md
+++ b/charts/opskubedbcom-proxysqlopsrequest-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/opskubedbcom-proxysqlopsrequest-editor --version=v0.4.8
-$ helm upgrade -i opskubedbcom-proxysqlopsrequest-editor bytebuilders-ui/opskubedbcom-proxysqlopsrequest-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/opskubedbcom-proxysqlopsrequest-editor --version=v0.4.9
+$ helm upgrade -i opskubedbcom-proxysqlopsrequest-editor bytebuilders-ui/opskubedbcom-proxysqlopsrequest-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a ProxySQLOpsRequest Editor on a [Kubernetes](http://kubernet
 To install/upgrade the chart with the release name `opskubedbcom-proxysqlopsrequest-editor`:
 
 ```bash
-$ helm upgrade -i opskubedbcom-proxysqlopsrequest-editor bytebuilders-ui/opskubedbcom-proxysqlopsrequest-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i opskubedbcom-proxysqlopsrequest-editor bytebuilders-ui/opskubedbcom-proxysqlopsrequest-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a ProxySQLOpsRequest Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `opskubedbcom-proxy
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i opskubedbcom-proxysqlopsrequest-editor bytebuilders-ui/opskubedbcom-proxysqlopsrequest-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=ops.kubedb.com/v1alpha1
+$ helm upgrade -i opskubedbcom-proxysqlopsrequest-editor bytebuilders-ui/opskubedbcom-proxysqlopsrequest-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=ops.kubedb.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i opskubedbcom-proxysqlopsrequest-editor bytebuilders-ui/opskubedbcom-proxysqlopsrequest-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i opskubedbcom-proxysqlopsrequest-editor bytebuilders-ui/opskubedbcom-proxysqlopsrequest-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/opskubedbcom-redisopsrequest-editor/Chart.yaml
+++ b/charts/opskubedbcom-redisopsrequest-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"ops.kubedb.com","version":"v1alpha1","resource":"redisopsrequests"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: RedisOpsRequest Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: opskubedbcom-redisopsrequest-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/opskubedbcom-redisopsrequest-editor/README.md
+++ b/charts/opskubedbcom-redisopsrequest-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/opskubedbcom-redisopsrequest-editor --version=v0.4.8
-$ helm upgrade -i opskubedbcom-redisopsrequest-editor bytebuilders-ui/opskubedbcom-redisopsrequest-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/opskubedbcom-redisopsrequest-editor --version=v0.4.9
+$ helm upgrade -i opskubedbcom-redisopsrequest-editor bytebuilders-ui/opskubedbcom-redisopsrequest-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a RedisOpsRequest Editor on a [Kubernetes](http://kubernetes.
 To install/upgrade the chart with the release name `opskubedbcom-redisopsrequest-editor`:
 
 ```bash
-$ helm upgrade -i opskubedbcom-redisopsrequest-editor bytebuilders-ui/opskubedbcom-redisopsrequest-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i opskubedbcom-redisopsrequest-editor bytebuilders-ui/opskubedbcom-redisopsrequest-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a RedisOpsRequest Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `opskubedbcom-redis
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i opskubedbcom-redisopsrequest-editor bytebuilders-ui/opskubedbcom-redisopsrequest-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=ops.kubedb.com/v1alpha1
+$ helm upgrade -i opskubedbcom-redisopsrequest-editor bytebuilders-ui/opskubedbcom-redisopsrequest-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=ops.kubedb.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i opskubedbcom-redisopsrequest-editor bytebuilders-ui/opskubedbcom-redisopsrequest-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i opskubedbcom-redisopsrequest-editor bytebuilders-ui/opskubedbcom-redisopsrequest-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/policy-eviction-editor/Chart.yaml
+++ b/charts/policy-eviction-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"policy","version":"v1beta1","resource":"evictions"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: Eviction Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: policy-eviction-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/policy-eviction-editor/README.md
+++ b/charts/policy-eviction-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/policy-eviction-editor --version=v0.4.8
-$ helm upgrade -i policy-eviction-editor bytebuilders-ui/policy-eviction-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/policy-eviction-editor --version=v0.4.9
+$ helm upgrade -i policy-eviction-editor bytebuilders-ui/policy-eviction-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a Eviction Editor on a [Kubernetes](http://kubernetes.io) clu
 To install/upgrade the chart with the release name `policy-eviction-editor`:
 
 ```bash
-$ helm upgrade -i policy-eviction-editor bytebuilders-ui/policy-eviction-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i policy-eviction-editor bytebuilders-ui/policy-eviction-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a Eviction Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `policy-eviction-ed
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i policy-eviction-editor bytebuilders-ui/policy-eviction-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=policy/v1beta1
+$ helm upgrade -i policy-eviction-editor bytebuilders-ui/policy-eviction-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=policy/v1beta1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i policy-eviction-editor bytebuilders-ui/policy-eviction-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i policy-eviction-editor bytebuilders-ui/policy-eviction-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/policy-poddisruptionbudget-editor/Chart.yaml
+++ b/charts/policy-poddisruptionbudget-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"policy","version":"v1beta1","resource":"poddisruptionbudgets"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: PodDisruptionBudget Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: policy-poddisruptionbudget-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/policy-poddisruptionbudget-editor/README.md
+++ b/charts/policy-poddisruptionbudget-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/policy-poddisruptionbudget-editor --version=v0.4.8
-$ helm upgrade -i policy-poddisruptionbudget-editor bytebuilders-ui/policy-poddisruptionbudget-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/policy-poddisruptionbudget-editor --version=v0.4.9
+$ helm upgrade -i policy-poddisruptionbudget-editor bytebuilders-ui/policy-poddisruptionbudget-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a PodDisruptionBudget Editor on a [Kubernetes](http://kuberne
 To install/upgrade the chart with the release name `policy-poddisruptionbudget-editor`:
 
 ```bash
-$ helm upgrade -i policy-poddisruptionbudget-editor bytebuilders-ui/policy-poddisruptionbudget-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i policy-poddisruptionbudget-editor bytebuilders-ui/policy-poddisruptionbudget-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a PodDisruptionBudget Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `policy-poddisrupti
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i policy-poddisruptionbudget-editor bytebuilders-ui/policy-poddisruptionbudget-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=policy/v1beta1
+$ helm upgrade -i policy-poddisruptionbudget-editor bytebuilders-ui/policy-poddisruptionbudget-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=policy/v1beta1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i policy-poddisruptionbudget-editor bytebuilders-ui/policy-poddisruptionbudget-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i policy-poddisruptionbudget-editor bytebuilders-ui/policy-poddisruptionbudget-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/policy-podsecuritypolicy-editor/Chart.yaml
+++ b/charts/policy-podsecuritypolicy-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"policy","version":"v1beta1","resource":"podsecuritypolicies"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: PodSecurityPolicy Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: policy-podsecuritypolicy-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/policy-podsecuritypolicy-editor/README.md
+++ b/charts/policy-podsecuritypolicy-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/policy-podsecuritypolicy-editor --version=v0.4.8
-$ helm upgrade -i policy-podsecuritypolicy-editor bytebuilders-ui/policy-podsecuritypolicy-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/policy-podsecuritypolicy-editor --version=v0.4.9
+$ helm upgrade -i policy-podsecuritypolicy-editor bytebuilders-ui/policy-podsecuritypolicy-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a PodSecurityPolicy Editor on a [Kubernetes](http://kubernete
 To install/upgrade the chart with the release name `policy-podsecuritypolicy-editor`:
 
 ```bash
-$ helm upgrade -i policy-podsecuritypolicy-editor bytebuilders-ui/policy-podsecuritypolicy-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i policy-podsecuritypolicy-editor bytebuilders-ui/policy-podsecuritypolicy-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a PodSecurityPolicy Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `policy-podsecurity
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i policy-podsecuritypolicy-editor bytebuilders-ui/policy-podsecuritypolicy-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=policy/v1beta1
+$ helm upgrade -i policy-podsecuritypolicy-editor bytebuilders-ui/policy-podsecuritypolicy-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=policy/v1beta1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i policy-podsecuritypolicy-editor bytebuilders-ui/policy-podsecuritypolicy-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i policy-podsecuritypolicy-editor bytebuilders-ui/policy-podsecuritypolicy-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/policykubevaultcom-vaultpolicy-editor/Chart.yaml
+++ b/charts/policykubevaultcom-vaultpolicy-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"policy.kubevault.com","version":"v1alpha1","resource":"vaultpolicies"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: VaultPolicy Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: policykubevaultcom-vaultpolicy-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/policykubevaultcom-vaultpolicy-editor/README.md
+++ b/charts/policykubevaultcom-vaultpolicy-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/policykubevaultcom-vaultpolicy-editor --version=v0.4.8
-$ helm upgrade -i policykubevaultcom-vaultpolicy-editor bytebuilders-ui/policykubevaultcom-vaultpolicy-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/policykubevaultcom-vaultpolicy-editor --version=v0.4.9
+$ helm upgrade -i policykubevaultcom-vaultpolicy-editor bytebuilders-ui/policykubevaultcom-vaultpolicy-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a VaultPolicy Editor on a [Kubernetes](http://kubernetes.io) 
 To install/upgrade the chart with the release name `policykubevaultcom-vaultpolicy-editor`:
 
 ```bash
-$ helm upgrade -i policykubevaultcom-vaultpolicy-editor bytebuilders-ui/policykubevaultcom-vaultpolicy-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i policykubevaultcom-vaultpolicy-editor bytebuilders-ui/policykubevaultcom-vaultpolicy-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a VaultPolicy Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `policykubevaultcom
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i policykubevaultcom-vaultpolicy-editor bytebuilders-ui/policykubevaultcom-vaultpolicy-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=policy.kubevault.com/v1alpha1
+$ helm upgrade -i policykubevaultcom-vaultpolicy-editor bytebuilders-ui/policykubevaultcom-vaultpolicy-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=policy.kubevault.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i policykubevaultcom-vaultpolicy-editor bytebuilders-ui/policykubevaultcom-vaultpolicy-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i policykubevaultcom-vaultpolicy-editor bytebuilders-ui/policykubevaultcom-vaultpolicy-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/policykubevaultcom-vaultpolicybinding-editor/Chart.yaml
+++ b/charts/policykubevaultcom-vaultpolicybinding-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"policy.kubevault.com","version":"v1alpha1","resource":"vaultpolicybindings"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: VaultPolicyBinding Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: policykubevaultcom-vaultpolicybinding-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/policykubevaultcom-vaultpolicybinding-editor/README.md
+++ b/charts/policykubevaultcom-vaultpolicybinding-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/policykubevaultcom-vaultpolicybinding-editor --version=v0.4.8
-$ helm upgrade -i policykubevaultcom-vaultpolicybinding-editor bytebuilders-ui/policykubevaultcom-vaultpolicybinding-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/policykubevaultcom-vaultpolicybinding-editor --version=v0.4.9
+$ helm upgrade -i policykubevaultcom-vaultpolicybinding-editor bytebuilders-ui/policykubevaultcom-vaultpolicybinding-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a VaultPolicyBinding Editor on a [Kubernetes](http://kubernet
 To install/upgrade the chart with the release name `policykubevaultcom-vaultpolicybinding-editor`:
 
 ```bash
-$ helm upgrade -i policykubevaultcom-vaultpolicybinding-editor bytebuilders-ui/policykubevaultcom-vaultpolicybinding-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i policykubevaultcom-vaultpolicybinding-editor bytebuilders-ui/policykubevaultcom-vaultpolicybinding-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a VaultPolicyBinding Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `policykubevaultcom
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i policykubevaultcom-vaultpolicybinding-editor bytebuilders-ui/policykubevaultcom-vaultpolicybinding-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=policy.kubevault.com/v1alpha1
+$ helm upgrade -i policykubevaultcom-vaultpolicybinding-editor bytebuilders-ui/policykubevaultcom-vaultpolicybinding-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=policy.kubevault.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i policykubevaultcom-vaultpolicybinding-editor bytebuilders-ui/policykubevaultcom-vaultpolicybinding-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i policykubevaultcom-vaultpolicybinding-editor bytebuilders-ui/policykubevaultcom-vaultpolicybinding-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/rbacauthorizationk8sio-clusterrole-editor/Chart.yaml
+++ b/charts/rbacauthorizationk8sio-clusterrole-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"rbac.authorization.k8s.io","version":"v1","resource":"clusterroles"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: ClusterRole Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: rbacauthorizationk8sio-clusterrole-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/rbacauthorizationk8sio-clusterrole-editor/README.md
+++ b/charts/rbacauthorizationk8sio-clusterrole-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/rbacauthorizationk8sio-clusterrole-editor --version=v0.4.8
-$ helm upgrade -i rbacauthorizationk8sio-clusterrole-editor bytebuilders-ui/rbacauthorizationk8sio-clusterrole-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/rbacauthorizationk8sio-clusterrole-editor --version=v0.4.9
+$ helm upgrade -i rbacauthorizationk8sio-clusterrole-editor bytebuilders-ui/rbacauthorizationk8sio-clusterrole-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a ClusterRole Editor on a [Kubernetes](http://kubernetes.io) 
 To install/upgrade the chart with the release name `rbacauthorizationk8sio-clusterrole-editor`:
 
 ```bash
-$ helm upgrade -i rbacauthorizationk8sio-clusterrole-editor bytebuilders-ui/rbacauthorizationk8sio-clusterrole-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i rbacauthorizationk8sio-clusterrole-editor bytebuilders-ui/rbacauthorizationk8sio-clusterrole-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a ClusterRole Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `rbacauthorizationk
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i rbacauthorizationk8sio-clusterrole-editor bytebuilders-ui/rbacauthorizationk8sio-clusterrole-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=rbac.authorization.k8s.io/v1
+$ helm upgrade -i rbacauthorizationk8sio-clusterrole-editor bytebuilders-ui/rbacauthorizationk8sio-clusterrole-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=rbac.authorization.k8s.io/v1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i rbacauthorizationk8sio-clusterrole-editor bytebuilders-ui/rbacauthorizationk8sio-clusterrole-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i rbacauthorizationk8sio-clusterrole-editor bytebuilders-ui/rbacauthorizationk8sio-clusterrole-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/rbacauthorizationk8sio-clusterrolebinding-editor/Chart.yaml
+++ b/charts/rbacauthorizationk8sio-clusterrolebinding-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"rbac.authorization.k8s.io","version":"v1","resource":"clusterrolebindings"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: ClusterRoleBinding Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: rbacauthorizationk8sio-clusterrolebinding-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/rbacauthorizationk8sio-clusterrolebinding-editor/README.md
+++ b/charts/rbacauthorizationk8sio-clusterrolebinding-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/rbacauthorizationk8sio-clusterrolebinding-editor --version=v0.4.8
-$ helm upgrade -i rbacauthorizationk8sio-clusterrolebinding-editor bytebuilders-ui/rbacauthorizationk8sio-clusterrolebinding-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/rbacauthorizationk8sio-clusterrolebinding-editor --version=v0.4.9
+$ helm upgrade -i rbacauthorizationk8sio-clusterrolebinding-editor bytebuilders-ui/rbacauthorizationk8sio-clusterrolebinding-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a ClusterRoleBinding Editor on a [Kubernetes](http://kubernet
 To install/upgrade the chart with the release name `rbacauthorizationk8sio-clusterrolebinding-editor`:
 
 ```bash
-$ helm upgrade -i rbacauthorizationk8sio-clusterrolebinding-editor bytebuilders-ui/rbacauthorizationk8sio-clusterrolebinding-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i rbacauthorizationk8sio-clusterrolebinding-editor bytebuilders-ui/rbacauthorizationk8sio-clusterrolebinding-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a ClusterRoleBinding Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `rbacauthorizationk
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i rbacauthorizationk8sio-clusterrolebinding-editor bytebuilders-ui/rbacauthorizationk8sio-clusterrolebinding-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=rbac.authorization.k8s.io/v1
+$ helm upgrade -i rbacauthorizationk8sio-clusterrolebinding-editor bytebuilders-ui/rbacauthorizationk8sio-clusterrolebinding-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=rbac.authorization.k8s.io/v1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i rbacauthorizationk8sio-clusterrolebinding-editor bytebuilders-ui/rbacauthorizationk8sio-clusterrolebinding-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i rbacauthorizationk8sio-clusterrolebinding-editor bytebuilders-ui/rbacauthorizationk8sio-clusterrolebinding-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/rbacauthorizationk8sio-role-editor/Chart.yaml
+++ b/charts/rbacauthorizationk8sio-role-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"rbac.authorization.k8s.io","version":"v1","resource":"roles"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: Role Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: rbacauthorizationk8sio-role-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/rbacauthorizationk8sio-role-editor/README.md
+++ b/charts/rbacauthorizationk8sio-role-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/rbacauthorizationk8sio-role-editor --version=v0.4.8
-$ helm upgrade -i rbacauthorizationk8sio-role-editor bytebuilders-ui/rbacauthorizationk8sio-role-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/rbacauthorizationk8sio-role-editor --version=v0.4.9
+$ helm upgrade -i rbacauthorizationk8sio-role-editor bytebuilders-ui/rbacauthorizationk8sio-role-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a Role Editor on a [Kubernetes](http://kubernetes.io) cluster
 To install/upgrade the chart with the release name `rbacauthorizationk8sio-role-editor`:
 
 ```bash
-$ helm upgrade -i rbacauthorizationk8sio-role-editor bytebuilders-ui/rbacauthorizationk8sio-role-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i rbacauthorizationk8sio-role-editor bytebuilders-ui/rbacauthorizationk8sio-role-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a Role Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `rbacauthorizationk
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i rbacauthorizationk8sio-role-editor bytebuilders-ui/rbacauthorizationk8sio-role-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=rbac.authorization.k8s.io/v1
+$ helm upgrade -i rbacauthorizationk8sio-role-editor bytebuilders-ui/rbacauthorizationk8sio-role-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=rbac.authorization.k8s.io/v1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i rbacauthorizationk8sio-role-editor bytebuilders-ui/rbacauthorizationk8sio-role-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i rbacauthorizationk8sio-role-editor bytebuilders-ui/rbacauthorizationk8sio-role-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/rbacauthorizationk8sio-rolebinding-editor/Chart.yaml
+++ b/charts/rbacauthorizationk8sio-rolebinding-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"rbac.authorization.k8s.io","version":"v1","resource":"rolebindings"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: RoleBinding Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: rbacauthorizationk8sio-rolebinding-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/rbacauthorizationk8sio-rolebinding-editor/README.md
+++ b/charts/rbacauthorizationk8sio-rolebinding-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/rbacauthorizationk8sio-rolebinding-editor --version=v0.4.8
-$ helm upgrade -i rbacauthorizationk8sio-rolebinding-editor bytebuilders-ui/rbacauthorizationk8sio-rolebinding-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/rbacauthorizationk8sio-rolebinding-editor --version=v0.4.9
+$ helm upgrade -i rbacauthorizationk8sio-rolebinding-editor bytebuilders-ui/rbacauthorizationk8sio-rolebinding-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a RoleBinding Editor on a [Kubernetes](http://kubernetes.io) 
 To install/upgrade the chart with the release name `rbacauthorizationk8sio-rolebinding-editor`:
 
 ```bash
-$ helm upgrade -i rbacauthorizationk8sio-rolebinding-editor bytebuilders-ui/rbacauthorizationk8sio-rolebinding-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i rbacauthorizationk8sio-rolebinding-editor bytebuilders-ui/rbacauthorizationk8sio-rolebinding-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a RoleBinding Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `rbacauthorizationk
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i rbacauthorizationk8sio-rolebinding-editor bytebuilders-ui/rbacauthorizationk8sio-rolebinding-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=rbac.authorization.k8s.io/v1
+$ helm upgrade -i rbacauthorizationk8sio-rolebinding-editor bytebuilders-ui/rbacauthorizationk8sio-rolebinding-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=rbac.authorization.k8s.io/v1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i rbacauthorizationk8sio-rolebinding-editor bytebuilders-ui/rbacauthorizationk8sio-rolebinding-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i rbacauthorizationk8sio-rolebinding-editor bytebuilders-ui/rbacauthorizationk8sio-rolebinding-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/repositoriesstashappscodecom-snapshot-editor/Chart.yaml
+++ b/charts/repositoriesstashappscodecom-snapshot-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"repositories.stash.appscode.com","version":"v1alpha1","resource":"snapshots"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: Snapshot Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: repositoriesstashappscodecom-snapshot-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/repositoriesstashappscodecom-snapshot-editor/README.md
+++ b/charts/repositoriesstashappscodecom-snapshot-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/repositoriesstashappscodecom-snapshot-editor --version=v0.4.8
-$ helm upgrade -i repositoriesstashappscodecom-snapshot-editor bytebuilders-ui/repositoriesstashappscodecom-snapshot-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/repositoriesstashappscodecom-snapshot-editor --version=v0.4.9
+$ helm upgrade -i repositoriesstashappscodecom-snapshot-editor bytebuilders-ui/repositoriesstashappscodecom-snapshot-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a Snapshot Editor on a [Kubernetes](http://kubernetes.io) clu
 To install/upgrade the chart with the release name `repositoriesstashappscodecom-snapshot-editor`:
 
 ```bash
-$ helm upgrade -i repositoriesstashappscodecom-snapshot-editor bytebuilders-ui/repositoriesstashappscodecom-snapshot-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i repositoriesstashappscodecom-snapshot-editor bytebuilders-ui/repositoriesstashappscodecom-snapshot-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a Snapshot Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `repositoriesstasha
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i repositoriesstashappscodecom-snapshot-editor bytebuilders-ui/repositoriesstashappscodecom-snapshot-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=repositories.stash.appscode.com/v1alpha1
+$ helm upgrade -i repositoriesstashappscodecom-snapshot-editor bytebuilders-ui/repositoriesstashappscodecom-snapshot-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=repositories.stash.appscode.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i repositoriesstashappscodecom-snapshot-editor bytebuilders-ui/repositoriesstashappscodecom-snapshot-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i repositoriesstashappscodecom-snapshot-editor bytebuilders-ui/repositoriesstashappscodecom-snapshot-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/schedulingk8sio-priorityclass-editor/Chart.yaml
+++ b/charts/schedulingk8sio-priorityclass-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"scheduling.k8s.io","version":"v1","resource":"priorityclasses"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: PriorityClass Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: schedulingk8sio-priorityclass-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/schedulingk8sio-priorityclass-editor/README.md
+++ b/charts/schedulingk8sio-priorityclass-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/schedulingk8sio-priorityclass-editor --version=v0.4.8
-$ helm upgrade -i schedulingk8sio-priorityclass-editor bytebuilders-ui/schedulingk8sio-priorityclass-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/schedulingk8sio-priorityclass-editor --version=v0.4.9
+$ helm upgrade -i schedulingk8sio-priorityclass-editor bytebuilders-ui/schedulingk8sio-priorityclass-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a PriorityClass Editor on a [Kubernetes](http://kubernetes.io
 To install/upgrade the chart with the release name `schedulingk8sio-priorityclass-editor`:
 
 ```bash
-$ helm upgrade -i schedulingk8sio-priorityclass-editor bytebuilders-ui/schedulingk8sio-priorityclass-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i schedulingk8sio-priorityclass-editor bytebuilders-ui/schedulingk8sio-priorityclass-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a PriorityClass Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `schedulingk8sio-pr
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i schedulingk8sio-priorityclass-editor bytebuilders-ui/schedulingk8sio-priorityclass-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=scheduling.k8s.io/v1
+$ helm upgrade -i schedulingk8sio-priorityclass-editor bytebuilders-ui/schedulingk8sio-priorityclass-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=scheduling.k8s.io/v1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i schedulingk8sio-priorityclass-editor bytebuilders-ui/schedulingk8sio-priorityclass-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i schedulingk8sio-priorityclass-editor bytebuilders-ui/schedulingk8sio-priorityclass-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/schemakubedbcom-mariadbdatabase-editor/Chart.yaml
+++ b/charts/schemakubedbcom-mariadbdatabase-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"schema.kubedb.com","version":"v1alpha1","resource":"mariadbdatabases"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: MariaDBDatabase Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: schemakubedbcom-mariadbdatabase-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/schemakubedbcom-mariadbdatabase-editor/README.md
+++ b/charts/schemakubedbcom-mariadbdatabase-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/schemakubedbcom-mariadbdatabase-editor --version=v0.4.8
-$ helm upgrade -i schemakubedbcom-mariadbdatabase-editor bytebuilders-ui/schemakubedbcom-mariadbdatabase-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/schemakubedbcom-mariadbdatabase-editor --version=v0.4.9
+$ helm upgrade -i schemakubedbcom-mariadbdatabase-editor bytebuilders-ui/schemakubedbcom-mariadbdatabase-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a MariaDBDatabase Editor on a [Kubernetes](http://kubernetes.
 To install/upgrade the chart with the release name `schemakubedbcom-mariadbdatabase-editor`:
 
 ```bash
-$ helm upgrade -i schemakubedbcom-mariadbdatabase-editor bytebuilders-ui/schemakubedbcom-mariadbdatabase-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i schemakubedbcom-mariadbdatabase-editor bytebuilders-ui/schemakubedbcom-mariadbdatabase-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a MariaDBDatabase Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `schemakubedbcom-ma
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i schemakubedbcom-mariadbdatabase-editor bytebuilders-ui/schemakubedbcom-mariadbdatabase-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=schema.kubedb.com/v1alpha1
+$ helm upgrade -i schemakubedbcom-mariadbdatabase-editor bytebuilders-ui/schemakubedbcom-mariadbdatabase-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=schema.kubedb.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i schemakubedbcom-mariadbdatabase-editor bytebuilders-ui/schemakubedbcom-mariadbdatabase-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i schemakubedbcom-mariadbdatabase-editor bytebuilders-ui/schemakubedbcom-mariadbdatabase-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/schemakubedbcom-mongodbdatabase-editor/Chart.yaml
+++ b/charts/schemakubedbcom-mongodbdatabase-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"schema.kubedb.com","version":"v1alpha1","resource":"mongodbdatabases"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: MongoDBDatabase Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: schemakubedbcom-mongodbdatabase-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/schemakubedbcom-mongodbdatabase-editor/README.md
+++ b/charts/schemakubedbcom-mongodbdatabase-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/schemakubedbcom-mongodbdatabase-editor --version=v0.4.8
-$ helm upgrade -i schemakubedbcom-mongodbdatabase-editor bytebuilders-ui/schemakubedbcom-mongodbdatabase-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/schemakubedbcom-mongodbdatabase-editor --version=v0.4.9
+$ helm upgrade -i schemakubedbcom-mongodbdatabase-editor bytebuilders-ui/schemakubedbcom-mongodbdatabase-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a MongoDBDatabase Editor on a [Kubernetes](http://kubernetes.
 To install/upgrade the chart with the release name `schemakubedbcom-mongodbdatabase-editor`:
 
 ```bash
-$ helm upgrade -i schemakubedbcom-mongodbdatabase-editor bytebuilders-ui/schemakubedbcom-mongodbdatabase-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i schemakubedbcom-mongodbdatabase-editor bytebuilders-ui/schemakubedbcom-mongodbdatabase-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a MongoDBDatabase Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `schemakubedbcom-mo
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i schemakubedbcom-mongodbdatabase-editor bytebuilders-ui/schemakubedbcom-mongodbdatabase-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=schema.kubedb.com/v1alpha1
+$ helm upgrade -i schemakubedbcom-mongodbdatabase-editor bytebuilders-ui/schemakubedbcom-mongodbdatabase-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=schema.kubedb.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i schemakubedbcom-mongodbdatabase-editor bytebuilders-ui/schemakubedbcom-mongodbdatabase-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i schemakubedbcom-mongodbdatabase-editor bytebuilders-ui/schemakubedbcom-mongodbdatabase-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/schemakubedbcom-mysqldatabase-editor/Chart.yaml
+++ b/charts/schemakubedbcom-mysqldatabase-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"schema.kubedb.com","version":"v1alpha1","resource":"mysqldatabases"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: MySQLDatabase Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: schemakubedbcom-mysqldatabase-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/schemakubedbcom-mysqldatabase-editor/README.md
+++ b/charts/schemakubedbcom-mysqldatabase-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/schemakubedbcom-mysqldatabase-editor --version=v0.4.8
-$ helm upgrade -i schemakubedbcom-mysqldatabase-editor bytebuilders-ui/schemakubedbcom-mysqldatabase-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/schemakubedbcom-mysqldatabase-editor --version=v0.4.9
+$ helm upgrade -i schemakubedbcom-mysqldatabase-editor bytebuilders-ui/schemakubedbcom-mysqldatabase-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a MySQLDatabase Editor on a [Kubernetes](http://kubernetes.io
 To install/upgrade the chart with the release name `schemakubedbcom-mysqldatabase-editor`:
 
 ```bash
-$ helm upgrade -i schemakubedbcom-mysqldatabase-editor bytebuilders-ui/schemakubedbcom-mysqldatabase-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i schemakubedbcom-mysqldatabase-editor bytebuilders-ui/schemakubedbcom-mysqldatabase-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a MySQLDatabase Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `schemakubedbcom-my
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i schemakubedbcom-mysqldatabase-editor bytebuilders-ui/schemakubedbcom-mysqldatabase-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=schema.kubedb.com/v1alpha1
+$ helm upgrade -i schemakubedbcom-mysqldatabase-editor bytebuilders-ui/schemakubedbcom-mysqldatabase-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=schema.kubedb.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i schemakubedbcom-mysqldatabase-editor bytebuilders-ui/schemakubedbcom-mysqldatabase-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i schemakubedbcom-mysqldatabase-editor bytebuilders-ui/schemakubedbcom-mysqldatabase-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/schemakubedbcom-postgresdatabase-editor/Chart.yaml
+++ b/charts/schemakubedbcom-postgresdatabase-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"schema.kubedb.com","version":"v1alpha1","resource":"postgresdatabases"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: PostgresDatabase Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: schemakubedbcom-postgresdatabase-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/schemakubedbcom-postgresdatabase-editor/README.md
+++ b/charts/schemakubedbcom-postgresdatabase-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/schemakubedbcom-postgresdatabase-editor --version=v0.4.8
-$ helm upgrade -i schemakubedbcom-postgresdatabase-editor bytebuilders-ui/schemakubedbcom-postgresdatabase-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/schemakubedbcom-postgresdatabase-editor --version=v0.4.9
+$ helm upgrade -i schemakubedbcom-postgresdatabase-editor bytebuilders-ui/schemakubedbcom-postgresdatabase-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a PostgresDatabase Editor on a [Kubernetes](http://kubernetes
 To install/upgrade the chart with the release name `schemakubedbcom-postgresdatabase-editor`:
 
 ```bash
-$ helm upgrade -i schemakubedbcom-postgresdatabase-editor bytebuilders-ui/schemakubedbcom-postgresdatabase-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i schemakubedbcom-postgresdatabase-editor bytebuilders-ui/schemakubedbcom-postgresdatabase-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a PostgresDatabase Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `schemakubedbcom-po
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i schemakubedbcom-postgresdatabase-editor bytebuilders-ui/schemakubedbcom-postgresdatabase-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=schema.kubedb.com/v1alpha1
+$ helm upgrade -i schemakubedbcom-postgresdatabase-editor bytebuilders-ui/schemakubedbcom-postgresdatabase-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=schema.kubedb.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i schemakubedbcom-postgresdatabase-editor bytebuilders-ui/schemakubedbcom-postgresdatabase-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i schemakubedbcom-postgresdatabase-editor bytebuilders-ui/schemakubedbcom-postgresdatabase-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/secretsstorecsixk8sio-secretproviderclass-editor/Chart.yaml
+++ b/charts/secretsstorecsixk8sio-secretproviderclass-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"secrets-store.csi.x-k8s.io","version":"v1alpha1","resource":"secretproviderclasses"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: SecretProviderClass Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: secretsstorecsixk8sio-secretproviderclass-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/secretsstorecsixk8sio-secretproviderclass-editor/README.md
+++ b/charts/secretsstorecsixk8sio-secretproviderclass-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/secretsstorecsixk8sio-secretproviderclass-editor --version=v0.4.8
-$ helm upgrade -i secretsstorecsixk8sio-secretproviderclass-editor bytebuilders-ui/secretsstorecsixk8sio-secretproviderclass-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/secretsstorecsixk8sio-secretproviderclass-editor --version=v0.4.9
+$ helm upgrade -i secretsstorecsixk8sio-secretproviderclass-editor bytebuilders-ui/secretsstorecsixk8sio-secretproviderclass-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a SecretProviderClass Editor on a [Kubernetes](http://kuberne
 To install/upgrade the chart with the release name `secretsstorecsixk8sio-secretproviderclass-editor`:
 
 ```bash
-$ helm upgrade -i secretsstorecsixk8sio-secretproviderclass-editor bytebuilders-ui/secretsstorecsixk8sio-secretproviderclass-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i secretsstorecsixk8sio-secretproviderclass-editor bytebuilders-ui/secretsstorecsixk8sio-secretproviderclass-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a SecretProviderClass Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `secretsstorecsixk8
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i secretsstorecsixk8sio-secretproviderclass-editor bytebuilders-ui/secretsstorecsixk8sio-secretproviderclass-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=secrets-store.csi.x-k8s.io/v1alpha1
+$ helm upgrade -i secretsstorecsixk8sio-secretproviderclass-editor bytebuilders-ui/secretsstorecsixk8sio-secretproviderclass-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=secrets-store.csi.x-k8s.io/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i secretsstorecsixk8sio-secretproviderclass-editor bytebuilders-ui/secretsstorecsixk8sio-secretproviderclass-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i secretsstorecsixk8sio-secretproviderclass-editor bytebuilders-ui/secretsstorecsixk8sio-secretproviderclass-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/secretsstorecsixk8sio-secretproviderclasspodstatus-editor/Chart.yaml
+++ b/charts/secretsstorecsixk8sio-secretproviderclasspodstatus-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"secrets-store.csi.x-k8s.io","version":"v1alpha1","resource":"secretproviderclasspodstatuses"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: SecretProviderClassPodStatus Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: secretsstorecsixk8sio-secretproviderclasspodstatus-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/secretsstorecsixk8sio-secretproviderclasspodstatus-editor/README.md
+++ b/charts/secretsstorecsixk8sio-secretproviderclasspodstatus-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/secretsstorecsixk8sio-secretproviderclasspodstatus-editor --version=v0.4.8
-$ helm upgrade -i secretsstorecsixk8sio-secretproviderclasspodstatus-editor bytebuilders-ui/secretsstorecsixk8sio-secretproviderclasspodstatus-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/secretsstorecsixk8sio-secretproviderclasspodstatus-editor --version=v0.4.9
+$ helm upgrade -i secretsstorecsixk8sio-secretproviderclasspodstatus-editor bytebuilders-ui/secretsstorecsixk8sio-secretproviderclasspodstatus-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a SecretProviderClassPodStatus Editor on a [Kubernetes](http:
 To install/upgrade the chart with the release name `secretsstorecsixk8sio-secretproviderclasspodstatus-editor`:
 
 ```bash
-$ helm upgrade -i secretsstorecsixk8sio-secretproviderclasspodstatus-editor bytebuilders-ui/secretsstorecsixk8sio-secretproviderclasspodstatus-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i secretsstorecsixk8sio-secretproviderclasspodstatus-editor bytebuilders-ui/secretsstorecsixk8sio-secretproviderclasspodstatus-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a SecretProviderClassPodStatus Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `secretsstorecsixk8
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i secretsstorecsixk8sio-secretproviderclasspodstatus-editor bytebuilders-ui/secretsstorecsixk8sio-secretproviderclasspodstatus-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=secrets-store.csi.x-k8s.io/v1alpha1
+$ helm upgrade -i secretsstorecsixk8sio-secretproviderclasspodstatus-editor bytebuilders-ui/secretsstorecsixk8sio-secretproviderclasspodstatus-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=secrets-store.csi.x-k8s.io/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i secretsstorecsixk8sio-secretproviderclasspodstatus-editor bytebuilders-ui/secretsstorecsixk8sio-secretproviderclasspodstatus-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i secretsstorecsixk8sio-secretproviderclasspodstatus-editor bytebuilders-ui/secretsstorecsixk8sio-secretproviderclasspodstatus-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/settingsk8sio-podpreset-editor/Chart.yaml
+++ b/charts/settingsk8sio-podpreset-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"settings.k8s.io","version":"v1alpha1","resource":"podpresets"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: PodPreset Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: settingsk8sio-podpreset-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/settingsk8sio-podpreset-editor/README.md
+++ b/charts/settingsk8sio-podpreset-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/settingsk8sio-podpreset-editor --version=v0.4.8
-$ helm upgrade -i settingsk8sio-podpreset-editor bytebuilders-ui/settingsk8sio-podpreset-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/settingsk8sio-podpreset-editor --version=v0.4.9
+$ helm upgrade -i settingsk8sio-podpreset-editor bytebuilders-ui/settingsk8sio-podpreset-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a PodPreset Editor on a [Kubernetes](http://kubernetes.io) cl
 To install/upgrade the chart with the release name `settingsk8sio-podpreset-editor`:
 
 ```bash
-$ helm upgrade -i settingsk8sio-podpreset-editor bytebuilders-ui/settingsk8sio-podpreset-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i settingsk8sio-podpreset-editor bytebuilders-ui/settingsk8sio-podpreset-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a PodPreset Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `settingsk8sio-podp
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i settingsk8sio-podpreset-editor bytebuilders-ui/settingsk8sio-podpreset-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=settings.k8s.io/v1alpha1
+$ helm upgrade -i settingsk8sio-podpreset-editor bytebuilders-ui/settingsk8sio-podpreset-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=settings.k8s.io/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i settingsk8sio-podpreset-editor bytebuilders-ui/settingsk8sio-podpreset-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i settingsk8sio-podpreset-editor bytebuilders-ui/settingsk8sio-podpreset-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/snapshotstoragek8sio-volumesnapshot-editor/Chart.yaml
+++ b/charts/snapshotstoragek8sio-volumesnapshot-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"snapshot.storage.k8s.io","version":"v1","resource":"volumesnapshots"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: VolumeSnapshot Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: snapshotstoragek8sio-volumesnapshot-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/snapshotstoragek8sio-volumesnapshot-editor/README.md
+++ b/charts/snapshotstoragek8sio-volumesnapshot-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/snapshotstoragek8sio-volumesnapshot-editor --version=v0.4.8
-$ helm upgrade -i snapshotstoragek8sio-volumesnapshot-editor bytebuilders-ui/snapshotstoragek8sio-volumesnapshot-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/snapshotstoragek8sio-volumesnapshot-editor --version=v0.4.9
+$ helm upgrade -i snapshotstoragek8sio-volumesnapshot-editor bytebuilders-ui/snapshotstoragek8sio-volumesnapshot-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a VolumeSnapshot Editor on a [Kubernetes](http://kubernetes.i
 To install/upgrade the chart with the release name `snapshotstoragek8sio-volumesnapshot-editor`:
 
 ```bash
-$ helm upgrade -i snapshotstoragek8sio-volumesnapshot-editor bytebuilders-ui/snapshotstoragek8sio-volumesnapshot-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i snapshotstoragek8sio-volumesnapshot-editor bytebuilders-ui/snapshotstoragek8sio-volumesnapshot-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a VolumeSnapshot Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `snapshotstoragek8s
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i snapshotstoragek8sio-volumesnapshot-editor bytebuilders-ui/snapshotstoragek8sio-volumesnapshot-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=snapshot.storage.k8s.io/v1
+$ helm upgrade -i snapshotstoragek8sio-volumesnapshot-editor bytebuilders-ui/snapshotstoragek8sio-volumesnapshot-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=snapshot.storage.k8s.io/v1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i snapshotstoragek8sio-volumesnapshot-editor bytebuilders-ui/snapshotstoragek8sio-volumesnapshot-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i snapshotstoragek8sio-volumesnapshot-editor bytebuilders-ui/snapshotstoragek8sio-volumesnapshot-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/snapshotstoragek8sio-volumesnapshotclass-editor/Chart.yaml
+++ b/charts/snapshotstoragek8sio-volumesnapshotclass-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"snapshot.storage.k8s.io","version":"v1","resource":"volumesnapshotclasses"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: VolumeSnapshotClass Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: snapshotstoragek8sio-volumesnapshotclass-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/snapshotstoragek8sio-volumesnapshotclass-editor/README.md
+++ b/charts/snapshotstoragek8sio-volumesnapshotclass-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/snapshotstoragek8sio-volumesnapshotclass-editor --version=v0.4.8
-$ helm upgrade -i snapshotstoragek8sio-volumesnapshotclass-editor bytebuilders-ui/snapshotstoragek8sio-volumesnapshotclass-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/snapshotstoragek8sio-volumesnapshotclass-editor --version=v0.4.9
+$ helm upgrade -i snapshotstoragek8sio-volumesnapshotclass-editor bytebuilders-ui/snapshotstoragek8sio-volumesnapshotclass-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a VolumeSnapshotClass Editor on a [Kubernetes](http://kuberne
 To install/upgrade the chart with the release name `snapshotstoragek8sio-volumesnapshotclass-editor`:
 
 ```bash
-$ helm upgrade -i snapshotstoragek8sio-volumesnapshotclass-editor bytebuilders-ui/snapshotstoragek8sio-volumesnapshotclass-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i snapshotstoragek8sio-volumesnapshotclass-editor bytebuilders-ui/snapshotstoragek8sio-volumesnapshotclass-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a VolumeSnapshotClass Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `snapshotstoragek8s
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i snapshotstoragek8sio-volumesnapshotclass-editor bytebuilders-ui/snapshotstoragek8sio-volumesnapshotclass-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=snapshot.storage.k8s.io/v1
+$ helm upgrade -i snapshotstoragek8sio-volumesnapshotclass-editor bytebuilders-ui/snapshotstoragek8sio-volumesnapshotclass-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=snapshot.storage.k8s.io/v1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i snapshotstoragek8sio-volumesnapshotclass-editor bytebuilders-ui/snapshotstoragek8sio-volumesnapshotclass-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i snapshotstoragek8sio-volumesnapshotclass-editor bytebuilders-ui/snapshotstoragek8sio-volumesnapshotclass-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/snapshotstoragek8sio-volumesnapshotcontent-editor/Chart.yaml
+++ b/charts/snapshotstoragek8sio-volumesnapshotcontent-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"snapshot.storage.k8s.io","version":"v1","resource":"volumesnapshotcontents"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: VolumeSnapshotContent Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: snapshotstoragek8sio-volumesnapshotcontent-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/snapshotstoragek8sio-volumesnapshotcontent-editor/README.md
+++ b/charts/snapshotstoragek8sio-volumesnapshotcontent-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/snapshotstoragek8sio-volumesnapshotcontent-editor --version=v0.4.8
-$ helm upgrade -i snapshotstoragek8sio-volumesnapshotcontent-editor bytebuilders-ui/snapshotstoragek8sio-volumesnapshotcontent-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/snapshotstoragek8sio-volumesnapshotcontent-editor --version=v0.4.9
+$ helm upgrade -i snapshotstoragek8sio-volumesnapshotcontent-editor bytebuilders-ui/snapshotstoragek8sio-volumesnapshotcontent-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a VolumeSnapshotContent Editor on a [Kubernetes](http://kuber
 To install/upgrade the chart with the release name `snapshotstoragek8sio-volumesnapshotcontent-editor`:
 
 ```bash
-$ helm upgrade -i snapshotstoragek8sio-volumesnapshotcontent-editor bytebuilders-ui/snapshotstoragek8sio-volumesnapshotcontent-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i snapshotstoragek8sio-volumesnapshotcontent-editor bytebuilders-ui/snapshotstoragek8sio-volumesnapshotcontent-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a VolumeSnapshotContent Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `snapshotstoragek8s
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i snapshotstoragek8sio-volumesnapshotcontent-editor bytebuilders-ui/snapshotstoragek8sio-volumesnapshotcontent-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=snapshot.storage.k8s.io/v1
+$ helm upgrade -i snapshotstoragek8sio-volumesnapshotcontent-editor bytebuilders-ui/snapshotstoragek8sio-volumesnapshotcontent-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=snapshot.storage.k8s.io/v1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i snapshotstoragek8sio-volumesnapshotcontent-editor bytebuilders-ui/snapshotstoragek8sio-volumesnapshotcontent-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i snapshotstoragek8sio-volumesnapshotcontent-editor bytebuilders-ui/snapshotstoragek8sio-volumesnapshotcontent-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/stashappscodecom-backupbatch-editor/Chart.yaml
+++ b/charts/stashappscodecom-backupbatch-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"stash.appscode.com","version":"v1beta1","resource":"backupbatches"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: BackupBatch Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: stashappscodecom-backupbatch-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/stashappscodecom-backupbatch-editor/README.md
+++ b/charts/stashappscodecom-backupbatch-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/stashappscodecom-backupbatch-editor --version=v0.4.8
-$ helm upgrade -i stashappscodecom-backupbatch-editor bytebuilders-ui/stashappscodecom-backupbatch-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/stashappscodecom-backupbatch-editor --version=v0.4.9
+$ helm upgrade -i stashappscodecom-backupbatch-editor bytebuilders-ui/stashappscodecom-backupbatch-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a BackupBatch Editor on a [Kubernetes](http://kubernetes.io) 
 To install/upgrade the chart with the release name `stashappscodecom-backupbatch-editor`:
 
 ```bash
-$ helm upgrade -i stashappscodecom-backupbatch-editor bytebuilders-ui/stashappscodecom-backupbatch-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i stashappscodecom-backupbatch-editor bytebuilders-ui/stashappscodecom-backupbatch-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a BackupBatch Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `stashappscodecom-b
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i stashappscodecom-backupbatch-editor bytebuilders-ui/stashappscodecom-backupbatch-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=stash.appscode.com/v1beta1
+$ helm upgrade -i stashappscodecom-backupbatch-editor bytebuilders-ui/stashappscodecom-backupbatch-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=stash.appscode.com/v1beta1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i stashappscodecom-backupbatch-editor bytebuilders-ui/stashappscodecom-backupbatch-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i stashappscodecom-backupbatch-editor bytebuilders-ui/stashappscodecom-backupbatch-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/stashappscodecom-backupblueprint-editor/Chart.yaml
+++ b/charts/stashappscodecom-backupblueprint-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"stash.appscode.com","version":"v1beta1","resource":"backupblueprints"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: BackupBlueprint Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: stashappscodecom-backupblueprint-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/stashappscodecom-backupblueprint-editor/README.md
+++ b/charts/stashappscodecom-backupblueprint-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/stashappscodecom-backupblueprint-editor --version=v0.4.8
-$ helm upgrade -i stashappscodecom-backupblueprint-editor bytebuilders-ui/stashappscodecom-backupblueprint-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/stashappscodecom-backupblueprint-editor --version=v0.4.9
+$ helm upgrade -i stashappscodecom-backupblueprint-editor bytebuilders-ui/stashappscodecom-backupblueprint-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a BackupBlueprint Editor on a [Kubernetes](http://kubernetes.
 To install/upgrade the chart with the release name `stashappscodecom-backupblueprint-editor`:
 
 ```bash
-$ helm upgrade -i stashappscodecom-backupblueprint-editor bytebuilders-ui/stashappscodecom-backupblueprint-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i stashappscodecom-backupblueprint-editor bytebuilders-ui/stashappscodecom-backupblueprint-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a BackupBlueprint Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `stashappscodecom-b
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i stashappscodecom-backupblueprint-editor bytebuilders-ui/stashappscodecom-backupblueprint-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=stash.appscode.com/v1beta1
+$ helm upgrade -i stashappscodecom-backupblueprint-editor bytebuilders-ui/stashappscodecom-backupblueprint-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=stash.appscode.com/v1beta1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i stashappscodecom-backupblueprint-editor bytebuilders-ui/stashappscodecom-backupblueprint-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i stashappscodecom-backupblueprint-editor bytebuilders-ui/stashappscodecom-backupblueprint-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/stashappscodecom-backupconfiguration-editor/Chart.yaml
+++ b/charts/stashappscodecom-backupconfiguration-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"stash.appscode.com","version":"v1beta1","resource":"backupconfigurations"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: BackupConfiguration Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: stashappscodecom-backupconfiguration-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/stashappscodecom-backupconfiguration-editor/README.md
+++ b/charts/stashappscodecom-backupconfiguration-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/stashappscodecom-backupconfiguration-editor --version=v0.4.8
-$ helm upgrade -i stashappscodecom-backupconfiguration-editor bytebuilders-ui/stashappscodecom-backupconfiguration-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/stashappscodecom-backupconfiguration-editor --version=v0.4.9
+$ helm upgrade -i stashappscodecom-backupconfiguration-editor bytebuilders-ui/stashappscodecom-backupconfiguration-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a BackupConfiguration Editor on a [Kubernetes](http://kuberne
 To install/upgrade the chart with the release name `stashappscodecom-backupconfiguration-editor`:
 
 ```bash
-$ helm upgrade -i stashappscodecom-backupconfiguration-editor bytebuilders-ui/stashappscodecom-backupconfiguration-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i stashappscodecom-backupconfiguration-editor bytebuilders-ui/stashappscodecom-backupconfiguration-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a BackupConfiguration Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `stashappscodecom-b
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i stashappscodecom-backupconfiguration-editor bytebuilders-ui/stashappscodecom-backupconfiguration-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=stash.appscode.com/v1beta1
+$ helm upgrade -i stashappscodecom-backupconfiguration-editor bytebuilders-ui/stashappscodecom-backupconfiguration-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=stash.appscode.com/v1beta1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i stashappscodecom-backupconfiguration-editor bytebuilders-ui/stashappscodecom-backupconfiguration-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i stashappscodecom-backupconfiguration-editor bytebuilders-ui/stashappscodecom-backupconfiguration-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/stashappscodecom-backupsession-editor/Chart.yaml
+++ b/charts/stashappscodecom-backupsession-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"stash.appscode.com","version":"v1beta1","resource":"backupsessions"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: BackupSession Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: stashappscodecom-backupsession-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/stashappscodecom-backupsession-editor/README.md
+++ b/charts/stashappscodecom-backupsession-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/stashappscodecom-backupsession-editor --version=v0.4.8
-$ helm upgrade -i stashappscodecom-backupsession-editor bytebuilders-ui/stashappscodecom-backupsession-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/stashappscodecom-backupsession-editor --version=v0.4.9
+$ helm upgrade -i stashappscodecom-backupsession-editor bytebuilders-ui/stashappscodecom-backupsession-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a BackupSession Editor on a [Kubernetes](http://kubernetes.io
 To install/upgrade the chart with the release name `stashappscodecom-backupsession-editor`:
 
 ```bash
-$ helm upgrade -i stashappscodecom-backupsession-editor bytebuilders-ui/stashappscodecom-backupsession-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i stashappscodecom-backupsession-editor bytebuilders-ui/stashappscodecom-backupsession-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a BackupSession Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `stashappscodecom-b
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i stashappscodecom-backupsession-editor bytebuilders-ui/stashappscodecom-backupsession-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=stash.appscode.com/v1beta1
+$ helm upgrade -i stashappscodecom-backupsession-editor bytebuilders-ui/stashappscodecom-backupsession-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=stash.appscode.com/v1beta1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i stashappscodecom-backupsession-editor bytebuilders-ui/stashappscodecom-backupsession-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i stashappscodecom-backupsession-editor bytebuilders-ui/stashappscodecom-backupsession-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/stashappscodecom-function-editor/Chart.yaml
+++ b/charts/stashappscodecom-function-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"stash.appscode.com","version":"v1beta1","resource":"functions"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: Function Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: stashappscodecom-function-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/stashappscodecom-function-editor/README.md
+++ b/charts/stashappscodecom-function-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/stashappscodecom-function-editor --version=v0.4.8
-$ helm upgrade -i stashappscodecom-function-editor bytebuilders-ui/stashappscodecom-function-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/stashappscodecom-function-editor --version=v0.4.9
+$ helm upgrade -i stashappscodecom-function-editor bytebuilders-ui/stashappscodecom-function-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a Function Editor on a [Kubernetes](http://kubernetes.io) clu
 To install/upgrade the chart with the release name `stashappscodecom-function-editor`:
 
 ```bash
-$ helm upgrade -i stashappscodecom-function-editor bytebuilders-ui/stashappscodecom-function-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i stashappscodecom-function-editor bytebuilders-ui/stashappscodecom-function-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a Function Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `stashappscodecom-f
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i stashappscodecom-function-editor bytebuilders-ui/stashappscodecom-function-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=stash.appscode.com/v1beta1
+$ helm upgrade -i stashappscodecom-function-editor bytebuilders-ui/stashappscodecom-function-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=stash.appscode.com/v1beta1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i stashappscodecom-function-editor bytebuilders-ui/stashappscodecom-function-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i stashappscodecom-function-editor bytebuilders-ui/stashappscodecom-function-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/stashappscodecom-recovery-editor/Chart.yaml
+++ b/charts/stashappscodecom-recovery-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"stash.appscode.com","version":"v1alpha1","resource":"recoveries"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: Recovery Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: stashappscodecom-recovery-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/stashappscodecom-recovery-editor/README.md
+++ b/charts/stashappscodecom-recovery-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/stashappscodecom-recovery-editor --version=v0.4.8
-$ helm upgrade -i stashappscodecom-recovery-editor bytebuilders-ui/stashappscodecom-recovery-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/stashappscodecom-recovery-editor --version=v0.4.9
+$ helm upgrade -i stashappscodecom-recovery-editor bytebuilders-ui/stashappscodecom-recovery-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a Recovery Editor on a [Kubernetes](http://kubernetes.io) clu
 To install/upgrade the chart with the release name `stashappscodecom-recovery-editor`:
 
 ```bash
-$ helm upgrade -i stashappscodecom-recovery-editor bytebuilders-ui/stashappscodecom-recovery-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i stashappscodecom-recovery-editor bytebuilders-ui/stashappscodecom-recovery-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a Recovery Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `stashappscodecom-r
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i stashappscodecom-recovery-editor bytebuilders-ui/stashappscodecom-recovery-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=stash.appscode.com/v1alpha1
+$ helm upgrade -i stashappscodecom-recovery-editor bytebuilders-ui/stashappscodecom-recovery-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=stash.appscode.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i stashappscodecom-recovery-editor bytebuilders-ui/stashappscodecom-recovery-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i stashappscodecom-recovery-editor bytebuilders-ui/stashappscodecom-recovery-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/stashappscodecom-repository-editor/Chart.yaml
+++ b/charts/stashappscodecom-repository-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"stash.appscode.com","version":"v1alpha1","resource":"repositories"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: Repository Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: stashappscodecom-repository-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/stashappscodecom-repository-editor/README.md
+++ b/charts/stashappscodecom-repository-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/stashappscodecom-repository-editor --version=v0.4.8
-$ helm upgrade -i stashappscodecom-repository-editor bytebuilders-ui/stashappscodecom-repository-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/stashappscodecom-repository-editor --version=v0.4.9
+$ helm upgrade -i stashappscodecom-repository-editor bytebuilders-ui/stashappscodecom-repository-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a Repository Editor on a [Kubernetes](http://kubernetes.io) c
 To install/upgrade the chart with the release name `stashappscodecom-repository-editor`:
 
 ```bash
-$ helm upgrade -i stashappscodecom-repository-editor bytebuilders-ui/stashappscodecom-repository-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i stashappscodecom-repository-editor bytebuilders-ui/stashappscodecom-repository-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a Repository Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `stashappscodecom-r
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i stashappscodecom-repository-editor bytebuilders-ui/stashappscodecom-repository-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=stash.appscode.com/v1alpha1
+$ helm upgrade -i stashappscodecom-repository-editor bytebuilders-ui/stashappscodecom-repository-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=stash.appscode.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i stashappscodecom-repository-editor bytebuilders-ui/stashappscodecom-repository-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i stashappscodecom-repository-editor bytebuilders-ui/stashappscodecom-repository-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/stashappscodecom-restic-editor/Chart.yaml
+++ b/charts/stashappscodecom-restic-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"stash.appscode.com","version":"v1alpha1","resource":"restics"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: Restic Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: stashappscodecom-restic-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/stashappscodecom-restic-editor/README.md
+++ b/charts/stashappscodecom-restic-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/stashappscodecom-restic-editor --version=v0.4.8
-$ helm upgrade -i stashappscodecom-restic-editor bytebuilders-ui/stashappscodecom-restic-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/stashappscodecom-restic-editor --version=v0.4.9
+$ helm upgrade -i stashappscodecom-restic-editor bytebuilders-ui/stashappscodecom-restic-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a Restic Editor on a [Kubernetes](http://kubernetes.io) clust
 To install/upgrade the chart with the release name `stashappscodecom-restic-editor`:
 
 ```bash
-$ helm upgrade -i stashappscodecom-restic-editor bytebuilders-ui/stashappscodecom-restic-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i stashappscodecom-restic-editor bytebuilders-ui/stashappscodecom-restic-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a Restic Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `stashappscodecom-r
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i stashappscodecom-restic-editor bytebuilders-ui/stashappscodecom-restic-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=stash.appscode.com/v1alpha1
+$ helm upgrade -i stashappscodecom-restic-editor bytebuilders-ui/stashappscodecom-restic-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=stash.appscode.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i stashappscodecom-restic-editor bytebuilders-ui/stashappscodecom-restic-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i stashappscodecom-restic-editor bytebuilders-ui/stashappscodecom-restic-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/stashappscodecom-restorebatch-editor/Chart.yaml
+++ b/charts/stashappscodecom-restorebatch-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"stash.appscode.com","version":"v1beta1","resource":"restorebatches"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: RestoreBatch Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: stashappscodecom-restorebatch-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/stashappscodecom-restorebatch-editor/README.md
+++ b/charts/stashappscodecom-restorebatch-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/stashappscodecom-restorebatch-editor --version=v0.4.8
-$ helm upgrade -i stashappscodecom-restorebatch-editor bytebuilders-ui/stashappscodecom-restorebatch-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/stashappscodecom-restorebatch-editor --version=v0.4.9
+$ helm upgrade -i stashappscodecom-restorebatch-editor bytebuilders-ui/stashappscodecom-restorebatch-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a RestoreBatch Editor on a [Kubernetes](http://kubernetes.io)
 To install/upgrade the chart with the release name `stashappscodecom-restorebatch-editor`:
 
 ```bash
-$ helm upgrade -i stashappscodecom-restorebatch-editor bytebuilders-ui/stashappscodecom-restorebatch-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i stashappscodecom-restorebatch-editor bytebuilders-ui/stashappscodecom-restorebatch-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a RestoreBatch Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `stashappscodecom-r
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i stashappscodecom-restorebatch-editor bytebuilders-ui/stashappscodecom-restorebatch-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=stash.appscode.com/v1beta1
+$ helm upgrade -i stashappscodecom-restorebatch-editor bytebuilders-ui/stashappscodecom-restorebatch-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=stash.appscode.com/v1beta1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i stashappscodecom-restorebatch-editor bytebuilders-ui/stashappscodecom-restorebatch-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i stashappscodecom-restorebatch-editor bytebuilders-ui/stashappscodecom-restorebatch-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/stashappscodecom-restoresession-editor/Chart.yaml
+++ b/charts/stashappscodecom-restoresession-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"stash.appscode.com","version":"v1beta1","resource":"restoresessions"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: RestoreSession Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: stashappscodecom-restoresession-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/stashappscodecom-restoresession-editor/README.md
+++ b/charts/stashappscodecom-restoresession-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/stashappscodecom-restoresession-editor --version=v0.4.8
-$ helm upgrade -i stashappscodecom-restoresession-editor bytebuilders-ui/stashappscodecom-restoresession-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/stashappscodecom-restoresession-editor --version=v0.4.9
+$ helm upgrade -i stashappscodecom-restoresession-editor bytebuilders-ui/stashappscodecom-restoresession-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a RestoreSession Editor on a [Kubernetes](http://kubernetes.i
 To install/upgrade the chart with the release name `stashappscodecom-restoresession-editor`:
 
 ```bash
-$ helm upgrade -i stashappscodecom-restoresession-editor bytebuilders-ui/stashappscodecom-restoresession-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i stashappscodecom-restoresession-editor bytebuilders-ui/stashappscodecom-restoresession-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a RestoreSession Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `stashappscodecom-r
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i stashappscodecom-restoresession-editor bytebuilders-ui/stashappscodecom-restoresession-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=stash.appscode.com/v1beta1
+$ helm upgrade -i stashappscodecom-restoresession-editor bytebuilders-ui/stashappscodecom-restoresession-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=stash.appscode.com/v1beta1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i stashappscodecom-restoresession-editor bytebuilders-ui/stashappscodecom-restoresession-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i stashappscodecom-restoresession-editor bytebuilders-ui/stashappscodecom-restoresession-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/stashappscodecom-task-editor/Chart.yaml
+++ b/charts/stashappscodecom-task-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"stash.appscode.com","version":"v1beta1","resource":"tasks"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: Task Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: stashappscodecom-task-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/stashappscodecom-task-editor/README.md
+++ b/charts/stashappscodecom-task-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/stashappscodecom-task-editor --version=v0.4.8
-$ helm upgrade -i stashappscodecom-task-editor bytebuilders-ui/stashappscodecom-task-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/stashappscodecom-task-editor --version=v0.4.9
+$ helm upgrade -i stashappscodecom-task-editor bytebuilders-ui/stashappscodecom-task-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a Task Editor on a [Kubernetes](http://kubernetes.io) cluster
 To install/upgrade the chart with the release name `stashappscodecom-task-editor`:
 
 ```bash
-$ helm upgrade -i stashappscodecom-task-editor bytebuilders-ui/stashappscodecom-task-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i stashappscodecom-task-editor bytebuilders-ui/stashappscodecom-task-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a Task Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `stashappscodecom-t
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i stashappscodecom-task-editor bytebuilders-ui/stashappscodecom-task-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=stash.appscode.com/v1beta1
+$ helm upgrade -i stashappscodecom-task-editor bytebuilders-ui/stashappscodecom-task-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=stash.appscode.com/v1beta1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i stashappscodecom-task-editor bytebuilders-ui/stashappscodecom-task-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i stashappscodecom-task-editor bytebuilders-ui/stashappscodecom-task-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/storagek8sio-csidriver-editor/Chart.yaml
+++ b/charts/storagek8sio-csidriver-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"storage.k8s.io","version":"v1","resource":"csidrivers"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: CSIDriver Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: storagek8sio-csidriver-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/storagek8sio-csidriver-editor/README.md
+++ b/charts/storagek8sio-csidriver-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/storagek8sio-csidriver-editor --version=v0.4.8
-$ helm upgrade -i storagek8sio-csidriver-editor bytebuilders-ui/storagek8sio-csidriver-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/storagek8sio-csidriver-editor --version=v0.4.9
+$ helm upgrade -i storagek8sio-csidriver-editor bytebuilders-ui/storagek8sio-csidriver-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a CSIDriver Editor on a [Kubernetes](http://kubernetes.io) cl
 To install/upgrade the chart with the release name `storagek8sio-csidriver-editor`:
 
 ```bash
-$ helm upgrade -i storagek8sio-csidriver-editor bytebuilders-ui/storagek8sio-csidriver-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i storagek8sio-csidriver-editor bytebuilders-ui/storagek8sio-csidriver-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a CSIDriver Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `storagek8sio-csidr
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i storagek8sio-csidriver-editor bytebuilders-ui/storagek8sio-csidriver-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=storage.k8s.io/v1
+$ helm upgrade -i storagek8sio-csidriver-editor bytebuilders-ui/storagek8sio-csidriver-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=storage.k8s.io/v1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i storagek8sio-csidriver-editor bytebuilders-ui/storagek8sio-csidriver-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i storagek8sio-csidriver-editor bytebuilders-ui/storagek8sio-csidriver-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/storagek8sio-csinode-editor/Chart.yaml
+++ b/charts/storagek8sio-csinode-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"storage.k8s.io","version":"v1","resource":"csinodes"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: CSINode Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: storagek8sio-csinode-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/storagek8sio-csinode-editor/README.md
+++ b/charts/storagek8sio-csinode-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/storagek8sio-csinode-editor --version=v0.4.8
-$ helm upgrade -i storagek8sio-csinode-editor bytebuilders-ui/storagek8sio-csinode-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/storagek8sio-csinode-editor --version=v0.4.9
+$ helm upgrade -i storagek8sio-csinode-editor bytebuilders-ui/storagek8sio-csinode-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a CSINode Editor on a [Kubernetes](http://kubernetes.io) clus
 To install/upgrade the chart with the release name `storagek8sio-csinode-editor`:
 
 ```bash
-$ helm upgrade -i storagek8sio-csinode-editor bytebuilders-ui/storagek8sio-csinode-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i storagek8sio-csinode-editor bytebuilders-ui/storagek8sio-csinode-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a CSINode Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `storagek8sio-csino
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i storagek8sio-csinode-editor bytebuilders-ui/storagek8sio-csinode-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=storage.k8s.io/v1
+$ helm upgrade -i storagek8sio-csinode-editor bytebuilders-ui/storagek8sio-csinode-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=storage.k8s.io/v1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i storagek8sio-csinode-editor bytebuilders-ui/storagek8sio-csinode-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i storagek8sio-csinode-editor bytebuilders-ui/storagek8sio-csinode-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/storagek8sio-csistoragecapacity-editor/Chart.yaml
+++ b/charts/storagek8sio-csistoragecapacity-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"storage.k8s.io","version":"v1beta1","resource":"csistoragecapacities"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: CSIStorageCapacity Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: storagek8sio-csistoragecapacity-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/storagek8sio-csistoragecapacity-editor/README.md
+++ b/charts/storagek8sio-csistoragecapacity-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/storagek8sio-csistoragecapacity-editor --version=v0.4.8
-$ helm upgrade -i storagek8sio-csistoragecapacity-editor bytebuilders-ui/storagek8sio-csistoragecapacity-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/storagek8sio-csistoragecapacity-editor --version=v0.4.9
+$ helm upgrade -i storagek8sio-csistoragecapacity-editor bytebuilders-ui/storagek8sio-csistoragecapacity-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a CSIStorageCapacity Editor on a [Kubernetes](http://kubernet
 To install/upgrade the chart with the release name `storagek8sio-csistoragecapacity-editor`:
 
 ```bash
-$ helm upgrade -i storagek8sio-csistoragecapacity-editor bytebuilders-ui/storagek8sio-csistoragecapacity-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i storagek8sio-csistoragecapacity-editor bytebuilders-ui/storagek8sio-csistoragecapacity-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a CSIStorageCapacity Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `storagek8sio-csist
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i storagek8sio-csistoragecapacity-editor bytebuilders-ui/storagek8sio-csistoragecapacity-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=storage.k8s.io/v1beta1
+$ helm upgrade -i storagek8sio-csistoragecapacity-editor bytebuilders-ui/storagek8sio-csistoragecapacity-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=storage.k8s.io/v1beta1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i storagek8sio-csistoragecapacity-editor bytebuilders-ui/storagek8sio-csistoragecapacity-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i storagek8sio-csistoragecapacity-editor bytebuilders-ui/storagek8sio-csistoragecapacity-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/storagek8sio-storageclass-editor/Chart.yaml
+++ b/charts/storagek8sio-storageclass-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"storage.k8s.io","version":"v1","resource":"storageclasses"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: StorageClass Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: storagek8sio-storageclass-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/storagek8sio-storageclass-editor/README.md
+++ b/charts/storagek8sio-storageclass-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/storagek8sio-storageclass-editor --version=v0.4.8
-$ helm upgrade -i storagek8sio-storageclass-editor bytebuilders-ui/storagek8sio-storageclass-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/storagek8sio-storageclass-editor --version=v0.4.9
+$ helm upgrade -i storagek8sio-storageclass-editor bytebuilders-ui/storagek8sio-storageclass-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a StorageClass Editor on a [Kubernetes](http://kubernetes.io)
 To install/upgrade the chart with the release name `storagek8sio-storageclass-editor`:
 
 ```bash
-$ helm upgrade -i storagek8sio-storageclass-editor bytebuilders-ui/storagek8sio-storageclass-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i storagek8sio-storageclass-editor bytebuilders-ui/storagek8sio-storageclass-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a StorageClass Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `storagek8sio-stora
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i storagek8sio-storageclass-editor bytebuilders-ui/storagek8sio-storageclass-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=storage.k8s.io/v1
+$ helm upgrade -i storagek8sio-storageclass-editor bytebuilders-ui/storagek8sio-storageclass-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=storage.k8s.io/v1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i storagek8sio-storageclass-editor bytebuilders-ui/storagek8sio-storageclass-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i storagek8sio-storageclass-editor bytebuilders-ui/storagek8sio-storageclass-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/storagek8sio-volumeattachment-editor/Chart.yaml
+++ b/charts/storagek8sio-volumeattachment-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"storage.k8s.io","version":"v1","resource":"volumeattachments"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: VolumeAttachment Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: storagek8sio-volumeattachment-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/storagek8sio-volumeattachment-editor/README.md
+++ b/charts/storagek8sio-volumeattachment-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/storagek8sio-volumeattachment-editor --version=v0.4.8
-$ helm upgrade -i storagek8sio-volumeattachment-editor bytebuilders-ui/storagek8sio-volumeattachment-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/storagek8sio-volumeattachment-editor --version=v0.4.9
+$ helm upgrade -i storagek8sio-volumeattachment-editor bytebuilders-ui/storagek8sio-volumeattachment-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a VolumeAttachment Editor on a [Kubernetes](http://kubernetes
 To install/upgrade the chart with the release name `storagek8sio-volumeattachment-editor`:
 
 ```bash
-$ helm upgrade -i storagek8sio-volumeattachment-editor bytebuilders-ui/storagek8sio-volumeattachment-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i storagek8sio-volumeattachment-editor bytebuilders-ui/storagek8sio-volumeattachment-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a VolumeAttachment Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `storagek8sio-volum
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i storagek8sio-volumeattachment-editor bytebuilders-ui/storagek8sio-volumeattachment-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=storage.k8s.io/v1
+$ helm upgrade -i storagek8sio-volumeattachment-editor bytebuilders-ui/storagek8sio-volumeattachment-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=storage.k8s.io/v1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i storagek8sio-volumeattachment-editor bytebuilders-ui/storagek8sio-volumeattachment-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i storagek8sio-volumeattachment-editor bytebuilders-ui/storagek8sio-volumeattachment-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/uibytebuildersdev-component-alert/Chart.yaml
+++ b/charts/uibytebuildersdev-component-alert/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: uibytebuildersdev-component-alert
 description: Alert Component Library
 type: library
-appVersion: v0.4.8
+appVersion: v0.4.9
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
 keywords:
@@ -11,4 +11,4 @@ kubeVersion: '>= 1.14.0'
 maintainers:
 - email: support@appscode.com
   name: appscode
-version: v0.4.8
+version: v0.4.9

--- a/charts/uibytebuildersdev-component-certificates/Chart.yaml
+++ b/charts/uibytebuildersdev-component-certificates/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: uibytebuildersdev-component-certificates
 description: Certificates Component Library
 type: library
-appVersion: v0.4.8
+appVersion: v0.4.9
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
 keywords:
@@ -11,4 +11,4 @@ kubeVersion: '>= 1.14.0'
 maintainers:
 - email: support@appscode.com
   name: appscode
-version: v0.4.8
+version: v0.4.9

--- a/charts/uibytebuildersdev-component-env-from/Chart.yaml
+++ b/charts/uibytebuildersdev-component-env-from/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: uibytebuildersdev-component-env-from
 description: EnvFrom Component Library
 type: library
-appVersion: v0.4.8
+appVersion: v0.4.9
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
 keywords:
@@ -11,4 +11,4 @@ kubeVersion: '>= 1.14.0'
 maintainers:
 - email: support@appscode.com
   name: appscode
-version: v0.4.8
+version: v0.4.9

--- a/charts/uibytebuildersdev-component-env/Chart.yaml
+++ b/charts/uibytebuildersdev-component-env/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: uibytebuildersdev-component-env
 description: Env Component Library
 type: library
-appVersion: v0.4.8
+appVersion: v0.4.9
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
 keywords:
@@ -11,4 +11,4 @@ kubeVersion: '>= 1.14.0'
 maintainers:
 - email: support@appscode.com
   name: appscode
-version: v0.4.8
+version: v0.4.9

--- a/charts/uibytebuildersdev-component-match-expressions/Chart.yaml
+++ b/charts/uibytebuildersdev-component-match-expressions/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: uibytebuildersdev-component-match-expressions
 description: MatchExpressions Component Library
 type: library
-appVersion: v0.4.8
+appVersion: v0.4.9
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
 keywords:
@@ -11,4 +11,4 @@ kubeVersion: '>= 1.14.0'
 maintainers:
 - email: support@appscode.com
   name: appscode
-version: v0.4.8
+version: v0.4.9

--- a/charts/uibytebuildersdev-component-match-fields/Chart.yaml
+++ b/charts/uibytebuildersdev-component-match-fields/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: uibytebuildersdev-component-match-fields
 description: MatchFields Component Library
 type: library
-appVersion: v0.4.8
+appVersion: v0.4.9
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
 keywords:
@@ -11,4 +11,4 @@ kubeVersion: '>= 1.14.0'
 maintainers:
 - email: support@appscode.com
   name: appscode
-version: v0.4.8
+version: v0.4.9

--- a/charts/uibytebuildersdev-component-monitoring-option/Chart.yaml
+++ b/charts/uibytebuildersdev-component-monitoring-option/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: uibytebuildersdev-component-monitoring-option
 description: Monitoring Option Component Library
 type: library
-appVersion: v0.4.8
+appVersion: v0.4.9
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
 keywords:
@@ -11,4 +11,4 @@ kubeVersion: '>= 1.14.0'
 maintainers:
 - email: support@appscode.com
   name: appscode
-version: v0.4.8
+version: v0.4.9

--- a/charts/uibytebuildersdev-component-pod-template/Chart.yaml
+++ b/charts/uibytebuildersdev-component-pod-template/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: uibytebuildersdev-component-pod-template
 description: PodTemplate Component Library
 type: library
-appVersion: v0.4.8
+appVersion: v0.4.9
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
 keywords:
@@ -11,4 +11,4 @@ kubeVersion: '>= 1.14.0'
 maintainers:
 - email: support@appscode.com
   name: appscode
-version: v0.4.8
+version: v0.4.9

--- a/charts/uibytebuildersdev-component-repository-create/Chart.yaml
+++ b/charts/uibytebuildersdev-component-repository-create/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: uibytebuildersdev-component-repository-create
 description: RepositoryCreate Component Library
 type: library
-appVersion: v0.4.8
+appVersion: v0.4.9
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
 keywords:
@@ -11,4 +11,4 @@ kubeVersion: '>= 1.14.0'
 maintainers:
 - email: support@appscode.com
   name: appscode
-version: v0.4.8
+version: v0.4.9

--- a/charts/uibytebuildersdev-component-resources/Chart.yaml
+++ b/charts/uibytebuildersdev-component-resources/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: uibytebuildersdev-component-resources
 description: Resources Component Library
 type: library
-appVersion: v0.4.8
+appVersion: v0.4.9
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
 keywords:
@@ -11,4 +11,4 @@ kubeVersion: '>= 1.14.0'
 maintainers:
 - email: support@appscode.com
   name: appscode
-version: v0.4.8
+version: v0.4.9

--- a/charts/uibytebuildersdev-component-runtime-settings/Chart.yaml
+++ b/charts/uibytebuildersdev-component-runtime-settings/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: uibytebuildersdev-component-runtime-settings
 description: RuntimeSettings Component Library
 type: library
-appVersion: v0.4.8
+appVersion: v0.4.9
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
 keywords:
@@ -11,4 +11,4 @@ kubeVersion: '>= 1.14.0'
 maintainers:
 - email: support@appscode.com
   name: appscode
-version: v0.4.8
+version: v0.4.9

--- a/charts/uibytebuildersdev-component-se-linux-options/Chart.yaml
+++ b/charts/uibytebuildersdev-component-se-linux-options/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: uibytebuildersdev-component-se-linux-options
 description: SELinuxOptions Component Library
 type: library
-appVersion: v0.4.8
+appVersion: v0.4.9
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
 keywords:
@@ -11,4 +11,4 @@ kubeVersion: '>= 1.14.0'
 maintainers:
 - email: support@appscode.com
   name: appscode
-version: v0.4.8
+version: v0.4.9

--- a/charts/uibytebuildersdev-component-service-templates/Chart.yaml
+++ b/charts/uibytebuildersdev-component-service-templates/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: uibytebuildersdev-component-service-templates
 description: Service Templates Component Library
 type: library
-appVersion: v0.4.8
+appVersion: v0.4.9
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
 keywords:
@@ -11,4 +11,4 @@ kubeVersion: '>= 1.14.0'
 maintainers:
 - email: support@appscode.com
   name: appscode
-version: v0.4.8
+version: v0.4.9

--- a/charts/uikubedbcom-elasticsearchinsight-editor/Chart.yaml
+++ b/charts/uikubedbcom-elasticsearchinsight-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"ui.kubedb.com","version":"v1alpha1","resource":"elasticsearchinsights"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: ElasticsearchInsight Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: uikubedbcom-elasticsearchinsight-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/uikubedbcom-elasticsearchinsight-editor/README.md
+++ b/charts/uikubedbcom-elasticsearchinsight-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/uikubedbcom-elasticsearchinsight-editor --version=v0.4.8
-$ helm upgrade -i uikubedbcom-elasticsearchinsight-editor bytebuilders-ui/uikubedbcom-elasticsearchinsight-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/uikubedbcom-elasticsearchinsight-editor --version=v0.4.9
+$ helm upgrade -i uikubedbcom-elasticsearchinsight-editor bytebuilders-ui/uikubedbcom-elasticsearchinsight-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a ElasticsearchInsight Editor on a [Kubernetes](http://kubern
 To install/upgrade the chart with the release name `uikubedbcom-elasticsearchinsight-editor`:
 
 ```bash
-$ helm upgrade -i uikubedbcom-elasticsearchinsight-editor bytebuilders-ui/uikubedbcom-elasticsearchinsight-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i uikubedbcom-elasticsearchinsight-editor bytebuilders-ui/uikubedbcom-elasticsearchinsight-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a ElasticsearchInsight Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `uikubedbcom-elasti
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i uikubedbcom-elasticsearchinsight-editor bytebuilders-ui/uikubedbcom-elasticsearchinsight-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=ui.kubedb.com/v1alpha1
+$ helm upgrade -i uikubedbcom-elasticsearchinsight-editor bytebuilders-ui/uikubedbcom-elasticsearchinsight-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=ui.kubedb.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i uikubedbcom-elasticsearchinsight-editor bytebuilders-ui/uikubedbcom-elasticsearchinsight-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i uikubedbcom-elasticsearchinsight-editor bytebuilders-ui/uikubedbcom-elasticsearchinsight-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/uikubedbcom-elasticsearchnodesstats-editor/Chart.yaml
+++ b/charts/uikubedbcom-elasticsearchnodesstats-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"ui.kubedb.com","version":"v1alpha1","resource":"elasticsearchnodesstats"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: ElasticsearchNodesStats Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: uikubedbcom-elasticsearchnodesstats-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/uikubedbcom-elasticsearchnodesstats-editor/README.md
+++ b/charts/uikubedbcom-elasticsearchnodesstats-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/uikubedbcom-elasticsearchnodesstats-editor --version=v0.4.8
-$ helm upgrade -i uikubedbcom-elasticsearchnodesstats-editor bytebuilders-ui/uikubedbcom-elasticsearchnodesstats-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/uikubedbcom-elasticsearchnodesstats-editor --version=v0.4.9
+$ helm upgrade -i uikubedbcom-elasticsearchnodesstats-editor bytebuilders-ui/uikubedbcom-elasticsearchnodesstats-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a ElasticsearchNodesStats Editor on a [Kubernetes](http://kub
 To install/upgrade the chart with the release name `uikubedbcom-elasticsearchnodesstats-editor`:
 
 ```bash
-$ helm upgrade -i uikubedbcom-elasticsearchnodesstats-editor bytebuilders-ui/uikubedbcom-elasticsearchnodesstats-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i uikubedbcom-elasticsearchnodesstats-editor bytebuilders-ui/uikubedbcom-elasticsearchnodesstats-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a ElasticsearchNodesStats Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `uikubedbcom-elasti
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i uikubedbcom-elasticsearchnodesstats-editor bytebuilders-ui/uikubedbcom-elasticsearchnodesstats-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=ui.kubedb.com/v1alpha1
+$ helm upgrade -i uikubedbcom-elasticsearchnodesstats-editor bytebuilders-ui/uikubedbcom-elasticsearchnodesstats-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=ui.kubedb.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i uikubedbcom-elasticsearchnodesstats-editor bytebuilders-ui/uikubedbcom-elasticsearchnodesstats-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i uikubedbcom-elasticsearchnodesstats-editor bytebuilders-ui/uikubedbcom-elasticsearchnodesstats-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/uikubedbcom-elasticsearchschemaoverview-editor/Chart.yaml
+++ b/charts/uikubedbcom-elasticsearchschemaoverview-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"ui.kubedb.com","version":"v1alpha1","resource":"elasticsearchschemaoverviews"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: ElasticsearchSchemaOverview Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: uikubedbcom-elasticsearchschemaoverview-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/uikubedbcom-elasticsearchschemaoverview-editor/README.md
+++ b/charts/uikubedbcom-elasticsearchschemaoverview-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/uikubedbcom-elasticsearchschemaoverview-editor --version=v0.4.8
-$ helm upgrade -i uikubedbcom-elasticsearchschemaoverview-editor bytebuilders-ui/uikubedbcom-elasticsearchschemaoverview-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/uikubedbcom-elasticsearchschemaoverview-editor --version=v0.4.9
+$ helm upgrade -i uikubedbcom-elasticsearchschemaoverview-editor bytebuilders-ui/uikubedbcom-elasticsearchschemaoverview-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a ElasticsearchSchemaOverview Editor on a [Kubernetes](http:/
 To install/upgrade the chart with the release name `uikubedbcom-elasticsearchschemaoverview-editor`:
 
 ```bash
-$ helm upgrade -i uikubedbcom-elasticsearchschemaoverview-editor bytebuilders-ui/uikubedbcom-elasticsearchschemaoverview-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i uikubedbcom-elasticsearchschemaoverview-editor bytebuilders-ui/uikubedbcom-elasticsearchschemaoverview-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a ElasticsearchSchemaOverview Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `uikubedbcom-elasti
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i uikubedbcom-elasticsearchschemaoverview-editor bytebuilders-ui/uikubedbcom-elasticsearchschemaoverview-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=ui.kubedb.com/v1alpha1
+$ helm upgrade -i uikubedbcom-elasticsearchschemaoverview-editor bytebuilders-ui/uikubedbcom-elasticsearchschemaoverview-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=ui.kubedb.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i uikubedbcom-elasticsearchschemaoverview-editor bytebuilders-ui/uikubedbcom-elasticsearchschemaoverview-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i uikubedbcom-elasticsearchschemaoverview-editor bytebuilders-ui/uikubedbcom-elasticsearchschemaoverview-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/uikubedbcom-mariadbinsight-editor/Chart.yaml
+++ b/charts/uikubedbcom-mariadbinsight-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"ui.kubedb.com","version":"v1alpha1","resource":"mariadbinsights"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: MariaDBInsight Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: uikubedbcom-mariadbinsight-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/uikubedbcom-mariadbinsight-editor/README.md
+++ b/charts/uikubedbcom-mariadbinsight-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/uikubedbcom-mariadbinsight-editor --version=v0.4.8
-$ helm upgrade -i uikubedbcom-mariadbinsight-editor bytebuilders-ui/uikubedbcom-mariadbinsight-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/uikubedbcom-mariadbinsight-editor --version=v0.4.9
+$ helm upgrade -i uikubedbcom-mariadbinsight-editor bytebuilders-ui/uikubedbcom-mariadbinsight-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a MariaDBInsight Editor on a [Kubernetes](http://kubernetes.i
 To install/upgrade the chart with the release name `uikubedbcom-mariadbinsight-editor`:
 
 ```bash
-$ helm upgrade -i uikubedbcom-mariadbinsight-editor bytebuilders-ui/uikubedbcom-mariadbinsight-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i uikubedbcom-mariadbinsight-editor bytebuilders-ui/uikubedbcom-mariadbinsight-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a MariaDBInsight Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `uikubedbcom-mariad
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i uikubedbcom-mariadbinsight-editor bytebuilders-ui/uikubedbcom-mariadbinsight-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=ui.kubedb.com/v1alpha1
+$ helm upgrade -i uikubedbcom-mariadbinsight-editor bytebuilders-ui/uikubedbcom-mariadbinsight-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=ui.kubedb.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i uikubedbcom-mariadbinsight-editor bytebuilders-ui/uikubedbcom-mariadbinsight-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i uikubedbcom-mariadbinsight-editor bytebuilders-ui/uikubedbcom-mariadbinsight-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/uikubedbcom-mariadbqueries-editor/Chart.yaml
+++ b/charts/uikubedbcom-mariadbqueries-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"ui.kubedb.com","version":"v1alpha1","resource":"mariadbqueries"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: MariaDBQueries Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: uikubedbcom-mariadbqueries-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/uikubedbcom-mariadbqueries-editor/README.md
+++ b/charts/uikubedbcom-mariadbqueries-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/uikubedbcom-mariadbqueries-editor --version=v0.4.8
-$ helm upgrade -i uikubedbcom-mariadbqueries-editor bytebuilders-ui/uikubedbcom-mariadbqueries-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/uikubedbcom-mariadbqueries-editor --version=v0.4.9
+$ helm upgrade -i uikubedbcom-mariadbqueries-editor bytebuilders-ui/uikubedbcom-mariadbqueries-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a MariaDBQueries Editor on a [Kubernetes](http://kubernetes.i
 To install/upgrade the chart with the release name `uikubedbcom-mariadbqueries-editor`:
 
 ```bash
-$ helm upgrade -i uikubedbcom-mariadbqueries-editor bytebuilders-ui/uikubedbcom-mariadbqueries-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i uikubedbcom-mariadbqueries-editor bytebuilders-ui/uikubedbcom-mariadbqueries-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a MariaDBQueries Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `uikubedbcom-mariad
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i uikubedbcom-mariadbqueries-editor bytebuilders-ui/uikubedbcom-mariadbqueries-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=ui.kubedb.com/v1alpha1
+$ helm upgrade -i uikubedbcom-mariadbqueries-editor bytebuilders-ui/uikubedbcom-mariadbqueries-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=ui.kubedb.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i uikubedbcom-mariadbqueries-editor bytebuilders-ui/uikubedbcom-mariadbqueries-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i uikubedbcom-mariadbqueries-editor bytebuilders-ui/uikubedbcom-mariadbqueries-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/uikubedbcom-mariadbschemaoverview-editor/Chart.yaml
+++ b/charts/uikubedbcom-mariadbschemaoverview-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"ui.kubedb.com","version":"v1alpha1","resource":"mariadbschemaoverviews"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: MariaDBSchemaOverview Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: uikubedbcom-mariadbschemaoverview-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/uikubedbcom-mariadbschemaoverview-editor/README.md
+++ b/charts/uikubedbcom-mariadbschemaoverview-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/uikubedbcom-mariadbschemaoverview-editor --version=v0.4.8
-$ helm upgrade -i uikubedbcom-mariadbschemaoverview-editor bytebuilders-ui/uikubedbcom-mariadbschemaoverview-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/uikubedbcom-mariadbschemaoverview-editor --version=v0.4.9
+$ helm upgrade -i uikubedbcom-mariadbschemaoverview-editor bytebuilders-ui/uikubedbcom-mariadbschemaoverview-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a MariaDBSchemaOverview Editor on a [Kubernetes](http://kuber
 To install/upgrade the chart with the release name `uikubedbcom-mariadbschemaoverview-editor`:
 
 ```bash
-$ helm upgrade -i uikubedbcom-mariadbschemaoverview-editor bytebuilders-ui/uikubedbcom-mariadbschemaoverview-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i uikubedbcom-mariadbschemaoverview-editor bytebuilders-ui/uikubedbcom-mariadbschemaoverview-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a MariaDBSchemaOverview Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `uikubedbcom-mariad
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i uikubedbcom-mariadbschemaoverview-editor bytebuilders-ui/uikubedbcom-mariadbschemaoverview-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=ui.kubedb.com/v1alpha1
+$ helm upgrade -i uikubedbcom-mariadbschemaoverview-editor bytebuilders-ui/uikubedbcom-mariadbschemaoverview-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=ui.kubedb.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i uikubedbcom-mariadbschemaoverview-editor bytebuilders-ui/uikubedbcom-mariadbschemaoverview-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i uikubedbcom-mariadbschemaoverview-editor bytebuilders-ui/uikubedbcom-mariadbschemaoverview-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/uikubedbcom-mongodbinsight-editor/Chart.yaml
+++ b/charts/uikubedbcom-mongodbinsight-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"ui.kubedb.com","version":"v1alpha1","resource":"mongodbinsights"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: MongoDBInsight Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: uikubedbcom-mongodbinsight-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/uikubedbcom-mongodbinsight-editor/README.md
+++ b/charts/uikubedbcom-mongodbinsight-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/uikubedbcom-mongodbinsight-editor --version=v0.4.8
-$ helm upgrade -i uikubedbcom-mongodbinsight-editor bytebuilders-ui/uikubedbcom-mongodbinsight-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/uikubedbcom-mongodbinsight-editor --version=v0.4.9
+$ helm upgrade -i uikubedbcom-mongodbinsight-editor bytebuilders-ui/uikubedbcom-mongodbinsight-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a MongoDBInsight Editor on a [Kubernetes](http://kubernetes.i
 To install/upgrade the chart with the release name `uikubedbcom-mongodbinsight-editor`:
 
 ```bash
-$ helm upgrade -i uikubedbcom-mongodbinsight-editor bytebuilders-ui/uikubedbcom-mongodbinsight-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i uikubedbcom-mongodbinsight-editor bytebuilders-ui/uikubedbcom-mongodbinsight-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a MongoDBInsight Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `uikubedbcom-mongod
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i uikubedbcom-mongodbinsight-editor bytebuilders-ui/uikubedbcom-mongodbinsight-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=ui.kubedb.com/v1alpha1
+$ helm upgrade -i uikubedbcom-mongodbinsight-editor bytebuilders-ui/uikubedbcom-mongodbinsight-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=ui.kubedb.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i uikubedbcom-mongodbinsight-editor bytebuilders-ui/uikubedbcom-mongodbinsight-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i uikubedbcom-mongodbinsight-editor bytebuilders-ui/uikubedbcom-mongodbinsight-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/uikubedbcom-mongodbqueries-editor/Chart.yaml
+++ b/charts/uikubedbcom-mongodbqueries-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"ui.kubedb.com","version":"v1alpha1","resource":"mongodbqueries"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: MongoDBQueries Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: uikubedbcom-mongodbqueries-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/uikubedbcom-mongodbqueries-editor/README.md
+++ b/charts/uikubedbcom-mongodbqueries-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/uikubedbcom-mongodbqueries-editor --version=v0.4.8
-$ helm upgrade -i uikubedbcom-mongodbqueries-editor bytebuilders-ui/uikubedbcom-mongodbqueries-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/uikubedbcom-mongodbqueries-editor --version=v0.4.9
+$ helm upgrade -i uikubedbcom-mongodbqueries-editor bytebuilders-ui/uikubedbcom-mongodbqueries-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a MongoDBQueries Editor on a [Kubernetes](http://kubernetes.i
 To install/upgrade the chart with the release name `uikubedbcom-mongodbqueries-editor`:
 
 ```bash
-$ helm upgrade -i uikubedbcom-mongodbqueries-editor bytebuilders-ui/uikubedbcom-mongodbqueries-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i uikubedbcom-mongodbqueries-editor bytebuilders-ui/uikubedbcom-mongodbqueries-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a MongoDBQueries Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `uikubedbcom-mongod
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i uikubedbcom-mongodbqueries-editor bytebuilders-ui/uikubedbcom-mongodbqueries-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=ui.kubedb.com/v1alpha1
+$ helm upgrade -i uikubedbcom-mongodbqueries-editor bytebuilders-ui/uikubedbcom-mongodbqueries-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=ui.kubedb.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i uikubedbcom-mongodbqueries-editor bytebuilders-ui/uikubedbcom-mongodbqueries-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i uikubedbcom-mongodbqueries-editor bytebuilders-ui/uikubedbcom-mongodbqueries-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/uikubedbcom-mongodbschemaoverview-editor/Chart.yaml
+++ b/charts/uikubedbcom-mongodbschemaoverview-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"ui.kubedb.com","version":"v1alpha1","resource":"mongodbschemaoverviews"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: MongoDBSchemaOverview Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: uikubedbcom-mongodbschemaoverview-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/uikubedbcom-mongodbschemaoverview-editor/README.md
+++ b/charts/uikubedbcom-mongodbschemaoverview-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/uikubedbcom-mongodbschemaoverview-editor --version=v0.4.8
-$ helm upgrade -i uikubedbcom-mongodbschemaoverview-editor bytebuilders-ui/uikubedbcom-mongodbschemaoverview-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/uikubedbcom-mongodbschemaoverview-editor --version=v0.4.9
+$ helm upgrade -i uikubedbcom-mongodbschemaoverview-editor bytebuilders-ui/uikubedbcom-mongodbschemaoverview-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a MongoDBSchemaOverview Editor on a [Kubernetes](http://kuber
 To install/upgrade the chart with the release name `uikubedbcom-mongodbschemaoverview-editor`:
 
 ```bash
-$ helm upgrade -i uikubedbcom-mongodbschemaoverview-editor bytebuilders-ui/uikubedbcom-mongodbschemaoverview-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i uikubedbcom-mongodbschemaoverview-editor bytebuilders-ui/uikubedbcom-mongodbschemaoverview-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a MongoDBSchemaOverview Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `uikubedbcom-mongod
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i uikubedbcom-mongodbschemaoverview-editor bytebuilders-ui/uikubedbcom-mongodbschemaoverview-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=ui.kubedb.com/v1alpha1
+$ helm upgrade -i uikubedbcom-mongodbschemaoverview-editor bytebuilders-ui/uikubedbcom-mongodbschemaoverview-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=ui.kubedb.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i uikubedbcom-mongodbschemaoverview-editor bytebuilders-ui/uikubedbcom-mongodbschemaoverview-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i uikubedbcom-mongodbschemaoverview-editor bytebuilders-ui/uikubedbcom-mongodbschemaoverview-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/uikubedbcom-mysqlinsight-editor/Chart.yaml
+++ b/charts/uikubedbcom-mysqlinsight-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"ui.kubedb.com","version":"v1alpha1","resource":"mysqlinsights"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: MySQLInsight Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: uikubedbcom-mysqlinsight-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/uikubedbcom-mysqlinsight-editor/README.md
+++ b/charts/uikubedbcom-mysqlinsight-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/uikubedbcom-mysqlinsight-editor --version=v0.4.8
-$ helm upgrade -i uikubedbcom-mysqlinsight-editor bytebuilders-ui/uikubedbcom-mysqlinsight-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/uikubedbcom-mysqlinsight-editor --version=v0.4.9
+$ helm upgrade -i uikubedbcom-mysqlinsight-editor bytebuilders-ui/uikubedbcom-mysqlinsight-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a MySQLInsight Editor on a [Kubernetes](http://kubernetes.io)
 To install/upgrade the chart with the release name `uikubedbcom-mysqlinsight-editor`:
 
 ```bash
-$ helm upgrade -i uikubedbcom-mysqlinsight-editor bytebuilders-ui/uikubedbcom-mysqlinsight-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i uikubedbcom-mysqlinsight-editor bytebuilders-ui/uikubedbcom-mysqlinsight-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a MySQLInsight Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `uikubedbcom-mysqli
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i uikubedbcom-mysqlinsight-editor bytebuilders-ui/uikubedbcom-mysqlinsight-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=ui.kubedb.com/v1alpha1
+$ helm upgrade -i uikubedbcom-mysqlinsight-editor bytebuilders-ui/uikubedbcom-mysqlinsight-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=ui.kubedb.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i uikubedbcom-mysqlinsight-editor bytebuilders-ui/uikubedbcom-mysqlinsight-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i uikubedbcom-mysqlinsight-editor bytebuilders-ui/uikubedbcom-mysqlinsight-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/uikubedbcom-mysqlqueries-editor/Chart.yaml
+++ b/charts/uikubedbcom-mysqlqueries-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"ui.kubedb.com","version":"v1alpha1","resource":"mysqlqueries"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: MySQLQueries Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: uikubedbcom-mysqlqueries-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/uikubedbcom-mysqlqueries-editor/README.md
+++ b/charts/uikubedbcom-mysqlqueries-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/uikubedbcom-mysqlqueries-editor --version=v0.4.8
-$ helm upgrade -i uikubedbcom-mysqlqueries-editor bytebuilders-ui/uikubedbcom-mysqlqueries-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/uikubedbcom-mysqlqueries-editor --version=v0.4.9
+$ helm upgrade -i uikubedbcom-mysqlqueries-editor bytebuilders-ui/uikubedbcom-mysqlqueries-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a MySQLQueries Editor on a [Kubernetes](http://kubernetes.io)
 To install/upgrade the chart with the release name `uikubedbcom-mysqlqueries-editor`:
 
 ```bash
-$ helm upgrade -i uikubedbcom-mysqlqueries-editor bytebuilders-ui/uikubedbcom-mysqlqueries-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i uikubedbcom-mysqlqueries-editor bytebuilders-ui/uikubedbcom-mysqlqueries-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a MySQLQueries Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `uikubedbcom-mysqlq
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i uikubedbcom-mysqlqueries-editor bytebuilders-ui/uikubedbcom-mysqlqueries-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=ui.kubedb.com/v1alpha1
+$ helm upgrade -i uikubedbcom-mysqlqueries-editor bytebuilders-ui/uikubedbcom-mysqlqueries-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=ui.kubedb.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i uikubedbcom-mysqlqueries-editor bytebuilders-ui/uikubedbcom-mysqlqueries-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i uikubedbcom-mysqlqueries-editor bytebuilders-ui/uikubedbcom-mysqlqueries-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/uikubedbcom-mysqlschemaoverview-editor/Chart.yaml
+++ b/charts/uikubedbcom-mysqlschemaoverview-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"ui.kubedb.com","version":"v1alpha1","resource":"mysqlschemaoverviews"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: MySQLSchemaOverview Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: uikubedbcom-mysqlschemaoverview-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/uikubedbcom-mysqlschemaoverview-editor/README.md
+++ b/charts/uikubedbcom-mysqlschemaoverview-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/uikubedbcom-mysqlschemaoverview-editor --version=v0.4.8
-$ helm upgrade -i uikubedbcom-mysqlschemaoverview-editor bytebuilders-ui/uikubedbcom-mysqlschemaoverview-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/uikubedbcom-mysqlschemaoverview-editor --version=v0.4.9
+$ helm upgrade -i uikubedbcom-mysqlschemaoverview-editor bytebuilders-ui/uikubedbcom-mysqlschemaoverview-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a MySQLSchemaOverview Editor on a [Kubernetes](http://kuberne
 To install/upgrade the chart with the release name `uikubedbcom-mysqlschemaoverview-editor`:
 
 ```bash
-$ helm upgrade -i uikubedbcom-mysqlschemaoverview-editor bytebuilders-ui/uikubedbcom-mysqlschemaoverview-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i uikubedbcom-mysqlschemaoverview-editor bytebuilders-ui/uikubedbcom-mysqlschemaoverview-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a MySQLSchemaOverview Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `uikubedbcom-mysqls
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i uikubedbcom-mysqlschemaoverview-editor bytebuilders-ui/uikubedbcom-mysqlschemaoverview-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=ui.kubedb.com/v1alpha1
+$ helm upgrade -i uikubedbcom-mysqlschemaoverview-editor bytebuilders-ui/uikubedbcom-mysqlschemaoverview-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=ui.kubedb.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i uikubedbcom-mysqlschemaoverview-editor bytebuilders-ui/uikubedbcom-mysqlschemaoverview-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i uikubedbcom-mysqlschemaoverview-editor bytebuilders-ui/uikubedbcom-mysqlschemaoverview-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/uikubedbcom-postgresinsight-editor/Chart.yaml
+++ b/charts/uikubedbcom-postgresinsight-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"ui.kubedb.com","version":"v1alpha1","resource":"postgresinsights"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: PostgresInsight Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: uikubedbcom-postgresinsight-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/uikubedbcom-postgresinsight-editor/README.md
+++ b/charts/uikubedbcom-postgresinsight-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/uikubedbcom-postgresinsight-editor --version=v0.4.8
-$ helm upgrade -i uikubedbcom-postgresinsight-editor bytebuilders-ui/uikubedbcom-postgresinsight-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/uikubedbcom-postgresinsight-editor --version=v0.4.9
+$ helm upgrade -i uikubedbcom-postgresinsight-editor bytebuilders-ui/uikubedbcom-postgresinsight-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a PostgresInsight Editor on a [Kubernetes](http://kubernetes.
 To install/upgrade the chart with the release name `uikubedbcom-postgresinsight-editor`:
 
 ```bash
-$ helm upgrade -i uikubedbcom-postgresinsight-editor bytebuilders-ui/uikubedbcom-postgresinsight-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i uikubedbcom-postgresinsight-editor bytebuilders-ui/uikubedbcom-postgresinsight-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a PostgresInsight Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `uikubedbcom-postgr
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i uikubedbcom-postgresinsight-editor bytebuilders-ui/uikubedbcom-postgresinsight-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=ui.kubedb.com/v1alpha1
+$ helm upgrade -i uikubedbcom-postgresinsight-editor bytebuilders-ui/uikubedbcom-postgresinsight-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=ui.kubedb.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i uikubedbcom-postgresinsight-editor bytebuilders-ui/uikubedbcom-postgresinsight-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i uikubedbcom-postgresinsight-editor bytebuilders-ui/uikubedbcom-postgresinsight-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/uikubedbcom-postgresqueries-editor/Chart.yaml
+++ b/charts/uikubedbcom-postgresqueries-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"ui.kubedb.com","version":"v1alpha1","resource":"postgresqueries"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: PostgresQueries Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: uikubedbcom-postgresqueries-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/uikubedbcom-postgresqueries-editor/README.md
+++ b/charts/uikubedbcom-postgresqueries-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/uikubedbcom-postgresqueries-editor --version=v0.4.8
-$ helm upgrade -i uikubedbcom-postgresqueries-editor bytebuilders-ui/uikubedbcom-postgresqueries-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/uikubedbcom-postgresqueries-editor --version=v0.4.9
+$ helm upgrade -i uikubedbcom-postgresqueries-editor bytebuilders-ui/uikubedbcom-postgresqueries-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a PostgresQueries Editor on a [Kubernetes](http://kubernetes.
 To install/upgrade the chart with the release name `uikubedbcom-postgresqueries-editor`:
 
 ```bash
-$ helm upgrade -i uikubedbcom-postgresqueries-editor bytebuilders-ui/uikubedbcom-postgresqueries-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i uikubedbcom-postgresqueries-editor bytebuilders-ui/uikubedbcom-postgresqueries-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a PostgresQueries Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `uikubedbcom-postgr
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i uikubedbcom-postgresqueries-editor bytebuilders-ui/uikubedbcom-postgresqueries-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=ui.kubedb.com/v1alpha1
+$ helm upgrade -i uikubedbcom-postgresqueries-editor bytebuilders-ui/uikubedbcom-postgresqueries-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=ui.kubedb.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i uikubedbcom-postgresqueries-editor bytebuilders-ui/uikubedbcom-postgresqueries-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i uikubedbcom-postgresqueries-editor bytebuilders-ui/uikubedbcom-postgresqueries-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/uikubedbcom-postgresschemaoverview-editor/Chart.yaml
+++ b/charts/uikubedbcom-postgresschemaoverview-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"ui.kubedb.com","version":"v1alpha1","resource":"postgresschemaoverviews"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: PostgresSchemaOverview Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: uikubedbcom-postgresschemaoverview-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/uikubedbcom-postgresschemaoverview-editor/README.md
+++ b/charts/uikubedbcom-postgresschemaoverview-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/uikubedbcom-postgresschemaoverview-editor --version=v0.4.8
-$ helm upgrade -i uikubedbcom-postgresschemaoverview-editor bytebuilders-ui/uikubedbcom-postgresschemaoverview-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/uikubedbcom-postgresschemaoverview-editor --version=v0.4.9
+$ helm upgrade -i uikubedbcom-postgresschemaoverview-editor bytebuilders-ui/uikubedbcom-postgresschemaoverview-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a PostgresSchemaOverview Editor on a [Kubernetes](http://kube
 To install/upgrade the chart with the release name `uikubedbcom-postgresschemaoverview-editor`:
 
 ```bash
-$ helm upgrade -i uikubedbcom-postgresschemaoverview-editor bytebuilders-ui/uikubedbcom-postgresschemaoverview-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i uikubedbcom-postgresschemaoverview-editor bytebuilders-ui/uikubedbcom-postgresschemaoverview-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a PostgresSchemaOverview Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `uikubedbcom-postgr
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i uikubedbcom-postgresschemaoverview-editor bytebuilders-ui/uikubedbcom-postgresschemaoverview-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=ui.kubedb.com/v1alpha1
+$ helm upgrade -i uikubedbcom-postgresschemaoverview-editor bytebuilders-ui/uikubedbcom-postgresschemaoverview-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=ui.kubedb.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i uikubedbcom-postgresschemaoverview-editor bytebuilders-ui/uikubedbcom-postgresschemaoverview-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i uikubedbcom-postgresschemaoverview-editor bytebuilders-ui/uikubedbcom-postgresschemaoverview-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/uikubedbcom-postgressettings-editor/Chart.yaml
+++ b/charts/uikubedbcom-postgressettings-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"ui.kubedb.com","version":"v1alpha1","resource":"postgressettings"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: PostgresSettings Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: uikubedbcom-postgressettings-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/uikubedbcom-postgressettings-editor/README.md
+++ b/charts/uikubedbcom-postgressettings-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/uikubedbcom-postgressettings-editor --version=v0.4.8
-$ helm upgrade -i uikubedbcom-postgressettings-editor bytebuilders-ui/uikubedbcom-postgressettings-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/uikubedbcom-postgressettings-editor --version=v0.4.9
+$ helm upgrade -i uikubedbcom-postgressettings-editor bytebuilders-ui/uikubedbcom-postgressettings-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a PostgresSettings Editor on a [Kubernetes](http://kubernetes
 To install/upgrade the chart with the release name `uikubedbcom-postgressettings-editor`:
 
 ```bash
-$ helm upgrade -i uikubedbcom-postgressettings-editor bytebuilders-ui/uikubedbcom-postgressettings-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i uikubedbcom-postgressettings-editor bytebuilders-ui/uikubedbcom-postgressettings-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a PostgresSettings Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `uikubedbcom-postgr
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i uikubedbcom-postgressettings-editor bytebuilders-ui/uikubedbcom-postgressettings-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=ui.kubedb.com/v1alpha1
+$ helm upgrade -i uikubedbcom-postgressettings-editor bytebuilders-ui/uikubedbcom-postgressettings-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=ui.kubedb.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i uikubedbcom-postgressettings-editor bytebuilders-ui/uikubedbcom-postgressettings-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i uikubedbcom-postgressettings-editor bytebuilders-ui/uikubedbcom-postgressettings-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/uikubedbcom-redisinsight-editor/Chart.yaml
+++ b/charts/uikubedbcom-redisinsight-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"ui.kubedb.com","version":"v1alpha1","resource":"redisinsights"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: RedisInsight Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: uikubedbcom-redisinsight-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/uikubedbcom-redisinsight-editor/README.md
+++ b/charts/uikubedbcom-redisinsight-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/uikubedbcom-redisinsight-editor --version=v0.4.8
-$ helm upgrade -i uikubedbcom-redisinsight-editor bytebuilders-ui/uikubedbcom-redisinsight-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/uikubedbcom-redisinsight-editor --version=v0.4.9
+$ helm upgrade -i uikubedbcom-redisinsight-editor bytebuilders-ui/uikubedbcom-redisinsight-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a RedisInsight Editor on a [Kubernetes](http://kubernetes.io)
 To install/upgrade the chart with the release name `uikubedbcom-redisinsight-editor`:
 
 ```bash
-$ helm upgrade -i uikubedbcom-redisinsight-editor bytebuilders-ui/uikubedbcom-redisinsight-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i uikubedbcom-redisinsight-editor bytebuilders-ui/uikubedbcom-redisinsight-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a RedisInsight Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `uikubedbcom-redisi
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i uikubedbcom-redisinsight-editor bytebuilders-ui/uikubedbcom-redisinsight-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=ui.kubedb.com/v1alpha1
+$ helm upgrade -i uikubedbcom-redisinsight-editor bytebuilders-ui/uikubedbcom-redisinsight-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=ui.kubedb.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i uikubedbcom-redisinsight-editor bytebuilders-ui/uikubedbcom-redisinsight-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i uikubedbcom-redisinsight-editor bytebuilders-ui/uikubedbcom-redisinsight-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/uikubedbcom-redisqueries-editor/Chart.yaml
+++ b/charts/uikubedbcom-redisqueries-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"ui.kubedb.com","version":"v1alpha1","resource":"redisqueries"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: RedisQueries Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: uikubedbcom-redisqueries-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/uikubedbcom-redisqueries-editor/README.md
+++ b/charts/uikubedbcom-redisqueries-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/uikubedbcom-redisqueries-editor --version=v0.4.8
-$ helm upgrade -i uikubedbcom-redisqueries-editor bytebuilders-ui/uikubedbcom-redisqueries-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/uikubedbcom-redisqueries-editor --version=v0.4.9
+$ helm upgrade -i uikubedbcom-redisqueries-editor bytebuilders-ui/uikubedbcom-redisqueries-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a RedisQueries Editor on a [Kubernetes](http://kubernetes.io)
 To install/upgrade the chart with the release name `uikubedbcom-redisqueries-editor`:
 
 ```bash
-$ helm upgrade -i uikubedbcom-redisqueries-editor bytebuilders-ui/uikubedbcom-redisqueries-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i uikubedbcom-redisqueries-editor bytebuilders-ui/uikubedbcom-redisqueries-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a RedisQueries Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `uikubedbcom-redisq
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i uikubedbcom-redisqueries-editor bytebuilders-ui/uikubedbcom-redisqueries-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=ui.kubedb.com/v1alpha1
+$ helm upgrade -i uikubedbcom-redisqueries-editor bytebuilders-ui/uikubedbcom-redisqueries-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=ui.kubedb.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i uikubedbcom-redisqueries-editor bytebuilders-ui/uikubedbcom-redisqueries-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i uikubedbcom-redisqueries-editor bytebuilders-ui/uikubedbcom-redisqueries-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/uikubedbcom-redisschemaoverview-editor/Chart.yaml
+++ b/charts/uikubedbcom-redisschemaoverview-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"ui.kubedb.com","version":"v1alpha1","resource":"redisschemaoverviews"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: RedisSchemaOverview Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: uikubedbcom-redisschemaoverview-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/uikubedbcom-redisschemaoverview-editor/README.md
+++ b/charts/uikubedbcom-redisschemaoverview-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/uikubedbcom-redisschemaoverview-editor --version=v0.4.8
-$ helm upgrade -i uikubedbcom-redisschemaoverview-editor bytebuilders-ui/uikubedbcom-redisschemaoverview-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/uikubedbcom-redisschemaoverview-editor --version=v0.4.9
+$ helm upgrade -i uikubedbcom-redisschemaoverview-editor bytebuilders-ui/uikubedbcom-redisschemaoverview-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a RedisSchemaOverview Editor on a [Kubernetes](http://kuberne
 To install/upgrade the chart with the release name `uikubedbcom-redisschemaoverview-editor`:
 
 ```bash
-$ helm upgrade -i uikubedbcom-redisschemaoverview-editor bytebuilders-ui/uikubedbcom-redisschemaoverview-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i uikubedbcom-redisschemaoverview-editor bytebuilders-ui/uikubedbcom-redisschemaoverview-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a RedisSchemaOverview Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `uikubedbcom-rediss
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i uikubedbcom-redisschemaoverview-editor bytebuilders-ui/uikubedbcom-redisschemaoverview-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=ui.kubedb.com/v1alpha1
+$ helm upgrade -i uikubedbcom-redisschemaoverview-editor bytebuilders-ui/uikubedbcom-redisschemaoverview-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=ui.kubedb.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i uikubedbcom-redisschemaoverview-editor bytebuilders-ui/uikubedbcom-redisschemaoverview-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i uikubedbcom-redisschemaoverview-editor bytebuilders-ui/uikubedbcom-redisschemaoverview-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/uistashappscodecom-backupoverview-editor/Chart.yaml
+++ b/charts/uistashappscodecom-backupoverview-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"ui.stash.appscode.com","version":"v1alpha1","resource":"backupoverviews"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: BackupOverview Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: uistashappscodecom-backupoverview-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/uistashappscodecom-backupoverview-editor/README.md
+++ b/charts/uistashappscodecom-backupoverview-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/uistashappscodecom-backupoverview-editor --version=v0.4.8
-$ helm upgrade -i uistashappscodecom-backupoverview-editor bytebuilders-ui/uistashappscodecom-backupoverview-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/uistashappscodecom-backupoverview-editor --version=v0.4.9
+$ helm upgrade -i uistashappscodecom-backupoverview-editor bytebuilders-ui/uistashappscodecom-backupoverview-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a BackupOverview Editor on a [Kubernetes](http://kubernetes.i
 To install/upgrade the chart with the release name `uistashappscodecom-backupoverview-editor`:
 
 ```bash
-$ helm upgrade -i uistashappscodecom-backupoverview-editor bytebuilders-ui/uistashappscodecom-backupoverview-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i uistashappscodecom-backupoverview-editor bytebuilders-ui/uistashappscodecom-backupoverview-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a BackupOverview Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `uistashappscodecom
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i uistashappscodecom-backupoverview-editor bytebuilders-ui/uistashappscodecom-backupoverview-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=ui.stash.appscode.com/v1alpha1
+$ helm upgrade -i uistashappscodecom-backupoverview-editor bytebuilders-ui/uistashappscodecom-backupoverview-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=ui.stash.appscode.com/v1alpha1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i uistashappscodecom-backupoverview-editor bytebuilders-ui/uistashappscodecom-backupoverview-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i uistashappscodecom-backupoverview-editor bytebuilders-ui/uistashappscodecom-backupoverview-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/voyagerappscodecom-certificate-editor/Chart.yaml
+++ b/charts/voyagerappscodecom-certificate-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"voyager.appscode.com","version":"v1beta1","resource":"certificates"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: Certificate Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: voyagerappscodecom-certificate-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/voyagerappscodecom-certificate-editor/README.md
+++ b/charts/voyagerappscodecom-certificate-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/voyagerappscodecom-certificate-editor --version=v0.4.8
-$ helm upgrade -i voyagerappscodecom-certificate-editor bytebuilders-ui/voyagerappscodecom-certificate-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/voyagerappscodecom-certificate-editor --version=v0.4.9
+$ helm upgrade -i voyagerappscodecom-certificate-editor bytebuilders-ui/voyagerappscodecom-certificate-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a Certificate Editor on a [Kubernetes](http://kubernetes.io) 
 To install/upgrade the chart with the release name `voyagerappscodecom-certificate-editor`:
 
 ```bash
-$ helm upgrade -i voyagerappscodecom-certificate-editor bytebuilders-ui/voyagerappscodecom-certificate-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i voyagerappscodecom-certificate-editor bytebuilders-ui/voyagerappscodecom-certificate-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a Certificate Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `voyagerappscodecom
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i voyagerappscodecom-certificate-editor bytebuilders-ui/voyagerappscodecom-certificate-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=voyager.appscode.com/v1beta1
+$ helm upgrade -i voyagerappscodecom-certificate-editor bytebuilders-ui/voyagerappscodecom-certificate-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=voyager.appscode.com/v1beta1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i voyagerappscodecom-certificate-editor bytebuilders-ui/voyagerappscodecom-certificate-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i voyagerappscodecom-certificate-editor bytebuilders-ui/voyagerappscodecom-certificate-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```

--- a/charts/voyagerappscodecom-ingress-editor/Chart.yaml
+++ b/charts/voyagerappscodecom-ingress-editor/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   meta.x-helm.dev/editor: '{"group":"voyager.appscode.com","version":"v1","resource":"ingresses"}'
 apiVersion: v2
-appVersion: v0.4.8
+appVersion: v0.4.9
 description: Ingress Editor
 home: https://byte.builders
 icon: https://cdn.appscode.com/images/products/bytebuilders/bytebuilders-512x512.png
@@ -13,4 +13,4 @@ maintainers:
   name: appscode
 name: voyagerappscodecom-ingress-editor
 type: application
-version: v0.4.8
+version: v0.4.9

--- a/charts/voyagerappscodecom-ingress-editor/README.md
+++ b/charts/voyagerappscodecom-ingress-editor/README.md
@@ -7,8 +7,8 @@
 ```bash
 $ helm repo add bytebuilders-ui https://bundles.byte.builders/ui/
 $ helm repo update
-$ helm search repo bytebuilders-ui/voyagerappscodecom-ingress-editor --version=v0.4.8
-$ helm upgrade -i voyagerappscodecom-ingress-editor bytebuilders-ui/voyagerappscodecom-ingress-editor -n default --create-namespace --version=v0.4.8
+$ helm search repo bytebuilders-ui/voyagerappscodecom-ingress-editor --version=v0.4.9
+$ helm upgrade -i voyagerappscodecom-ingress-editor bytebuilders-ui/voyagerappscodecom-ingress-editor -n default --create-namespace --version=v0.4.9
 ```
 
 ## Introduction
@@ -24,7 +24,7 @@ This chart deploys a Ingress Editor on a [Kubernetes](http://kubernetes.io) clus
 To install/upgrade the chart with the release name `voyagerappscodecom-ingress-editor`:
 
 ```bash
-$ helm upgrade -i voyagerappscodecom-ingress-editor bytebuilders-ui/voyagerappscodecom-ingress-editor -n default --create-namespace --version=v0.4.8
+$ helm upgrade -i voyagerappscodecom-ingress-editor bytebuilders-ui/voyagerappscodecom-ingress-editor -n default --create-namespace --version=v0.4.9
 ```
 
 The command deploys a Ingress Editor on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -56,12 +56,12 @@ The following table lists the configurable parameters of the `voyagerappscodecom
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm upgrade -i`. For example:
 
 ```bash
-$ helm upgrade -i voyagerappscodecom-ingress-editor bytebuilders-ui/voyagerappscodecom-ingress-editor -n default --create-namespace --version=v0.4.8 --set apiVersion=voyager.appscode.com/v1
+$ helm upgrade -i voyagerappscodecom-ingress-editor bytebuilders-ui/voyagerappscodecom-ingress-editor -n default --create-namespace --version=v0.4.9 --set apiVersion=voyager.appscode.com/v1
 ```
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while
 installing the chart. For example:
 
 ```bash
-$ helm upgrade -i voyagerappscodecom-ingress-editor bytebuilders-ui/voyagerappscodecom-ingress-editor -n default --create-namespace --version=v0.4.8 --values values.yaml
+$ helm upgrade -i voyagerappscodecom-ingress-editor bytebuilders-ui/voyagerappscodecom-ingress-editor -n default --create-namespace --version=v0.4.9 --values values.yaml
 ```


### PR DESCRIPTION
ProductLine: ByteBuilders
Release: v2022.08.01
Release-tracker: https://github.com/bytebuilders/CHANGELOG/pull/29
Signed-off-by: 1gtm <1gtm@appscode.com>