### PR TITLE
Use namespaced appbindings list for client-org users

### DIFF
--- a/charts/kubedbcom-druid-editor-options/ui/functions.js
+++ b/charts/kubedbcom-druid-editor-options/ui/functions.js
@@ -697,6 +697,17 @@ export const useFunc = (model) => {
   async function getAppBindings(type) {
     const owner = storeGet('/route/params/user')
     const cluster = storeGet('/route/params/cluster')
+    const namespace =
+      getValue(model, '/metadata/release/namespace') || storeGet('/route/query/namespace') || ''
+    const activeOrg = storeGet('/activeOrganization') || ''
+    const orgList = storeGet('/organizations') || []
+    const orgType = orgList.find((item) => item.username === activeOrg)?.orgType
+
+    let url = `/clusters/${owner}/${cluster}/proxy/appcatalog.appscode.com/v1alpha1/appbindings`
+    if (orgType === 3 && namespace) {
+      url = `/clusters/${owner}/${cluster}/proxy/appcatalog.appscode.com/v1alpha1/namespaces/${namespace}/appbindings`
+    }
+
     const queryParams = {
       filter: {
         items: {
@@ -706,10 +717,7 @@ export const useFunc = (model) => {
       },
     }
     try {
-      const resp = await axios.get(
-        `/clusters/${owner}/${cluster}/proxy/appcatalog.appscode.com/v1alpha1/appbindings`,
-        queryParams,
-      )
+      const resp = await axios.get(url, queryParams)
       const resources = (resp && resp.data && resp.data.items) || []
 
       const fileredResources = resources

--- a/charts/kubedbcom-mysql-editor-options/ui/functions.js
+++ b/charts/kubedbcom-mysql-editor-options/ui/functions.js
@@ -1411,9 +1411,18 @@ export const useFunc = (model) => {
   }
 
   async function getAppBindings() {
-    const namespace = getValue(model, '/metadata/release/namespace')
     const owner = storeGet('/route/params/user')
     const cluster = storeGet('/route/params/cluster')
+    const namespace =
+      getValue(model, '/metadata/release/namespace') || storeGet('/route/query/namespace') || ''
+    const activeOrg = storeGet('/activeOrganization') || ''
+    const orgList = storeGet('/organizations') || []
+    const orgType = orgList.find((item) => item.username === activeOrg)?.orgType
+
+    let url = `/clusters/${owner}/${cluster}/proxy/appcatalog.appscode.com/v1alpha1/appbindings`
+    if (orgType === 3 && namespace) {
+      url = `/clusters/${owner}/${cluster}/proxy/appcatalog.appscode.com/v1alpha1/namespaces/${namespace}/appbindings`
+    }
 
     const queryParams = {
       filter: {
@@ -1424,12 +1433,9 @@ export const useFunc = (model) => {
       },
     }
     try {
-      const resp = await axios.get(
-        `/clusters/${owner}/${cluster}/proxy/appcatalog.appscode.com/v1alpha1/appbindings`,
-        {
-          params: queryParams,
-        },
-      )
+      const resp = await axios.get(url, {
+        params: queryParams,
+      })
 
       const resources = (resp && resp.data && resp.data.items) || []
 

--- a/charts/kubedbcom-pgbouncer-editor-options/ui/functions.js
+++ b/charts/kubedbcom-pgbouncer-editor-options/ui/functions.js
@@ -334,6 +334,17 @@ export const useFunc = (model) => {
   async function getAppBindings(type) {
     const owner = storeGet('/route/params/user')
     const cluster = storeGet('/route/params/cluster')
+    const namespace =
+      getValue(model, '/metadata/release/namespace') || storeGet('/route/query/namespace') || ''
+    const activeOrg = storeGet('/activeOrganization') || ''
+    const orgList = storeGet('/organizations') || []
+    const orgType = orgList.find((item) => item.username === activeOrg)?.orgType
+
+    let url = `/clusters/${owner}/${cluster}/proxy/appcatalog.appscode.com/v1alpha1/appbindings`
+    if (orgType === 3 && namespace) {
+      url = `/clusters/${owner}/${cluster}/proxy/appcatalog.appscode.com/v1alpha1/namespaces/${namespace}/appbindings`
+    }
+
     const queryParams = {
       filter: {
         items: {
@@ -343,10 +354,7 @@ export const useFunc = (model) => {
       },
     }
     try {
-      const resp = await axios.get(
-        `/clusters/${owner}/${cluster}/proxy/appcatalog.appscode.com/v1alpha1/appbindings`,
-        queryParams,
-      )
+      const resp = await axios.get(url, queryParams)
       const resources = (resp && resp.data && resp.data.items) || []
 
       const fileredResources = resources

--- a/charts/kubedbcom-pgpool-editor-options/ui/functions.js
+++ b/charts/kubedbcom-pgpool-editor-options/ui/functions.js
@@ -1142,6 +1142,17 @@ export const useFunc = (model) => {
   async function getAppBindings(type) {
     const owner = storeGet('/route/params/user')
     const cluster = storeGet('/route/params/cluster')
+    const namespace =
+      getValue(model, '/metadata/release/namespace') || storeGet('/route/query/namespace') || ''
+    const activeOrg = storeGet('/activeOrganization') || ''
+    const orgList = storeGet('/organizations') || []
+    const orgType = orgList.find((item) => item.username === activeOrg)?.orgType
+
+    let url = `/clusters/${owner}/${cluster}/proxy/appcatalog.appscode.com/v1alpha1/appbindings`
+    if (orgType === 3 && namespace) {
+      url = `/clusters/${owner}/${cluster}/proxy/appcatalog.appscode.com/v1alpha1/namespaces/${namespace}/appbindings`
+    }
+
     const queryParams = {
       filter: {
         items: {
@@ -1151,10 +1162,7 @@ export const useFunc = (model) => {
       },
     }
     try {
-      const resp = await axios.get(
-        `/clusters/${owner}/${cluster}/proxy/appcatalog.appscode.com/v1alpha1/appbindings`,
-        queryParams,
-      )
+      const resp = await axios.get(url, queryParams)
       const resources = (resp && resp.data && resp.data.items) || []
 
       const fileredResources = resources

--- a/charts/kubedbcom-postgres-editor-options/ui/functions.js
+++ b/charts/kubedbcom-postgres-editor-options/ui/functions.js
@@ -1596,6 +1596,16 @@ export const useFunc = (model) => {
   async function getAppBindings() {
     const owner = storeGet('/route/params/user')
     const cluster = storeGet('/route/params/cluster')
+    const namespace =
+      getValue(model, '/metadata/release/namespace') || storeGet('/route/query/namespace') || ''
+    const activeOrg = storeGet('/activeOrganization') || ''
+    const orgList = storeGet('/organizations') || []
+    const orgType = orgList.find((item) => item.username === activeOrg)?.orgType
+
+    let url = `/clusters/${owner}/${cluster}/proxy/appcatalog.appscode.com/v1alpha1/appbindings`
+    if (orgType === 3 && namespace) {
+      url = `/clusters/${owner}/${cluster}/proxy/appcatalog.appscode.com/v1alpha1/namespaces/${namespace}/appbindings`
+    }
 
     const queryParams = {
       filter: {
@@ -1606,12 +1616,9 @@ export const useFunc = (model) => {
       },
     }
     try {
-      const resp = await axios.get(
-        `/clusters/${owner}/${cluster}/proxy/appcatalog.appscode.com/v1alpha1/appbindings`,
-        {
-          params: queryParams,
-        },
-      )
+      const resp = await axios.get(url, {
+        params: queryParams,
+      })
 
       const resources = (resp && resp.data && resp.data.items) || []
 

--- a/charts/kubedbcom-proxysql-editor-options/ui/functions.js
+++ b/charts/kubedbcom-proxysql-editor-options/ui/functions.js
@@ -395,6 +395,16 @@ export const useFunc = (model) => {
   async function getAppBindings() {
     const owner = storeGet('/route/params/user')
     const cluster = storeGet('/route/params/cluster')
+    const namespace =
+      getValue(model, '/metadata/release/namespace') || storeGet('/route/query/namespace') || ''
+    const activeOrg = storeGet('/activeOrganization') || ''
+    const orgList = storeGet('/organizations') || []
+    const orgType = orgList.find((item) => item.username === activeOrg)?.orgType
+
+    let url = `/clusters/${owner}/${cluster}/proxy/appcatalog.appscode.com/v1alpha1/appbindings`
+    if (orgType === 3 && namespace) {
+      url = `/clusters/${owner}/${cluster}/proxy/appcatalog.appscode.com/v1alpha1/namespaces/${namespace}/appbindings`
+    }
 
     const queryParams = {
       filter: {
@@ -406,12 +416,9 @@ export const useFunc = (model) => {
     }
 
     try {
-      const resp = await axios.get(
-        `/clusters/${owner}/${cluster}/proxy/appcatalog.appscode.com/v1alpha1/appbindings`,
-        {
-          params: queryParams,
-        },
-      )
+      const resp = await axios.get(url, {
+        params: queryParams,
+      })
 
       const resources = (resp && resp.data && resp.data.items) || []
 

--- a/charts/kubedbcom-solr-editor-options/ui/functions.js
+++ b/charts/kubedbcom-solr-editor-options/ui/functions.js
@@ -1113,9 +1113,18 @@ export const useFunc = (model) => {
   }
 
   async function getAppBindings() {
-    const namespace = getValue(model, '/metadata/release/namespace')
     const owner = storeGet('/route/params/user')
     const cluster = storeGet('/route/params/cluster')
+    const namespace =
+      getValue(model, '/metadata/release/namespace') || storeGet('/route/query/namespace') || ''
+    const activeOrg = storeGet('/activeOrganization') || ''
+    const orgList = storeGet('/organizations') || []
+    const orgType = orgList.find((item) => item.username === activeOrg)?.orgType
+
+    let url = `/clusters/${owner}/${cluster}/proxy/appcatalog.appscode.com/v1alpha1/appbindings`
+    if (orgType === 3 && namespace) {
+      url = `/clusters/${owner}/${cluster}/proxy/appcatalog.appscode.com/v1alpha1/namespaces/${namespace}/appbindings`
+    }
 
     const queryParams = {
       filter: {
@@ -1127,12 +1136,9 @@ export const useFunc = (model) => {
     }
 
     try {
-      const resp = await axios.get(
-        `/clusters/${owner}/${cluster}/proxy/appcatalog.appscode.com/v1alpha1/appbindings`,
-        {
-          params: queryParams,
-        },
-      )
+      const resp = await axios.get(url, {
+        params: queryParams,
+      })
 
       const resources = (resp && resp.data && resp.data.items) || []
 


### PR DESCRIPTION
Client organizations (`orgType === 3`) are scoped to a single namespace and cannot list appbindings cluster-wide, so `getAppBindings` returned nothing for them.

All 7 `kubedbcom-<db>-editor-options` charts with an appbindings list call now switch to the namespaced path when the active org is a client org:

```js
let url = `/clusters/${owner}/${cluster}/proxy/appcatalog.appscode.com/v1alpha1/appbindings`
if (orgType === 3 && namespace) {
  url = `/clusters/${owner}/${cluster}/proxy/appcatalog.appscode.com/v1alpha1/namespaces/${namespace}/appbindings`
}
```

Charts touched: pgpool, postgres, mysql, solr, druid, pgbouncer, proxysql.

The `orgType === 3` check follows the existing precedent in `charts/corekubestashcom-restoresession-editor-options/ui/functions.js`. Namespace resolves from `/metadata/release/namespace`, falling back to `/route/query/namespace`; when neither is set the call stays cluster-scoped rather than building a `/namespaces//appbindings` path.

Side effect: solr and mysql already labelled every result `${releaseNamespace}/${name}` while listing cluster-wide — that label was wrong for cross-namespace results, and namespacing the list makes it correct.

Other cluster-scoped `proxy/` calls in these files were left alone because they are not namespaceable: `storageclasses` (cluster-scoped), `selfsubjectnamespaceaccessreviews` (the call that discovers namespaces), `gatewayinfos/${namespace}` (already namespace-keyed), and the generic `${group}/${version}/${resource}` helper (only used for `*Version` CRDs and `core/v1/namespaces`).