### PR TITLE
Split announce shard endpoints from comma-separated input in redis editor

### DIFF
--- a/charts/kubedbcom-redis-editor-options/ui/create-ui.yaml
+++ b/charts/kubedbcom-redis-editor-options/ui/create-ui.yaml
@@ -168,9 +168,16 @@ step:
     - element:
         label: Shard Endpoints (comma-separated, e.g. "endpoint1,endpoint2,endpoint3")
         type: input
+      init:
+        type: func
+        value: setAnnounceShards
       label: Shards
-      schema: schema/properties/spec/properties/cluster/properties/announce/properties/shards
+      schema: temp/announceShards
       type: array-item-form
+      watcher:
+        func: onAnnounceShardsChange
+        paths:
+        - temp/announceShards
     if:
       name: showAnnounce
       type: function

--- a/charts/kubedbcom-redis-editor-options/ui/create-ui.yaml
+++ b/charts/kubedbcom-redis-editor-options/ui/create-ui.yaml
@@ -174,6 +174,9 @@ step:
       label: Shards
       schema: temp/announceShards
       type: array-item-form
+      validation:
+        type: custom
+        name: validateAnnounceShards
       watcher:
         func: onAnnounceShardsChange
         paths:

--- a/charts/kubedbcom-redis-editor-options/ui/functions.js
+++ b/charts/kubedbcom-redis-editor-options/ui/functions.js
@@ -1113,11 +1113,31 @@ export const useFunc = (model) => {
         .map((endpoint) => endpoint.trim())
         .filter((endpoint) => endpoint),
     }))
+
     commit('wizard/model$update', {
       path: '/spec/cluster/announce/shards',
       value: transformed,
       force: true,
     })
+  }
+
+  function validateAnnounceShards() {
+    const shards = getValue(discriminator, '/announceShards') || []
+    const master = getValue(model, '/spec/cluster/master') || 0
+    const replicas = getValue(model, '/spec/cluster/replicas') || 0
+    if (shards.length !== master) {
+      return `Shards Length should be equal to master(${master})`
+    }
+    for (let i = 0; i < shards.length; i++) {
+      const shard = shards[i]
+      const endpoints = shard
+        .split(',')
+        .map((endpoint) => endpoint.trim())
+        .filter((endpoint) => endpoint)
+      if (endpoints.length !== replicas) {
+        return `Each Shard should have ${replicas} comma-separated endpoints, but found ${endpoints.length}.`
+      }
+    }
   }
 
   function setBackup() {
@@ -1448,6 +1468,7 @@ export const useFunc = (model) => {
     isVariantAvailable,
     notEqualToDatabaseMode,
     onAnnounceShardsChange,
+    validateAnnounceShards,
     onAuthChange,
     onBackupSwitch,
     onCreateSentinelChange,

--- a/charts/kubedbcom-redis-editor-options/ui/functions.js
+++ b/charts/kubedbcom-redis-editor-options/ui/functions.js
@@ -1100,6 +1100,26 @@ export const useFunc = (model) => {
     })
   }
 
+  function setAnnounceShards() {
+    const shards = getValue(model, '/spec/cluster/announce/shards') || []
+    return shards.map((shard) => (shard?.endpoints || []).join(','))
+  }
+
+  function onAnnounceShardsChange() {
+    const shards = getValue(discriminator, '/announceShards') || []
+    const transformed = shards.map((shard) => ({
+      endpoints: (shard || '')
+        .split(',')
+        .map((endpoint) => endpoint.trim())
+        .filter((endpoint) => endpoint),
+    }))
+    commit('wizard/model$update', {
+      path: '/spec/cluster/announce/shards',
+      value: transformed,
+      force: true,
+    })
+  }
+
   function setBackup() {
     const backup = getValue(model, '/spec/backup/tool')
     const val = getValue(model, '/spec/admin/backup/enable/default')
@@ -1427,6 +1447,7 @@ export const useFunc = (model) => {
     isToggleOn,
     isVariantAvailable,
     notEqualToDatabaseMode,
+    onAnnounceShardsChange,
     onAuthChange,
     onBackupSwitch,
     onCreateSentinelChange,
@@ -1434,6 +1455,7 @@ export const useFunc = (model) => {
     returnFalse,
     returnTrue,
     setAnnounce,
+    setAnnounceShards,
     setBackup,
     setLimits,
     setMachineToCustom,


### PR DESCRIPTION
## What

The `announce.shards` field in `kubedbcom-redis-editor-options` takes string input, but the resource expects an array of objects shaped like `{ endpoints: ["endpoint1", "endpoint2"] }`.

## Changes

- **create-ui.yaml**: bind the shards `array-item-form` to `temp/announceShards` (comma-separated string per shard) instead of writing raw strings into the schema path; wire `init` and `watcher`.
- **functions.js**:
  - `setAnnounceShards()` — renders existing model shards as comma-joined strings for display.
  - `onAnnounceShardsChange()` — splits each comma-separated input into `{ endpoints: [...] }` and commits the correct shape to `/spec/cluster/announce/shards`.

Keeps the model in the schema-required shape, so `isAnnounceValid()`'s length-vs-master check still works.