### PR TITLE
Fix Neo4j editor-options defaults

### DIFF
--- a/charts/kubedbcom-neo4j-editor-options/templates/_helpers.tpl
+++ b/charts/kubedbcom-neo4j-editor-options/templates/_helpers.tpl
@@ -125,7 +125,7 @@ capabilities:
   - ALL
 runAsGroup: 0
 runAsNonRoot: true
-runAsUser: {{ $.Values.spec.openshift.securityContext.runAsUser | default 54321 }}
+runAsUser: {{ $.Values.spec.openshift.securityContext.runAsUser | default 7474 }}
 seccompProfile:
   type: RuntimeDefault
 {{- end }}

--- a/charts/kubedbcom-neo4j-editor-options/templates/db.yaml
+++ b/charts/kubedbcom-neo4j-editor-options/templates/db.yaml
@@ -100,7 +100,7 @@ spec:
   podTemplate:
     spec:
       securityContext:
-        fsGroup: {{ .Values.spec.openshift.securityContext.runAsUser | default 54321 }}
+        fsGroup: {{ .Values.spec.openshift.securityContext.runAsUser | default 7474 }}
       containers:
         - name: neo4j
           resources:
@@ -112,10 +112,12 @@ spec:
 {{- if .Values.spec.authSecret.name }}
   authSecret:
     name: {{ .Values.spec.authSecret.name }}
+    kind: Secret
 {{- end }}
 {{- if .Values.spec.authSecret.password }}
   authSecret:
     name: {{ include "kubedbcom-neo4j-editor-options.fullname" . }}-auth
+    kind: Secret
 {{- end }}
 {{- if (and .Values.spec.admin.monitoring .Values.spec.admin.monitoring.agent) }}
   monitor:
@@ -123,9 +125,7 @@ spec:
     prometheus:
     {{- with .Values.spec.admin.monitoring.exporter }}
       exporter:
-        {{- if .port }}
-        port: {{ .port }}
-        {{- end }}
+        port: {{ .port | default 2004 }}
         resources:
           {{- toYaml .resources | nindent 10 }}
     {{- end }}

--- a/charts/kubedbcom-neo4j-editor-options/templates/secret.yaml
+++ b/charts/kubedbcom-neo4j-editor-options/templates/secret.yaml
@@ -8,6 +8,6 @@ metadata:
     {{- include "kubedbcom-neo4j-editor-options.labels" . | nindent 4 }}
 type: kubernetes.io/basic-auth
 data:
-  username: {{ "root" | b64enc | quote }}
+  username: {{ "neo4j" | b64enc | quote }}
   password: {{ .Values.spec.authSecret.password | trim | b64enc | quote }}
 {{- end }}


### PR DESCRIPTION
Fixes four incorrect values in the `kubedbcom-neo4j-editor-options` templates.

- **`runAsUser` / `fsGroup`: `54321` → `7474`** (`_helpers.tpl`, `db.yaml`). Neo4j runs as uid 7474 (`Neo4jHTTPPort`); the operator also defaults `fsGroup` to the version's `runAsUser`.
- **Exporter port defaults to `2004`** (`db.yaml`). The field was guarded by `{{- if .port }}`, so the values default of `0` omitted it entirely and the operator fell back to its generic exporter port. 2004 is `Neo4jPrometheusPort` in kubedb apimachinery constants.
- **Bootstrap username: `root` → `neo4j`** (`secret.yaml`). When the user supplies only a password, the username must be `neo4j` for first-time bootstrap.
- **Added `authSecret.kind: Secret`** to both branches in `db.yaml`. `SecretReference` inlines `appcat.TypedLocalObjectReference`, whose `Kind` is non-optional (defaulted to `Secret`).

Verified with `helm template` (both the referExisting and generated-secret paths) and `helm lint`. No `apis/` types changed, so no schema regen.

Note: `make fmt` could not run locally (Docker daemon down); the diff is templates-only, so gofmt/license-header steps don't apply.