### PR TITLE
added rabbitmq ops request form

### DIFF
--- a/charts/kubedbcom-rabbitmq-editor/ui/edit-ui.yaml
+++ b/charts/kubedbcom-rabbitmq-editor/ui/edit-ui.yaml
@@ -238,10 +238,7 @@ step:
           schema: schema/properties/resources/properties/autoscalingKubedbComRabbitMQAutoscaler/properties/spec/properties/storage/properties/rabbitmq/properties/usageThreshold
           subtitle: Set the threshold percentage of storage usage that triggers autoscaling
           type: threshold-input
-        - init:
-            type: func
-            value: setValueFromDbDetails|resources/kubedbComRabbitMQ/spec/storage/resources/requests/storage
-          label: Scaling Rules
+        - label: Scaling Rules
           loader: setValueFromDbDetails|resources/kubedbComRabbitMQ/spec/storage/resources/requests/storage
           schema: schema/properties/resources/properties/autoscalingKubedbComRabbitMQAutoscaler/properties/spec/properties/storage/properties/rabbitmq/properties/scalingRules
           type: scaling-rules

--- a/charts/kubedbcom-rabbitmq-editor/ui/functions.js
+++ b/charts/kubedbcom-rabbitmq-editor/ui/functions.js
@@ -29,16 +29,8 @@ export const useFunc = (model) => {
   // Compute Autoscaler Discriminators
   setDiscriminatorValue('/dbDetails', false)
   setDiscriminatorValue('/topologyMachines', [])
-  setDiscriminatorValue('/allowedMachine-standalone-min', '')
-  setDiscriminatorValue('/allowedMachine-standalone-max', '')
-  setDiscriminatorValue('/allowedMachine-replicaSet-min', '')
-  setDiscriminatorValue('/allowedMachine-replicaSet-max', '')
-  setDiscriminatorValue('/allowedMachine-shard-min', '')
-  setDiscriminatorValue('/allowedMachine-shard-max', '')
-  setDiscriminatorValue('/allowedMachine-configServer-min', '')
-  setDiscriminatorValue('/allowedMachine-configServer-max', '')
-  setDiscriminatorValue('/allowedMachine-mongos-min', '')
-  setDiscriminatorValue('/allowedMachine-mongos-max', '')
+  setDiscriminatorValue('/allowedMachine-node-min', '')
+  setDiscriminatorValue('/allowedMachine-node-max', '')
 
   // monitoring
 
@@ -877,7 +869,7 @@ export const useFunc = (model) => {
     const labels = getValue(model, '/resources/kubedbComRabbitMQ/metadata/labels')
     const bindingValues = {
       apiVersion: 'catalog.appscode.com/v1alpha1',
-      kind: 'PostgresBinding',
+      kind: 'RabbitMQBinding',
       metadata: {
         labels,
         name: dbName,

--- a/charts/kubedbcom-rabbitmq-editor/ui/functions.js
+++ b/charts/kubedbcom-rabbitmq-editor/ui/functions.js
@@ -211,11 +211,22 @@ export const useFunc = (model) => {
     const pathSplit = pathPrefix.split('/').slice(0, -1).join('/')
     const pathConstructedForKubedb = pathSplit + `/${reqType.toLowerCase()}?namespace=${namespace}`
 
+    const requestTypeMap = {
+      'update-version': 'UpdateVersion',
+      'scale-vertically': 'VerticalScaling',
+      'scale-storage': 'VolumeExpansion',
+      'horizontal-scale': 'HorizontalScaling',
+      restart: 'Restart',
+      reconfigure: 'Reconfigure',
+      'tls-configure': 'ReconfigureTLS',
+    }
+    const requestType = requestTypeMap[reqType] || 'VerticalScaling'
+
     const isKube = !!storeGet('/route/params/actions')
 
     if (isKube) return pathConstructedForKubedb
     else
-      return `${domain}/console/${owner}/kubernetes/${cluster}/ops.kubedb.com/v1alpha1/rabbitmqopsrequests/create?name=${dbname}&namespace=${namespace}&group=${group}&version=${version}&resource=${resource}&kind=${kind}&page=operations&requestType=VerticalScaling`
+      return `${domain}/console/${owner}/kubernetes/${cluster}/ops.kubedb.com/v1alpha1/rabbitmqopsrequests/create?name=${dbname}&namespace=${namespace}&group=${group}&version=${version}&resource=${resource}&kind=${kind}&page=operations&requestType=${requestType}`
   }
 
   function onNamespaceChange() {

--- a/charts/opskubedbcom-rabbitmqopsrequest-editor/ui/create-ui.yaml
+++ b/charts/opskubedbcom-rabbitmqopsrequest-editor/ui/create-ui.yaml
@@ -191,43 +191,19 @@ step:
           type: label-element
         - elements:
           - label: Key
-            schema: schema/properties/spec/properties/verticalScaling/properties/node/properties/topology/properties/key
+            schema: temp/topologyKey
             type: input
             validation:
               name: isVerticalScaleTopologyRequired
               type: custom
           - label: Value
-            schema: schema/properties/spec/properties/verticalScaling/properties/node/properties/topology/properties/value
+            schema: temp/topologyValue
             type: input
             validation:
               name: isVerticalScaleTopologyRequired
               type: custom
           type: horizontal-layout
         label: Node Selection
-        showLabels: true
-        type: block-layout
-      - elements:
-        - elements:
-          - init:
-              type: func
-              value: setExporter|cpu
-            label: CPU
-            schema: schema/properties/spec/properties/verticalScaling/properties/exporter/properties/resources/properties/requests/properties/cpu
-            type: input
-          - init:
-              type: func
-              value: setExporter|memory
-            label: Memory
-            schema: schema/properties/spec/properties/verticalScaling/properties/exporter/properties/resources/properties/limits/properties/memory
-            type: input
-            watcher:
-              func: onExporterResourceChange|memory
-              paths:
-              - schema/properties/spec/properties/verticalScaling/properties/exporter/properties/resources/properties/limits/properties/memory
-          showLabels: true
-          type: horizontal-layout
-        hideBlock: true
-        label: Exporter
         showLabels: true
         type: block-layout
       label: Node

--- a/charts/opskubedbcom-rabbitmqopsrequest-editor/ui/create-ui.yaml
+++ b/charts/opskubedbcom-rabbitmqopsrequest-editor/ui/create-ui.yaml
@@ -82,10 +82,9 @@ step:
     schema: schema/properties/spec/properties/type
     type: radio
     watcher:
-      func: isDbDetailsLoading
+      func: onRequestTypeChange
       paths:
-      - temp/dbDetails
-      - schema/properties/spec/properties/databaseRef/properties/name
+      - schema/properties/spec/properties/type
   - elements:
     - init:
         type: func

--- a/charts/opskubedbcom-rabbitmqopsrequest-editor/ui/functions.js
+++ b/charts/opskubedbcom-rabbitmqopsrequest-editor/ui/functions.js
@@ -540,6 +540,7 @@ export const useFunc = (model) => {
   }
 
   function getVersion() {
+    const filteredVersion = getValue(discriminator, '/filteredVersion')
     return filteredVersion.map((item) => {
       const name = (item.metadata && item.metadata.name) || ''
       const specVersion = (item.spec && item.spec.version) || ''
@@ -617,12 +618,7 @@ export const useFunc = (model) => {
   }
 
   function disableOpsRequest() {
-    if (itemCtx.value === 'HorizontalScaling') {
-      const dbType = getDbType()
-
-      if (dbType === 'Standalone') return true
-      else return false
-    } else return false
+    return false
   }
 
   function getDbTls() {
@@ -1805,18 +1801,6 @@ export const useFunc = (model) => {
     return limitVal
   }
 
-  function onExporterResourceChange(type) {
-    const commitPath = `/spec/verticalScaling/exporter/resources/requests/${type}`
-    const valPath = `/spec/verticalScaling/exporter/resources/limits/${type}`
-    const val = getValue(model, valPath)
-    if (val)
-      commit('wizard/model$update', {
-        path: commitPath,
-        value: val,
-        force: true,
-      })
-  }
-
   function isMachineValid() {
     const dbDetails = getValue(discriminator, '/dbDetails')
     const containers = dbDetails?.spec?.podTemplate?.spec?.containers || []
@@ -1836,7 +1820,6 @@ export const useFunc = (model) => {
   return {
     isMachineValid,
     setExporter,
-    onExporterResourceChange,
     fetchAliasOptions,
     validateNewCertificates,
     disableAlias,

--- a/charts/opskubedbcom-rabbitmqopsrequest-editor/ui/functions.js
+++ b/charts/opskubedbcom-rabbitmqopsrequest-editor/ui/functions.js
@@ -1614,6 +1614,18 @@ export const useFunc = (model) => {
     return resource[0].resources
   }
 
+  function setConfigFiles() {
+    const configFiles = getValue(model, '/resources/secret_config/stringData')
+    const files = []
+    for (const item in configFiles) {
+      const obj = {}
+      obj.key = item
+      obj.value = configFiles[item]
+      files.push(obj)
+    }
+    return files
+  }
+
   function getAliasOptions() {
     return ['server', 'client', 'metrics-exporter']
   }
@@ -1829,6 +1841,7 @@ export const useFunc = (model) => {
     validateNewCertificates,
     disableAlias,
     setResource,
+    setConfigFiles,
     fetchJsons,
     returnFalse,
     getNamespaces,


### PR DESCRIPTION
- Fix ops request type radio watcher to use onRequestTypeChange so the form sections show/hide correctly when switching between ops types
- Add requestTypeMap to getOpsRequestUrl so console navigation routes to the correct ops request type (UpdateVersion, HorizontalScaling, etc.)
- Add setConfigFiles utility function to ops request editor functions