### PR TITLE
add routers node to druid editor-options

### DIFF
--- a/apis/wizards/v1alpha1/kubedbcom_druid_editor_options_types.go
+++ b/apis/wizards/v1alpha1/kubedbcom_druid_editor_options_types.go
@@ -75,6 +75,7 @@ type DruidTopology struct {
 	MiddleManagers *DruidDataNode `json:"middleManagers"`
 	Historicals    *DruidDataNode `json:"historicals"`
 	Brokers        *DruidNode     `json:"brokers"`
+	Routers        *DruidNode     `json:"routers"`
 }
 
 type DruidDeepStorage struct {

--- a/charts/kubedbcom-druid-editor-options/templates/_helpers.tpl
+++ b/charts/kubedbcom-druid-editor-options/templates/_helpers.tpl
@@ -185,6 +185,17 @@ seccompProfile:
   {{- end }}
 {{- end }}
 
+{{- $routers_res = .Values.spec.topology.routers.podResources.resources -}}
+{{- if and .Values.spec.topology.routers.podResources.machine (hasKey $machines .Values.spec.topology.routers.podResources.machine) }}
+  {{- $routers_res = get (get $machines .Values.spec.topology.routers.podResources.machine) "resources" }}
+{{- end }}
+{{- range .Values.spec.admin.machineProfiles.machines }}
+  {{- if and $.Values.spec.topology.routers.podResources.machine (eq .id $.Values.spec.topology.routers.podResources.machine) }}
+    {{- $routers_res  = dict "requests" .limits "limits" .limits }}
+    {{- $_ := set $profiles "routers" .id }}
+  {{- end }}
+{{- end }}
+
 
 {{- $init_res := dict "limits" (dict "memory" "512Mi") "requests" (dict "cpu" "200m" "memory" "256Mi") -}}
 {{- $sidecar_res := dict "limits" (dict "memory" "256Mi") "requests" (dict "cpu" "200m" "memory" "256Mi") -}}
@@ -193,6 +204,7 @@ seccompProfile:
 {{- $_ := set . "middleManagers_res" $middleManagers_res -}}
 {{- $_ := set . "historicals_res" $historicals_res -}}
 {{- $_ := set . "brokers_res" $brokers_res -}}
+{{- $_ := set . "routers_res" $routers_res -}}
 {{- $_ = set . "init_res" $init_res -}}
 {{- $_ = set . "sidecar_res" $sidecar_res -}}
 

--- a/charts/kubedbcom-druid-editor-options/templates/autoscaler.yaml
+++ b/charts/kubedbcom-druid-editor-options/templates/autoscaler.yaml
@@ -42,6 +42,7 @@
     {{- $_ = set $instanceMap "middleManagers" (printf "%s,%s" $minMachine $maxMachine) }}
     {{- $_ = set $instanceMap "historicals" (printf "%s,%s" $minMachine $maxMachine) }}
     {{- $_ = set $instanceMap "brokers" (printf "%s,%s" $minMachine $maxMachine) }}
+    {{- $_ = set $instanceMap "routers" (printf "%s,%s" $minMachine $maxMachine) }}
 
     {{- $instanceMap | toJson | trim -}}
   {{- else }}
@@ -76,6 +77,8 @@ spec:
     historicals:
       {{- $commonCompute | toYaml | nindent 6 }}
     brokers:
+      {{- $commonCompute | toYaml | nindent 6 }}
+    routers:
       {{- $commonCompute | toYaml | nindent 6 }}
 {{- if eq .Values.spec.admin.deployment.default "Dedicated" }}
     nodeTopology:

--- a/charts/kubedbcom-druid-editor-options/templates/db.yaml
+++ b/charts/kubedbcom-druid-editor-options/templates/db.yaml
@@ -143,6 +143,22 @@ spec:
                 {{- toYaml .init_res | nindent 16 }}
               securityContext:
                 {{- include "container.securityContext" . | nindent 16 }}
+    routers:
+      replicas: {{ .Values.spec.topology.routers.replicas }}
+      podTemplate:
+        spec:
+          containers:
+          - name: druid
+            resources:
+              {{- toYaml .routers_res | nindent 14 }}
+            securityContext:
+              {{- include "container.securityContext" . | nindent 16 }}
+          initContainers:
+            - name: init-druid
+              resources:
+                {{- toYaml .init_res | nindent 16 }}
+              securityContext:
+                {{- include "container.securityContext" . | nindent 16 }}
   deepStorage:
     type: {{ .Values.spec.deepStorage.type }}
     configSecret:

--- a/charts/kubedbcom-druid-editor-options/ui/create-ui.yaml
+++ b/charts/kubedbcom-druid-editor-options/ui/create-ui.yaml
@@ -244,6 +244,60 @@ step:
       label: Coordinators
       showLabels: true
       type: block-layout
+    - elements:
+      - label: ""
+        subtitle: Router nodes provide a unified API gateway that routes queries and
+          requests to brokers, coordinators, and overlords. Configure replicas and
+          resource allocation for reliable request routing.
+        type: label-element
+      - label: Replicaset Number
+        schema: schema/properties/spec/properties/topology/properties/routers/properties/replicas
+        type: input
+      - elements:
+        - init:
+            type: func
+            value: setMachineToCustom
+          label: Machine
+          loader: getMachineListForOptions
+          schema: schema/properties/spec/properties/topology/properties/routers/properties/podResources/properties/machine
+          type: select
+        - disable:
+            name: isMachineNotCustom|topology/routers
+            watchPaths:
+            - schema/properties/spec/properties/topology/properties/routers/properties/podResources/properties/machine
+          init:
+            type: func
+            value: setLimits|cpu|topology/routers
+          label: CPU
+          loader: setLimits|cpu|topology/routers
+          schema: schema/properties/spec/properties/topology/properties/routers/properties/podResources/properties/resources/properties/requests/properties/cpu
+          type: input
+          watcher:
+            func: setRequests|cpu|topology/routers
+            paths:
+            - schema/properties/spec/properties/topology/properties/routers/properties/podResources/properties/resources/properties/requests/properties/cpu
+            - schema/properties/spec/properties/topology/properties/routers/properties/podResources/properties/machine
+        - disable:
+            name: isMachineNotCustom|topology/routers
+            watchPaths:
+            - schema/properties/spec/properties/topology/properties/routers/properties/podResources/properties/machine
+          init:
+            type: func
+            value: setLimits|memory|topology/routers
+          label: Memory
+          loader: setLimits|memory|topology/routers
+          schema: schema/properties/spec/properties/topology/properties/routers/properties/podResources/properties/resources/properties/requests/properties/memory
+          type: input
+          watcher:
+            func: setRequests|memory|topology/routers
+            paths:
+            - schema/properties/spec/properties/topology/properties/routers/properties/podResources/properties/resources/properties/requests/properties/memory
+            - schema/properties/spec/properties/topology/properties/routers/properties/podResources/properties/machine
+        showLabels: true
+        type: horizontal-layout
+      label: Routers
+      showLabels: true
+      type: block-layout
     type: block-layout
   - elements:
     - if:

--- a/charts/kubedbcom-druid-editor-options/ui/language.yaml
+++ b/charts/kubedbcom-druid-editor-options/ui/language.yaml
@@ -198,6 +198,7 @@ en:
       snapshot: Snapshot
       title: Restore Session
     role: Role
+    routers: Routers
     run_as_group: Run as Group
     run_as_non_root: Run As Non Root?
     run_as_user: Run as User


### PR DESCRIPTION
Adds the `routers` topology node to `kubedbcom-druid-editor-options` (previously wired 4 nodes: brokers, coordinators, historicals, middleManagers).

`routers` is a query node with no persistence — mirrors `brokers`/`coordinators` (`*DruidNode`).

Changes:
- apis: add `Routers *DruidNode` to `DruidTopology`
- db.yaml: `routers` topology block
- _helpers.tpl: `routers_res` resolution + set
- create-ui.yaml: Routers block-layout
- language.yaml: `routers: Routers`
- autoscaler.yaml: routers in instanceMap + spec.compute

Note: `make gen` (schema/deepcopy/docs regen) and build to be run separately.