### PR TITLE
Treat a nil alert severity as disabled in alert helpers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,10 +4,22 @@ on:
   push:
     tags:
       - "*.*"
+    # git tag -fa v0.36.1 -m "v0.36.1" -m "Charts: kubedbcom-*-editor-options"
   workflow_dispatch:
     inputs:
+      # single `find -name` glob, so no brace expansion; anchor on the group
+      # prefix -- `*-editor` matches 824 charts, not just the db editors.
+      # counts below were taken when this was written; they drift as charts land.
+      #   kubedbcom-*-editor-options   30   db options only
+      #   kubedbcom-*                  63   db editors + options
+      #   <empty>                     886   every chart
+      #   *-editor-options             39   options charts of every group
+      #   kubedbcom-mongodb-*           2   one db, editor + options
+      #   opskubedbcom-*               33   ops-request editors
+      #   *kubestashcom-*              19   kubestash core + storage + addons
+      # dry-run locally: make stage-charts CHARTS_PATTERN='<glob>'
       charts_pattern:
-        description: "Glob of chart dirs to publish: kubedbcom-*-editor-options | kubedbcom-* | empty = all"
+        description: "Chart dir glob; Use patterns like 'kubedbcom-*-editor-options' or 'kubedbcom-*' etc"
         required: false
         default: "kubedbcom-*-editor-options"
 

--- a/charts/corekubestashcom-backupconfiguration-editor-options/templates/_helpers.tpl
+++ b/charts/corekubestashcom-backupconfiguration-editor-options/templates/_helpers.tpl
@@ -78,7 +78,7 @@ Alerts Enabled
 */}}
 {{- define "kubestashcom-backupconfiguration-editor-options.alertsEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
-{{- $result := dig . 0 $ranks -}}
+{{- $result := dig (. | default "none") 0 $ranks -}}
 {{- if $result -}}{{ . }}{{- end -}}
 {{- end }}
 
@@ -88,11 +88,11 @@ Alert Group Enabled
 {{- define "kubestashcom-backupconfiguration-editor-options.alertGroupEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
 {{- $flags := (mustLast .) -}}
-{{- $group := dig (mustFirst .) 0 $ranks -}}
-{{- $group = min $group (dig $flags.enabled 0 $ranks) -}}
+{{- $group := dig (mustFirst . | default "none") 0 $ranks -}}
+{{- $group = min $group (dig ($flags.enabled | default "none") 0 $ranks) -}}
 {{- $hasRules := false -}}
 {{- range $k, $v := $flags.rules -}}
-{{- $sev := dig $v.severity 0 $ranks -}}
+{{- $sev := dig ($v.severity | default "none") 0 $ranks -}}
 {{- if (and $sev (le $sev $group) $v.enabled) -}}{{ $hasRules = true }}{{- end -}}
 {{- end -}}
 {{- if (and $group $hasRules) -}}{{ $flags.enabled }}{{- end -}}
@@ -103,13 +103,13 @@ Alert Enabled
 */}}
 {{- define "kubestashcom-backupconfiguration-editor-options.alertEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
-{{- $sev := dig (mustLast .) 0 $ranks -}}
+{{- $sev := dig (mustLast . | default "none") 0 $ranks -}}
 {{- $flags := mustInitial . -}}
 {{- $enabled := mustLast $flags -}}
 {{- $flags = mustInitial $flags -}}
 {{- $result := 3 -}}
 {{- range $x := $flags -}}
-{{- $result = min $result (dig $x 0 $ranks) -}}
+{{- $result = min $result (dig ($x | default "none") 0 $ranks) -}}
 {{- end -}}
 {{- if (and $sev (le $sev $result) $enabled) -}}{{ (mustLast .) }}{{- end -}}
 {{- end }}

--- a/charts/kubedbcom-cassandra-editor-options/templates/_helpers.tpl
+++ b/charts/kubedbcom-cassandra-editor-options/templates/_helpers.tpl
@@ -78,7 +78,7 @@ Alerts Enabled
 */}}
 {{- define "kubedbcom-cassandra-editor-options.alertsEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
-{{- $result := dig . 0 $ranks -}}
+{{- $result := dig (. | default "none") 0 $ranks -}}
 {{- if $result -}}{{ . }}{{- end -}}
 {{- end }}
 
@@ -88,11 +88,11 @@ Alert Group Enabled
 {{- define "kubedbcom-cassandra-editor-options.alertGroupEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
 {{- $flags := (mustLast .) -}}
-{{- $group := dig (mustFirst .) 0 $ranks -}}
-{{- $group = min $group (dig $flags.enabled 0 $ranks) -}}
+{{- $group := dig (mustFirst . | default "none") 0 $ranks -}}
+{{- $group = min $group (dig ($flags.enabled | default "none") 0 $ranks) -}}
 {{- $hasRules := false -}}
 {{- range $k, $v := $flags.rules -}}
-{{- $sev := dig $v.severity 0 $ranks -}}
+{{- $sev := dig ($v.severity | default "none") 0 $ranks -}}
 {{- if (and $sev (le $sev $group) $v.enabled) -}}{{ $hasRules = true }}{{- end -}}
 {{- end -}}
 {{- if (and $group $hasRules) -}}{{ $flags.enabled }}{{- end -}}
@@ -110,10 +110,10 @@ Alert Enabled
 {{- $rule := dig $key (dict) $rules -}}
 {{- $severity := dig "severity" "" $rule -}}
 {{- $enabled := dig "enabled" false $rule -}}
-{{- $sev := dig $severity 0 $ranks -}}
+{{- $sev := dig ($severity | default "none") 0 $ranks -}}
 {{- $result := 3 -}}
 {{- range $x := $flags -}}
-{{- $result = min $result (dig $x 0 $ranks) -}}
+{{- $result = min $result (dig ($x | default "none") 0 $ranks) -}}
 {{- end -}}
 {{- if (and $sev (le $sev $result) $enabled) -}}{{ $severity }}{{- end -}}
 {{- end }}

--- a/charts/kubedbcom-cassandra-editor/templates/_helpers.tpl
+++ b/charts/kubedbcom-cassandra-editor/templates/_helpers.tpl
@@ -78,7 +78,7 @@ Alerts Enabled
 */}}
 {{- define "kubedbcom-cassandra-editor.alertsEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
-{{- $result := dig . 0 $ranks -}}
+{{- $result := dig (. | default "none") 0 $ranks -}}
 {{- if $result -}}{{ . }}{{- end -}}
 {{- end }}
 
@@ -88,11 +88,11 @@ Alert Group Enabled
 {{- define "kubedbcom-cassandra-editor.alertGroupEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
 {{- $flags := (mustLast .) -}}
-{{- $group := dig (mustFirst .) 0 $ranks -}}
-{{- $group = min $group (dig $flags.enabled 0 $ranks) -}}
+{{- $group := dig (mustFirst . | default "none") 0 $ranks -}}
+{{- $group = min $group (dig ($flags.enabled | default "none") 0 $ranks) -}}
 {{- $hasRules := false -}}
 {{- range $k, $v := $flags.rules -}}
-{{- $sev := dig $v.severity 0 $ranks -}}
+{{- $sev := dig ($v.severity | default "none") 0 $ranks -}}
 {{- if (and $sev (le $sev $group) $v.enabled) -}}{{ $hasRules = true }}{{- end -}}
 {{- end -}}
 {{- if (and $group $hasRules) -}}{{ $flags.enabled }}{{- end -}}
@@ -110,10 +110,10 @@ Alert Enabled
 {{- $rule := dig $key (dict) $rules -}}
 {{- $severity := dig "severity" "" $rule -}}
 {{- $enabled := dig "enabled" false $rule -}}
-{{- $sev := dig $severity 0 $ranks -}}
+{{- $sev := dig ($severity | default "none") 0 $ranks -}}
 {{- $result := 3 -}}
 {{- range $x := $flags -}}
-{{- $result = min $result (dig $x 0 $ranks) -}}
+{{- $result = min $result (dig ($x | default "none") 0 $ranks) -}}
 {{- end -}}
 {{- if (and $sev (le $sev $result) $enabled) -}}{{ $severity }}{{- end -}}
 {{- end }}

--- a/charts/kubedbcom-clickhouse-editor-options/templates/_helpers.tpl
+++ b/charts/kubedbcom-clickhouse-editor-options/templates/_helpers.tpl
@@ -78,7 +78,7 @@ Alerts Enabled
 */}}
 {{- define "kubedbcom-clickhouse-editor-options.alertsEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
-{{- $result := dig . 0 $ranks -}}
+{{- $result := dig (. | default "none") 0 $ranks -}}
 {{- if $result -}}{{ . }}{{- end -}}
 {{- end }}
 
@@ -88,11 +88,11 @@ Alert Group Enabled
 {{- define "kubedbcom-clickhouse-editor-options.alertGroupEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
 {{- $flags := (mustLast .) -}}
-{{- $group := dig (mustFirst .) 0 $ranks -}}
-{{- $group = min $group (dig $flags.enabled 0 $ranks) -}}
+{{- $group := dig (mustFirst . | default "none") 0 $ranks -}}
+{{- $group = min $group (dig ($flags.enabled | default "none") 0 $ranks) -}}
 {{- $hasRules := false -}}
 {{- range $k, $v := $flags.rules -}}
-{{- $sev := dig $v.severity 0 $ranks -}}
+{{- $sev := dig ($v.severity | default "none") 0 $ranks -}}
 {{- if (and $sev (le $sev $group) $v.enabled) -}}{{ $hasRules = true }}{{- end -}}
 {{- end -}}
 {{- if (and $group $hasRules) -}}{{ $flags.enabled }}{{- end -}}
@@ -110,10 +110,10 @@ Alert Enabled
 {{- $rule := dig $key (dict) $rules -}}
 {{- $severity := dig "severity" "" $rule -}}
 {{- $enabled := dig "enabled" false $rule -}}
-{{- $sev := dig $severity 0 $ranks -}}
+{{- $sev := dig ($severity | default "none") 0 $ranks -}}
 {{- $result := 3 -}}
 {{- range $x := $flags -}}
-{{- $result = min $result (dig $x 0 $ranks) -}}
+{{- $result = min $result (dig ($x | default "none") 0 $ranks) -}}
 {{- end -}}
 {{- if (and $sev (le $sev $result) $enabled) -}}{{ $severity }}{{- end -}}
 {{- end }}

--- a/charts/kubedbcom-clickhouse-editor/templates/_helpers.tpl
+++ b/charts/kubedbcom-clickhouse-editor/templates/_helpers.tpl
@@ -78,7 +78,7 @@ Alerts Enabled
 */}}
 {{- define "kubedbcom-clickhouse-editor.alertsEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
-{{- $result := dig . 0 $ranks -}}
+{{- $result := dig (. | default "none") 0 $ranks -}}
 {{- if $result -}}{{ . }}{{- end -}}
 {{- end }}
 
@@ -88,11 +88,11 @@ Alert Group Enabled
 {{- define "kubedbcom-clickhouse-editor.alertGroupEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
 {{- $flags := (mustLast .) -}}
-{{- $group := dig (mustFirst .) 0 $ranks -}}
-{{- $group = min $group (dig $flags.enabled 0 $ranks) -}}
+{{- $group := dig (mustFirst . | default "none") 0 $ranks -}}
+{{- $group = min $group (dig ($flags.enabled | default "none") 0 $ranks) -}}
 {{- $hasRules := false -}}
 {{- range $k, $v := $flags.rules -}}
-{{- $sev := dig $v.severity 0 $ranks -}}
+{{- $sev := dig ($v.severity | default "none") 0 $ranks -}}
 {{- if (and $sev (le $sev $group) $v.enabled) -}}{{ $hasRules = true }}{{- end -}}
 {{- end -}}
 {{- if (and $group $hasRules) -}}{{ $flags.enabled }}{{- end -}}
@@ -103,13 +103,13 @@ Alert Enabled
 */}}
 {{- define "kubedbcom-clickhouse-editor.alertEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
-{{- $sev := dig (mustLast .) 0 $ranks -}}
+{{- $sev := dig (mustLast . | default "none") 0 $ranks -}}
 {{- $flags := mustInitial . -}}
 {{- $enabled := mustLast $flags -}}
 {{- $flags = mustInitial $flags -}}
 {{- $result := 3 -}}
 {{- range $x := $flags -}}
-{{- $result = min $result (dig $x 0 $ranks) -}}
+{{- $result = min $result (dig ($x | default "none") 0 $ranks) -}}
 {{- end -}}
 {{- if (and $sev (le $sev $result) $enabled) -}}{{ (mustLast .) }}{{- end -}}
 {{- end }}

--- a/charts/kubedbcom-db2-editor-options/templates/_helpers.tpl
+++ b/charts/kubedbcom-db2-editor-options/templates/_helpers.tpl
@@ -78,7 +78,7 @@ Alerts Enabled
 */}}
 {{- define "kubedbcom-db2-editor-options.alertsEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
-{{- $result := dig . 0 $ranks -}}
+{{- $result := dig (. | default "none") 0 $ranks -}}
 {{- if $result -}}{{ . }}{{- end -}}
 {{- end }}
 
@@ -88,11 +88,11 @@ Alert Group Enabled
 {{- define "kubedbcom-db2-editor-options.alertGroupEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
 {{- $flags := (mustLast .) -}}
-{{- $group := dig (mustFirst .) 0 $ranks -}}
-{{- $group = min $group (dig $flags.enabled 0 $ranks) -}}
+{{- $group := dig (mustFirst . | default "none") 0 $ranks -}}
+{{- $group = min $group (dig ($flags.enabled | default "none") 0 $ranks) -}}
 {{- $hasRules := false -}}
 {{- range $k, $v := $flags.rules -}}
-{{- $sev := dig $v.severity 0 $ranks -}}
+{{- $sev := dig ($v.severity | default "none") 0 $ranks -}}
 {{- if (and $sev (le $sev $group) $v.enabled) -}}{{ $hasRules = true }}{{- end -}}
 {{- end -}}
 {{- if (and $group $hasRules) -}}{{ $flags.enabled }}{{- end -}}
@@ -103,13 +103,13 @@ Alert Enabled
 */}}
 {{- define "kubedbcom-db2-editor-options.alertEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
-{{- $sev := dig (mustLast .) 0 $ranks -}}
+{{- $sev := dig (mustLast . | default "none") 0 $ranks -}}
 {{- $flags := mustInitial . -}}
 {{- $enabled := mustLast $flags -}}
 {{- $flags = mustInitial $flags -}}
 {{- $result := 3 -}}
 {{- range $x := $flags -}}
-{{- $result = min $result (dig $x 0 $ranks) -}}
+{{- $result = min $result (dig ($x | default "none") 0 $ranks) -}}
 {{- end -}}
 {{- if (and $sev (le $sev $result) $enabled) -}}{{ (mustLast .) }}{{- end -}}
 {{- end }}

--- a/charts/kubedbcom-db2-editor/templates/_helpers.tpl
+++ b/charts/kubedbcom-db2-editor/templates/_helpers.tpl
@@ -78,7 +78,7 @@ Alerts Enabled
 */}}
 {{- define "kubedbcom-db2-editor.alertsEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
-{{- $result := dig . 0 $ranks -}}
+{{- $result := dig (. | default "none") 0 $ranks -}}
 {{- if $result -}}{{ . }}{{- end -}}
 {{- end }}
 
@@ -88,11 +88,11 @@ Alert Group Enabled
 {{- define "kubedbcom-db2-editor.alertGroupEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
 {{- $flags := (mustLast .) -}}
-{{- $group := dig (mustFirst .) 0 $ranks -}}
-{{- $group = min $group (dig $flags.enabled 0 $ranks) -}}
+{{- $group := dig (mustFirst . | default "none") 0 $ranks -}}
+{{- $group = min $group (dig ($flags.enabled | default "none") 0 $ranks) -}}
 {{- $hasRules := false -}}
 {{- range $k, $v := $flags.rules -}}
-{{- $sev := dig $v.severity 0 $ranks -}}
+{{- $sev := dig ($v.severity | default "none") 0 $ranks -}}
 {{- if (and $sev (le $sev $group) $v.enabled) -}}{{ $hasRules = true }}{{- end -}}
 {{- end -}}
 {{- if (and $group $hasRules) -}}{{ $flags.enabled }}{{- end -}}
@@ -103,13 +103,13 @@ Alert Enabled
 */}}
 {{- define "kubedbcom-db2-editor.alertEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
-{{- $sev := dig (mustLast .) 0 $ranks -}}
+{{- $sev := dig (mustLast . | default "none") 0 $ranks -}}
 {{- $flags := mustInitial . -}}
 {{- $enabled := mustLast $flags -}}
 {{- $flags = mustInitial $flags -}}
 {{- $result := 3 -}}
 {{- range $x := $flags -}}
-{{- $result = min $result (dig $x 0 $ranks) -}}
+{{- $result = min $result (dig ($x | default "none") 0 $ranks) -}}
 {{- end -}}
 {{- if (and $sev (le $sev $result) $enabled) -}}{{ (mustLast .) }}{{- end -}}
 {{- end }}

--- a/charts/kubedbcom-documentdb-editor-options/templates/_helpers.tpl
+++ b/charts/kubedbcom-documentdb-editor-options/templates/_helpers.tpl
@@ -78,7 +78,7 @@ Alerts Enabled
 */}}
 {{- define "kubedbcom-documentdb-editor-options.alertsEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
-{{- $result := dig . 0 $ranks -}}
+{{- $result := dig (. | default "none") 0 $ranks -}}
 {{- if $result -}}{{ . }}{{- end -}}
 {{- end }}
 
@@ -88,11 +88,11 @@ Alert Group Enabled
 {{- define "kubedbcom-documentdb-editor-options.alertGroupEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
 {{- $flags := (mustLast .) -}}
-{{- $group := dig (mustFirst .) 0 $ranks -}}
-{{- $group = min $group (dig $flags.enabled 0 $ranks) -}}
+{{- $group := dig (mustFirst . | default "none") 0 $ranks -}}
+{{- $group = min $group (dig ($flags.enabled | default "none") 0 $ranks) -}}
 {{- $hasRules := false -}}
 {{- range $k, $v := $flags.rules -}}
-{{- $sev := dig $v.severity 0 $ranks -}}
+{{- $sev := dig ($v.severity | default "none") 0 $ranks -}}
 {{- if (and $sev (le $sev $group) $v.enabled) -}}{{ $hasRules = true }}{{- end -}}
 {{- end -}}
 {{- if (and $group $hasRules) -}}{{ $flags.enabled }}{{- end -}}
@@ -103,13 +103,13 @@ Alert Enabled
 */}}
 {{- define "kubedbcom-documentdb-editor-options.alertEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
-{{- $sev := dig (mustLast .) 0 $ranks -}}
+{{- $sev := dig (mustLast . | default "none") 0 $ranks -}}
 {{- $flags := mustInitial . -}}
 {{- $enabled := mustLast $flags -}}
 {{- $flags = mustInitial $flags -}}
 {{- $result := 3 -}}
 {{- range $x := $flags -}}
-{{- $result = min $result (dig $x 0 $ranks) -}}
+{{- $result = min $result (dig ($x | default "none") 0 $ranks) -}}
 {{- end -}}
 {{- if (and $sev (le $sev $result) $enabled) -}}{{ (mustLast .) }}{{- end -}}
 {{- end }}

--- a/charts/kubedbcom-druid-editor-options/templates/_helpers.tpl
+++ b/charts/kubedbcom-druid-editor-options/templates/_helpers.tpl
@@ -78,7 +78,7 @@ Alerts Enabled
 */}}
 {{- define "kubedbcom-druid-editor-options.alertsEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
-{{- $result := dig . 0 $ranks -}}
+{{- $result := dig (. | default "none") 0 $ranks -}}
 {{- if $result -}}{{ . }}{{- end -}}
 {{- end }}
 
@@ -88,11 +88,11 @@ Alert Group Enabled
 {{- define "kubedbcom-druid-editor-options.alertGroupEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
 {{- $flags := (mustLast .) -}}
-{{- $group := dig (mustFirst .) 0 $ranks -}}
-{{- $group = min $group (dig $flags.enabled 0 $ranks) -}}
+{{- $group := dig (mustFirst . | default "none") 0 $ranks -}}
+{{- $group = min $group (dig ($flags.enabled | default "none") 0 $ranks) -}}
 {{- $hasRules := false -}}
 {{- range $k, $v := $flags.rules -}}
-{{- $sev := dig $v.severity 0 $ranks -}}
+{{- $sev := dig ($v.severity | default "none") 0 $ranks -}}
 {{- if (and $sev (le $sev $group) $v.enabled) -}}{{ $hasRules = true }}{{- end -}}
 {{- end -}}
 {{- if (and $group $hasRules) -}}{{ $flags.enabled }}{{- end -}}
@@ -110,10 +110,10 @@ Alert Enabled
 {{- $rule := dig $key (dict) $rules -}}
 {{- $severity := dig "severity" "" $rule -}}
 {{- $enabled := dig "enabled" false $rule -}}
-{{- $sev := dig $severity 0 $ranks -}}
+{{- $sev := dig ($severity | default "none") 0 $ranks -}}
 {{- $result := 3 -}}
 {{- range $x := $flags -}}
-{{- $result = min $result (dig $x 0 $ranks) -}}
+{{- $result = min $result (dig ($x | default "none") 0 $ranks) -}}
 {{- end -}}
 {{- if (and $sev (le $sev $result) $enabled) -}}{{ $severity }}{{- end -}}
 {{- end }}

--- a/charts/kubedbcom-druid-editor/templates/_helpers.tpl
+++ b/charts/kubedbcom-druid-editor/templates/_helpers.tpl
@@ -78,7 +78,7 @@ Alerts Enabled
 */}}
 {{- define "kubedbcom-druid-editor.alertsEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
-{{- $result := dig . 0 $ranks -}}
+{{- $result := dig (. | default "none") 0 $ranks -}}
 {{- if $result -}}{{ . }}{{- end -}}
 {{- end }}
 
@@ -88,11 +88,11 @@ Alert Group Enabled
 {{- define "kubedbcom-druid-editor.alertGroupEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
 {{- $flags := (mustLast .) -}}
-{{- $group := dig (mustFirst .) 0 $ranks -}}
-{{- $group = min $group (dig $flags.enabled 0 $ranks) -}}
+{{- $group := dig (mustFirst . | default "none") 0 $ranks -}}
+{{- $group = min $group (dig ($flags.enabled | default "none") 0 $ranks) -}}
 {{- $hasRules := false -}}
 {{- range $k, $v := $flags.rules -}}
-{{- $sev := dig $v.severity 0 $ranks -}}
+{{- $sev := dig ($v.severity | default "none") 0 $ranks -}}
 {{- if (and $sev (le $sev $group) $v.enabled) -}}{{ $hasRules = true }}{{- end -}}
 {{- end -}}
 {{- if (and $group $hasRules) -}}{{ $flags.enabled }}{{- end -}}
@@ -110,10 +110,10 @@ Alert Enabled
 {{- $rule := dig $key (dict) $rules -}}
 {{- $severity := dig "severity" "" $rule -}}
 {{- $enabled := dig "enabled" false $rule -}}
-{{- $sev := dig $severity 0 $ranks -}}
+{{- $sev := dig ($severity | default "none") 0 $ranks -}}
 {{- $result := 3 -}}
 {{- range $x := $flags -}}
-{{- $result = min $result (dig $x 0 $ranks) -}}
+{{- $result = min $result (dig ($x | default "none") 0 $ranks) -}}
 {{- end -}}
 {{- if (and $sev (le $sev $result) $enabled) -}}{{ $severity }}{{- end -}}
 {{- end }}

--- a/charts/kubedbcom-elasticsearch-editor-options/templates/_helpers.tpl
+++ b/charts/kubedbcom-elasticsearch-editor-options/templates/_helpers.tpl
@@ -78,7 +78,7 @@ Alerts Enabled
 */}}
 {{- define "kubedbcom-elasticsearch-editor-options.alertsEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
-{{- $result := dig . 0 $ranks -}}
+{{- $result := dig (. | default "none") 0 $ranks -}}
 {{- if $result -}}{{ . }}{{- end -}}
 {{- end }}
 
@@ -88,11 +88,11 @@ Alert Group Enabled
 {{- define "kubedbcom-elasticsearch-editor-options.alertGroupEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
 {{- $flags := (mustLast .) -}}
-{{- $group := dig (mustFirst .) 0 $ranks -}}
-{{- $group = min $group (dig $flags.enabled 0 $ranks) -}}
+{{- $group := dig (mustFirst . | default "none") 0 $ranks -}}
+{{- $group = min $group (dig ($flags.enabled | default "none") 0 $ranks) -}}
 {{- $hasRules := false -}}
 {{- range $k, $v := $flags.rules -}}
-{{- $sev := dig $v.severity 0 $ranks -}}
+{{- $sev := dig ($v.severity | default "none") 0 $ranks -}}
 {{- if (and $sev (le $sev $group) $v.enabled) -}}{{ $hasRules = true }}{{- end -}}
 {{- end -}}
 {{- if (and $group $hasRules) -}}{{ $flags.enabled }}{{- end -}}
@@ -110,10 +110,10 @@ Alert Enabled
 {{- $rule := dig $key (dict) $rules -}}
 {{- $severity := dig "severity" "" $rule -}}
 {{- $enabled := dig "enabled" false $rule -}}
-{{- $sev := dig $severity 0 $ranks -}}
+{{- $sev := dig ($severity | default "none") 0 $ranks -}}
 {{- $result := 3 -}}
 {{- range $x := $flags -}}
-{{- $result = min $result (dig $x 0 $ranks) -}}
+{{- $result = min $result (dig ($x | default "none") 0 $ranks) -}}
 {{- end -}}
 {{- if (and $sev (le $sev $result) $enabled) -}}{{ $severity }}{{- end -}}
 {{- end }}

--- a/charts/kubedbcom-elasticsearch-editor/templates/_helpers.tpl
+++ b/charts/kubedbcom-elasticsearch-editor/templates/_helpers.tpl
@@ -78,7 +78,7 @@ Alerts Enabled
 */}}
 {{- define "kubedbcom-elasticsearch-editor.alertsEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
-{{- $result := dig . 0 $ranks -}}
+{{- $result := dig (. | default "none") 0 $ranks -}}
 {{- if $result -}}{{ . }}{{- end -}}
 {{- end }}
 
@@ -88,11 +88,11 @@ Alert Group Enabled
 {{- define "kubedbcom-elasticsearch-editor.alertGroupEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
 {{- $flags := (mustLast .) -}}
-{{- $group := dig (mustFirst .) 0 $ranks -}}
-{{- $group = min $group (dig $flags.enabled 0 $ranks) -}}
+{{- $group := dig (mustFirst . | default "none") 0 $ranks -}}
+{{- $group = min $group (dig ($flags.enabled | default "none") 0 $ranks) -}}
 {{- $hasRules := false -}}
 {{- range $k, $v := $flags.rules -}}
-{{- $sev := dig $v.severity 0 $ranks -}}
+{{- $sev := dig ($v.severity | default "none") 0 $ranks -}}
 {{- if (and $sev (le $sev $group) $v.enabled) -}}{{ $hasRules = true }}{{- end -}}
 {{- end -}}
 {{- if (and $group $hasRules) -}}{{ $flags.enabled }}{{- end -}}
@@ -110,10 +110,10 @@ Alert Enabled
 {{- $rule := dig $key (dict) $rules -}}
 {{- $severity := dig "severity" "" $rule -}}
 {{- $enabled := dig "enabled" false $rule -}}
-{{- $sev := dig $severity 0 $ranks -}}
+{{- $sev := dig ($severity | default "none") 0 $ranks -}}
 {{- $result := 3 -}}
 {{- range $x := $flags -}}
-{{- $result = min $result (dig $x 0 $ranks) -}}
+{{- $result = min $result (dig ($x | default "none") 0 $ranks) -}}
 {{- end -}}
 {{- if (and $sev (le $sev $result) $enabled) -}}{{ $severity }}{{- end -}}
 {{- end }}

--- a/charts/kubedbcom-hanadb-editor-options/templates/_helpers.tpl
+++ b/charts/kubedbcom-hanadb-editor-options/templates/_helpers.tpl
@@ -78,7 +78,7 @@ Alerts Enabled
 */}}
 {{- define "kubedbcom-hanadb-editor-options.alertsEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
-{{- $result := dig . 0 $ranks -}}
+{{- $result := dig (. | default "none") 0 $ranks -}}
 {{- if $result -}}{{ . }}{{- end -}}
 {{- end }}
 
@@ -88,11 +88,11 @@ Alert Group Enabled
 {{- define "kubedbcom-hanadb-editor-options.alertGroupEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
 {{- $flags := (mustLast .) -}}
-{{- $group := dig (mustFirst .) 0 $ranks -}}
-{{- $group = min $group (dig $flags.enabled 0 $ranks) -}}
+{{- $group := dig (mustFirst . | default "none") 0 $ranks -}}
+{{- $group = min $group (dig ($flags.enabled | default "none") 0 $ranks) -}}
 {{- $hasRules := false -}}
 {{- range $k, $v := $flags.rules -}}
-{{- $sev := dig $v.severity 0 $ranks -}}
+{{- $sev := dig ($v.severity | default "none") 0 $ranks -}}
 {{- if (and $sev (le $sev $group) $v.enabled) -}}{{ $hasRules = true }}{{- end -}}
 {{- end }}
 {{- if (and $group $hasRules) -}}{{ $flags.enabled }}{{- end -}}
@@ -110,10 +110,10 @@ Alert Enabled
 {{- $rule := dig $key (dict) $rules -}}
 {{- $severity := dig "severity" "" $rule -}}
 {{- $enabled := dig "enabled" false $rule -}}
-{{- $sev := dig $severity 0 $ranks -}}
+{{- $sev := dig ($severity | default "none") 0 $ranks -}}
 {{- $result := 3 -}}
 {{- range $x := $flags -}}
-{{- $result = min $result (dig $x 0 $ranks) -}}
+{{- $result = min $result (dig ($x | default "none") 0 $ranks) -}}
 {{- end -}}
 {{- if (and $sev (le $sev $result) $enabled) -}}{{ $severity }}{{- end -}}
 {{- end }}

--- a/charts/kubedbcom-hanadb-editor/templates/_helpers.tpl
+++ b/charts/kubedbcom-hanadb-editor/templates/_helpers.tpl
@@ -78,7 +78,7 @@ Alerts Enabled
 */}}
 {{- define "kubedbcom-hanadb-editor.alertsEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
-{{- $result := dig . 0 $ranks -}}
+{{- $result := dig (. | default "none") 0 $ranks -}}
 {{- if $result -}}{{ . }}{{- end -}}
 {{- end }}
 
@@ -88,11 +88,11 @@ Alert Group Enabled
 {{- define "kubedbcom-hanadb-editor.alertGroupEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
 {{- $flags := (mustLast .) -}}
-{{- $group := dig (mustFirst .) 0 $ranks -}}
-{{- $group = min $group (dig $flags.enabled 0 $ranks) -}}
+{{- $group := dig (mustFirst . | default "none") 0 $ranks -}}
+{{- $group = min $group (dig ($flags.enabled | default "none") 0 $ranks) -}}
 {{- $hasRules := false -}}
 {{- range $k, $v := $flags.rules -}}
-{{- $sev := dig $v.severity 0 $ranks -}}
+{{- $sev := dig ($v.severity | default "none") 0 $ranks -}}
 {{- if (and $sev (le $sev $group) $v.enabled) -}}{{ $hasRules = true }}{{- end -}}
 {{- end }}
 {{- if (and $group $hasRules) -}}{{ $flags.enabled }}{{- end -}}
@@ -110,10 +110,10 @@ Alert Enabled
 {{- $rule := dig $key (dict) $rules -}}
 {{- $severity := dig "severity" "" $rule -}}
 {{- $enabled := dig "enabled" false $rule -}}
-{{- $sev := dig $severity 0 $ranks -}}
+{{- $sev := dig ($severity | default "none") 0 $ranks -}}
 {{- $result := 3 -}}
 {{- range $x := $flags -}}
-{{- $result = min $result (dig $x 0 $ranks) -}}
+{{- $result = min $result (dig ($x | default "none") 0 $ranks) -}}
 {{- end -}}
 {{- if (and $sev (le $sev $result) $enabled) -}}{{ $severity }}{{- end -}}
 {{- end }}

--- a/charts/kubedbcom-hazelcast-editor-options/templates/_helpers.tpl
+++ b/charts/kubedbcom-hazelcast-editor-options/templates/_helpers.tpl
@@ -78,7 +78,7 @@ Alerts Enabled
 */}}
 {{- define "kubedbcom-hazelcast-editor-options.alertsEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
-{{- $result := dig . 0 $ranks -}}
+{{- $result := dig (. | default "none") 0 $ranks -}}
 {{- if $result -}}{{ . }}{{- end -}}
 {{- end }}
 
@@ -88,11 +88,11 @@ Alert Group Enabled
 {{- define "kubedbcom-hazelcast-editor-options.alertGroupEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
 {{- $flags := (mustLast .) -}}
-{{- $group := dig (mustFirst .) 0 $ranks -}}
-{{- $group = min $group (dig $flags.enabled 0 $ranks) -}}
+{{- $group := dig (mustFirst . | default "none") 0 $ranks -}}
+{{- $group = min $group (dig ($flags.enabled | default "none") 0 $ranks) -}}
 {{- $hasRules := false -}}
 {{- range $k, $v := $flags.rules -}}
-{{- $sev := dig $v.severity 0 $ranks -}}
+{{- $sev := dig ($v.severity | default "none") 0 $ranks -}}
 {{- if (and $sev (le $sev $group) $v.enabled) -}}{{ $hasRules = true }}{{- end -}}
 {{- end -}}
 {{- if (and $group $hasRules) -}}{{ $flags.enabled }}{{- end -}}
@@ -110,10 +110,10 @@ Alert Enabled
 {{- $rule := dig $key (dict) $rules -}}
 {{- $severity := dig "severity" "" $rule -}}
 {{- $enabled := dig "enabled" false $rule -}}
-{{- $sev := dig $severity 0 $ranks -}}
+{{- $sev := dig ($severity | default "none") 0 $ranks -}}
 {{- $result := 3 -}}
 {{- range $x := $flags -}}
-{{- $result = min $result (dig $x 0 $ranks) -}}
+{{- $result = min $result (dig ($x | default "none") 0 $ranks) -}}
 {{- end -}}
 {{- if (and $sev (le $sev $result) $enabled) -}}{{ $severity }}{{- end -}}
 {{- end }}

--- a/charts/kubedbcom-hazelcast-editor/templates/_helpers.tpl
+++ b/charts/kubedbcom-hazelcast-editor/templates/_helpers.tpl
@@ -78,7 +78,7 @@ Alerts Enabled
 */}}
 {{- define "kubedbcom-hazelcast-editor.alertsEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
-{{- $result := dig . 0 $ranks -}}
+{{- $result := dig (. | default "none") 0 $ranks -}}
 {{- if $result -}}{{ . }}{{- end -}}
 {{- end }}
 
@@ -88,11 +88,11 @@ Alert Group Enabled
 {{- define "kubedbcom-hazelcast-editor.alertGroupEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
 {{- $flags := (mustLast .) -}}
-{{- $group := dig (mustFirst .) 0 $ranks -}}
-{{- $group = min $group (dig $flags.enabled 0 $ranks) -}}
+{{- $group := dig (mustFirst . | default "none") 0 $ranks -}}
+{{- $group = min $group (dig ($flags.enabled | default "none") 0 $ranks) -}}
 {{- $hasRules := false -}}
 {{- range $k, $v := $flags.rules -}}
-{{- $sev := dig $v.severity 0 $ranks -}}
+{{- $sev := dig ($v.severity | default "none") 0 $ranks -}}
 {{- if (and $sev (le $sev $group) $v.enabled) -}}{{ $hasRules = true }}{{- end -}}
 {{- end -}}
 {{- if (and $group $hasRules) -}}{{ $flags.enabled }}{{- end -}}
@@ -110,10 +110,10 @@ Alert Enabled
 {{- $rule := dig $key (dict) $rules -}}
 {{- $severity := dig "severity" "" $rule -}}
 {{- $enabled := dig "enabled" false $rule -}}
-{{- $sev := dig $severity 0 $ranks -}}
+{{- $sev := dig ($severity | default "none") 0 $ranks -}}
 {{- $result := 3 -}}
 {{- range $x := $flags -}}
-{{- $result = min $result (dig $x 0 $ranks) -}}
+{{- $result = min $result (dig ($x | default "none") 0 $ranks) -}}
 {{- end -}}
 {{- if (and $sev (le $sev $result) $enabled) -}}{{ $severity }}{{- end -}}
 {{- end }}

--- a/charts/kubedbcom-ignite-editor-options/templates/_helpers.tpl
+++ b/charts/kubedbcom-ignite-editor-options/templates/_helpers.tpl
@@ -78,7 +78,7 @@ Alerts Enabled
 */}}
 {{- define "kubedbcom-ignite-editor-options.alertsEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
-{{- $result := dig . 0 $ranks -}}
+{{- $result := dig (. | default "none") 0 $ranks -}}
 {{- if $result -}}{{ . }}{{- end -}}
 {{- end }}
 
@@ -88,11 +88,11 @@ Alert Group Enabled
 {{- define "kubedbcom-ignite-editor-options.alertGroupEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
 {{- $flags := (mustLast .) -}}
-{{- $group := dig (mustFirst .) 0 $ranks -}}
-{{- $group = min $group (dig $flags.enabled 0 $ranks) -}}
+{{- $group := dig (mustFirst . | default "none") 0 $ranks -}}
+{{- $group = min $group (dig ($flags.enabled | default "none") 0 $ranks) -}}
 {{- $hasRules := false -}}
 {{- range $k, $v := $flags.rules -}}
-{{- $sev := dig $v.severity 0 $ranks -}}
+{{- $sev := dig ($v.severity | default "none") 0 $ranks -}}
 {{- if (and $sev (le $sev $group) $v.enabled) -}}{{ $hasRules = true }}{{- end -}}
 {{- end -}}
 {{- if (and $group $hasRules) -}}{{ $flags.enabled }}{{- end -}}
@@ -110,10 +110,10 @@ Alert Enabled
 {{- $rule := dig $key (dict) $rules -}}
 {{- $severity := dig "severity" "" $rule -}}
 {{- $enabled := dig "enabled" false $rule -}}
-{{- $sev := dig $severity 0 $ranks -}}
+{{- $sev := dig ($severity | default "none") 0 $ranks -}}
 {{- $result := 3 -}}
 {{- range $x := $flags -}}
-{{- $result = min $result (dig $x 0 $ranks) -}}
+{{- $result = min $result (dig ($x | default "none") 0 $ranks) -}}
 {{- end -}}
 {{- if (and $sev (le $sev $result) $enabled) -}}{{ $severity }}{{- end -}}
 {{- end }}

--- a/charts/kubedbcom-ignite-editor/templates/_helpers.tpl
+++ b/charts/kubedbcom-ignite-editor/templates/_helpers.tpl
@@ -78,7 +78,7 @@ Alerts Enabled
 */}}
 {{- define "kubedbcom-ignite-editor.alertsEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
-{{- $result := dig . 0 $ranks -}}
+{{- $result := dig (. | default "none") 0 $ranks -}}
 {{- if $result -}}{{ . }}{{- end -}}
 {{- end }}
 
@@ -88,11 +88,11 @@ Alert Group Enabled
 {{- define "kubedbcom-ignite-editor.alertGroupEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
 {{- $flags := (mustLast .) -}}
-{{- $group := dig (mustFirst .) 0 $ranks -}}
-{{- $group = min $group (dig $flags.enabled 0 $ranks) -}}
+{{- $group := dig (mustFirst . | default "none") 0 $ranks -}}
+{{- $group = min $group (dig ($flags.enabled | default "none") 0 $ranks) -}}
 {{- $hasRules := false -}}
 {{- range $k, $v := $flags.rules -}}
-{{- $sev := dig $v.severity 0 $ranks -}}
+{{- $sev := dig ($v.severity | default "none") 0 $ranks -}}
 {{- if (and $sev (le $sev $group) $v.enabled) -}}{{ $hasRules = true }}{{- end -}}
 {{- end -}}
 {{- if (and $group $hasRules) -}}{{ $flags.enabled }}{{- end -}}
@@ -110,10 +110,10 @@ Alert Enabled
 {{- $rule := dig $key (dict) $rules -}}
 {{- $severity := dig "severity" "" $rule -}}
 {{- $enabled := dig "enabled" false $rule -}}
-{{- $sev := dig $severity 0 $ranks -}}
+{{- $sev := dig ($severity | default "none") 0 $ranks -}}
 {{- $result := 3 -}}
 {{- range $x := $flags -}}
-{{- $result = min $result (dig $x 0 $ranks) -}}
+{{- $result = min $result (dig ($x | default "none") 0 $ranks) -}}
 {{- end -}}
 {{- if (and $sev (le $sev $result) $enabled) -}}{{ $severity }}{{- end -}}
 {{- end }}

--- a/charts/kubedbcom-kafka-editor-options/templates/_helpers.tpl
+++ b/charts/kubedbcom-kafka-editor-options/templates/_helpers.tpl
@@ -78,7 +78,7 @@ Alerts Enabled
 */}}
 {{- define "kubedbcom-kafka-editor-options.alertsEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
-{{- $result := dig . 0 $ranks -}}
+{{- $result := dig (. | default "none") 0 $ranks -}}
 {{- if $result -}}{{ . }}{{- end -}}
 {{- end }}
 
@@ -88,11 +88,11 @@ Alert Group Enabled
 {{- define "kubedbcom-kafka-editor-options.alertGroupEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
 {{- $flags := (mustLast .) -}}
-{{- $group := dig (mustFirst .) 0 $ranks -}}
-{{- $group = min $group (dig $flags.enabled 0 $ranks) -}}
+{{- $group := dig (mustFirst . | default "none") 0 $ranks -}}
+{{- $group = min $group (dig ($flags.enabled | default "none") 0 $ranks) -}}
 {{- $hasRules := false -}}
 {{- range $k, $v := $flags.rules -}}
-{{- $sev := dig $v.severity 0 $ranks -}}
+{{- $sev := dig ($v.severity | default "none") 0 $ranks -}}
 {{- if (and $sev (le $sev $group) $v.enabled) -}}{{ $hasRules = true }}{{- end -}}
 {{- end -}}
 {{- if (and $group $hasRules) -}}{{ $flags.enabled }}{{- end -}}
@@ -110,10 +110,10 @@ Alert Enabled
 {{- $rule := dig $key (dict) $rules -}}
 {{- $severity := dig "severity" "" $rule -}}
 {{- $enabled := dig "enabled" false $rule -}}
-{{- $sev := dig $severity 0 $ranks -}}
+{{- $sev := dig ($severity | default "none") 0 $ranks -}}
 {{- $result := 3 -}}
 {{- range $x := $flags -}}
-{{- $result = min $result (dig $x 0 $ranks) -}}
+{{- $result = min $result (dig ($x | default "none") 0 $ranks) -}}
 {{- end -}}
 {{- if (and $sev (le $sev $result) $enabled) -}}{{ $severity }}{{- end -}}
 {{- end }}

--- a/charts/kubedbcom-kafka-editor/templates/_helpers.tpl
+++ b/charts/kubedbcom-kafka-editor/templates/_helpers.tpl
@@ -78,7 +78,7 @@ Alerts Enabled
 */}}
 {{- define "kubedbcom-kafka-editor.alertsEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
-{{- $result := dig . 0 $ranks -}}
+{{- $result := dig (. | default "none") 0 $ranks -}}
 {{- if $result -}}{{ . }}{{- end -}}
 {{- end }}
 
@@ -88,11 +88,11 @@ Alert Group Enabled
 {{- define "kubedbcom-kafka-editor.alertGroupEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
 {{- $flags := (mustLast .) -}}
-{{- $group := dig (mustFirst .) 0 $ranks -}}
-{{- $group = min $group (dig $flags.enabled 0 $ranks) -}}
+{{- $group := dig (mustFirst . | default "none") 0 $ranks -}}
+{{- $group = min $group (dig ($flags.enabled | default "none") 0 $ranks) -}}
 {{- $hasRules := false -}}
 {{- range $k, $v := $flags.rules -}}
-{{- $sev := dig $v.severity 0 $ranks -}}
+{{- $sev := dig ($v.severity | default "none") 0 $ranks -}}
 {{- if (and $sev (le $sev $group) $v.enabled) -}}{{ $hasRules = true }}{{- end -}}
 {{- end -}}
 {{- if (and $group $hasRules) -}}{{ $flags.enabled }}{{- end -}}
@@ -110,10 +110,10 @@ Alert Enabled
 {{- $rule := dig $key (dict) $rules -}}
 {{- $severity := dig "severity" "" $rule -}}
 {{- $enabled := dig "enabled" false $rule -}}
-{{- $sev := dig $severity 0 $ranks -}}
+{{- $sev := dig ($severity | default "none") 0 $ranks -}}
 {{- $result := 3 -}}
 {{- range $x := $flags -}}
-{{- $result = min $result (dig $x 0 $ranks) -}}
+{{- $result = min $result (dig ($x | default "none") 0 $ranks) -}}
 {{- end -}}
 {{- if (and $sev (le $sev $result) $enabled) -}}{{ $severity }}{{- end -}}
 {{- end }}

--- a/charts/kubedbcom-mariadb-editor-options/templates/_helpers.tpl
+++ b/charts/kubedbcom-mariadb-editor-options/templates/_helpers.tpl
@@ -78,7 +78,7 @@ Alerts Enabled
 */}}
 {{- define "kubedbcom-mariadb-editor-options.alertsEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
-{{- $result := dig . 0 $ranks -}}
+{{- $result := dig (. | default "none") 0 $ranks -}}
 {{- if $result -}}{{ . }}{{- end -}}
 {{- end }}
 
@@ -88,11 +88,11 @@ Alert Group Enabled
 {{- define "kubedbcom-mariadb-editor-options.alertGroupEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
 {{- $flags := (mustLast .) -}}
-{{- $group := dig (mustFirst .) 0 $ranks -}}
-{{- $group = min $group (dig $flags.enabled 0 $ranks) -}}
+{{- $group := dig (mustFirst . | default "none") 0 $ranks -}}
+{{- $group = min $group (dig ($flags.enabled | default "none") 0 $ranks) -}}
 {{- $hasRules := false -}}
 {{- range $k, $v := $flags.rules -}}
-{{- $sev := dig $v.severity 0 $ranks -}}
+{{- $sev := dig ($v.severity | default "none") 0 $ranks -}}
 {{- if (and $sev (le $sev $group) $v.enabled) -}}{{ $hasRules = true }}{{- end -}}
 {{- end -}}
 {{- if (and $group $hasRules) -}}{{ $flags.enabled }}{{- end -}}
@@ -110,10 +110,10 @@ Alert Enabled
 {{- $rule := dig $key (dict) $rules -}}
 {{- $severity := dig "severity" "" $rule -}}
 {{- $enabled := dig "enabled" false $rule -}}
-{{- $sev := dig $severity 0 $ranks -}}
+{{- $sev := dig ($severity | default "none") 0 $ranks -}}
 {{- $result := 3 -}}
 {{- range $x := $flags -}}
-{{- $result = min $result (dig $x 0 $ranks) -}}
+{{- $result = min $result (dig ($x | default "none") 0 $ranks) -}}
 {{- end -}}
 {{- if (and $sev (le $sev $result) $enabled) -}}{{ $severity }}{{- end -}}
 {{- end }}

--- a/charts/kubedbcom-mariadb-editor/templates/_helpers.tpl
+++ b/charts/kubedbcom-mariadb-editor/templates/_helpers.tpl
@@ -78,7 +78,7 @@ Alerts Enabled
 */}}
 {{- define "kubedbcom-mariadb-editor.alertsEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
-{{- $result := dig . 0 $ranks -}}
+{{- $result := dig (. | default "none") 0 $ranks -}}
 {{- if $result -}}{{ . }}{{- end -}}
 {{- end }}
 
@@ -88,11 +88,11 @@ Alert Group Enabled
 {{- define "kubedbcom-mariadb-editor.alertGroupEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
 {{- $flags := (mustLast .) -}}
-{{- $group := dig (mustFirst .) 0 $ranks -}}
-{{- $group = min $group (dig $flags.enabled 0 $ranks) -}}
+{{- $group := dig (mustFirst . | default "none") 0 $ranks -}}
+{{- $group = min $group (dig ($flags.enabled | default "none") 0 $ranks) -}}
 {{- $hasRules := false -}}
 {{- range $k, $v := $flags.rules -}}
-{{- $sev := dig $v.severity 0 $ranks -}}
+{{- $sev := dig ($v.severity | default "none") 0 $ranks -}}
 {{- if (and $sev (le $sev $group) $v.enabled) -}}{{ $hasRules = true }}{{- end -}}
 {{- end -}}
 {{- if (and $group $hasRules) -}}{{ $flags.enabled }}{{- end -}}
@@ -110,10 +110,10 @@ Alert Enabled
 {{- $rule := dig $key (dict) $rules -}}
 {{- $severity := dig "severity" "" $rule -}}
 {{- $enabled := dig "enabled" false $rule -}}
-{{- $sev := dig $severity 0 $ranks -}}
+{{- $sev := dig ($severity | default "none") 0 $ranks -}}
 {{- $result := 3 -}}
 {{- range $x := $flags -}}
-{{- $result = min $result (dig $x 0 $ranks) -}}
+{{- $result = min $result (dig ($x | default "none") 0 $ranks) -}}
 {{- end -}}
 {{- if (and $sev (le $sev $result) $enabled) -}}{{ $severity }}{{- end -}}
 {{- end }}

--- a/charts/kubedbcom-memcached-editor-options/templates/_helpers.tpl
+++ b/charts/kubedbcom-memcached-editor-options/templates/_helpers.tpl
@@ -78,7 +78,7 @@ Alerts Enabled
 */}}
 {{- define "kubedbcom-memcached-editor-options.alertsEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
-{{- $result := dig . 0 $ranks -}}
+{{- $result := dig (. | default "none") 0 $ranks -}}
 {{- if $result -}}{{ . }}{{- end -}}
 {{- end }}
 
@@ -88,11 +88,11 @@ Alert Group Enabled
 {{- define "kubedbcom-memcached-editor-options.alertGroupEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
 {{- $flags := (mustLast .) -}}
-{{- $group := dig (mustFirst .) 0 $ranks -}}
-{{- $group = min $group (dig $flags.enabled 0 $ranks) -}}
+{{- $group := dig (mustFirst . | default "none") 0 $ranks -}}
+{{- $group = min $group (dig ($flags.enabled | default "none") 0 $ranks) -}}
 {{- $hasRules := false -}}
 {{- range $k, $v := $flags.rules -}}
-{{- $sev := dig $v.severity 0 $ranks -}}
+{{- $sev := dig ($v.severity | default "none") 0 $ranks -}}
 {{- if (and $sev (le $sev $group) $v.enabled) -}}{{ $hasRules = true }}{{- end -}}
 {{- end -}}
 {{- if (and $group $hasRules) -}}{{ $flags.enabled }}{{- end -}}
@@ -110,10 +110,10 @@ Alert Enabled
 {{- $rule := dig $key (dict) $rules -}}
 {{- $severity := dig "severity" "" $rule -}}
 {{- $enabled := dig "enabled" false $rule -}}
-{{- $sev := dig $severity 0 $ranks -}}
+{{- $sev := dig ($severity | default "none") 0 $ranks -}}
 {{- $result := 3 -}}
 {{- range $x := $flags -}}
-{{- $result = min $result (dig $x 0 $ranks) -}}
+{{- $result = min $result (dig ($x | default "none") 0 $ranks) -}}
 {{- end -}}
 {{- if (and $sev (le $sev $result) $enabled) -}}{{ $severity }}{{- end -}}
 {{- end }}

--- a/charts/kubedbcom-memcached-editor/templates/_helpers.tpl
+++ b/charts/kubedbcom-memcached-editor/templates/_helpers.tpl
@@ -78,7 +78,7 @@ Alerts Enabled
 */}}
 {{- define "kubedbcom-memcached-editor.alertsEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
-{{- $result := dig . 0 $ranks -}}
+{{- $result := dig (. | default "none") 0 $ranks -}}
 {{- if $result -}}{{ . }}{{- end -}}
 {{- end }}
 
@@ -88,11 +88,11 @@ Alert Group Enabled
 {{- define "kubedbcom-memcached-editor.alertGroupEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
 {{- $flags := (mustLast .) -}}
-{{- $group := dig (mustFirst .) 0 $ranks -}}
-{{- $group = min $group (dig $flags.enabled 0 $ranks) -}}
+{{- $group := dig (mustFirst . | default "none") 0 $ranks -}}
+{{- $group = min $group (dig ($flags.enabled | default "none") 0 $ranks) -}}
 {{- $hasRules := false -}}
 {{- range $k, $v := $flags.rules -}}
-{{- $sev := dig $v.severity 0 $ranks -}}
+{{- $sev := dig ($v.severity | default "none") 0 $ranks -}}
 {{- if (and $sev (le $sev $group) $v.enabled) -}}{{ $hasRules = true }}{{- end -}}
 {{- end -}}
 {{- if (and $group $hasRules) -}}{{ $flags.enabled }}{{- end -}}
@@ -110,10 +110,10 @@ Alert Enabled
 {{- $rule := dig $key (dict) $rules -}}
 {{- $severity := dig "severity" "" $rule -}}
 {{- $enabled := dig "enabled" false $rule -}}
-{{- $sev := dig $severity 0 $ranks -}}
+{{- $sev := dig ($severity | default "none") 0 $ranks -}}
 {{- $result := 3 -}}
 {{- range $x := $flags -}}
-{{- $result = min $result (dig $x 0 $ranks) -}}
+{{- $result = min $result (dig ($x | default "none") 0 $ranks) -}}
 {{- end -}}
 {{- if (and $sev (le $sev $result) $enabled) -}}{{ $severity }}{{- end -}}
 {{- end }}

--- a/charts/kubedbcom-milvus-editor-options/templates/_helpers.tpl
+++ b/charts/kubedbcom-milvus-editor-options/templates/_helpers.tpl
@@ -78,7 +78,7 @@ Alerts Enabled
 */}}
 {{- define "kubedbcom-milvus-editor-options.alertsEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
-{{- $result := dig . 0 $ranks -}}
+{{- $result := dig (. | default "none") 0 $ranks -}}
 {{- if $result -}}{{ . }}{{- end -}}
 {{- end }}
 
@@ -88,11 +88,11 @@ Alert Group Enabled
 {{- define "kubedbcom-milvus-editor-options.alertGroupEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
 {{- $flags := (mustLast .) -}}
-{{- $group := dig (mustFirst .) 0 $ranks -}}
-{{- $group = min $group (dig $flags.enabled 0 $ranks) -}}
+{{- $group := dig (mustFirst . | default "none") 0 $ranks -}}
+{{- $group = min $group (dig ($flags.enabled | default "none") 0 $ranks) -}}
 {{- $hasRules := false -}}
 {{- range $k, $v := $flags.rules -}}
-{{- $sev := dig $v.severity 0 $ranks -}}
+{{- $sev := dig ($v.severity | default "none") 0 $ranks -}}
 {{- if (and $sev (le $sev $group) $v.enabled) -}}{{ $hasRules = true }}{{- end -}}
 {{- end }}
 {{- if (and $group $hasRules) -}}{{ $flags.enabled }}{{- end -}}
@@ -110,10 +110,10 @@ Alert Enabled
 {{- $rule := dig $key (dict) $rules -}}
 {{- $severity := dig "severity" "" $rule -}}
 {{- $enabled := dig "enabled" false $rule -}}
-{{- $sev := dig $severity 0 $ranks -}}
+{{- $sev := dig ($severity | default "none") 0 $ranks -}}
 {{- $result := 3 -}}
 {{- range $x := $flags -}}
-{{- $result = min $result (dig $x 0 $ranks) -}}
+{{- $result = min $result (dig ($x | default "none") 0 $ranks) -}}
 {{- end -}}
 {{- if (and $sev (le $sev $result) $enabled) -}}{{ $severity }}{{- end -}}
 {{- end }}

--- a/charts/kubedbcom-milvus-editor/templates/_helpers.tpl
+++ b/charts/kubedbcom-milvus-editor/templates/_helpers.tpl
@@ -78,7 +78,7 @@ Alerts Enabled
 */}}
 {{- define "kubedbcom-milvus-editor.alertsEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
-{{- $result := dig . 0 $ranks -}}
+{{- $result := dig (. | default "none") 0 $ranks -}}
 {{- if $result -}}{{ . }}{{- end -}}
 {{- end }}
 
@@ -88,11 +88,11 @@ Alert Group Enabled
 {{- define "kubedbcom-milvus-editor.alertGroupEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
 {{- $flags := (mustLast .) -}}
-{{- $group := dig (mustFirst .) 0 $ranks -}}
-{{- $group = min $group (dig $flags.enabled 0 $ranks) -}}
+{{- $group := dig (mustFirst . | default "none") 0 $ranks -}}
+{{- $group = min $group (dig ($flags.enabled | default "none") 0 $ranks) -}}
 {{- $hasRules := false -}}
 {{- range $k, $v := $flags.rules -}}
-{{- $sev := dig $v.severity 0 $ranks -}}
+{{- $sev := dig ($v.severity | default "none") 0 $ranks -}}
 {{- if (and $sev (le $sev $group) $v.enabled) -}}{{ $hasRules = true }}{{- end -}}
 {{- end }}
 {{- if (and $group $hasRules) -}}{{ $flags.enabled }}{{- end -}}
@@ -110,10 +110,10 @@ Alert Enabled
 {{- $rule := dig $key (dict) $rules -}}
 {{- $severity := dig "severity" "" $rule -}}
 {{- $enabled := dig "enabled" false $rule -}}
-{{- $sev := dig $severity 0 $ranks -}}
+{{- $sev := dig ($severity | default "none") 0 $ranks -}}
 {{- $result := 3 -}}
 {{- range $x := $flags -}}
-{{- $result = min $result (dig $x 0 $ranks) -}}
+{{- $result = min $result (dig ($x | default "none") 0 $ranks) -}}
 {{- end -}}
 {{- if (and $sev (le $sev $result) $enabled) -}}{{ $severity }}{{- end -}}
 {{- end }}

--- a/charts/kubedbcom-mongodb-editor-options/templates/_helpers.tpl
+++ b/charts/kubedbcom-mongodb-editor-options/templates/_helpers.tpl
@@ -78,7 +78,7 @@ Alerts Enabled
 */}}
 {{- define "kubedbcom-mongodb-editor-options.alertsEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
-{{- $result := dig . 0 $ranks -}}
+{{- $result := dig (. | default "none") 0 $ranks -}}
 {{- if $result -}}{{ . }}{{- end -}}
 {{- end }}
 
@@ -88,11 +88,11 @@ Alert Group Enabled
 {{- define "kubedbcom-mongodb-editor-options.alertGroupEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
 {{- $flags := (mustLast .) -}}
-{{- $group := dig (mustFirst .) 0 $ranks -}}
-{{- $group = min $group (dig $flags.enabled 0 $ranks) -}}
+{{- $group := dig (mustFirst . | default "none") 0 $ranks -}}
+{{- $group = min $group (dig ($flags.enabled | default "none") 0 $ranks) -}}
 {{- $hasRules := false -}}
 {{- range $k, $v := $flags.rules -}}
-{{- $sev := dig $v.severity 0 $ranks -}}
+{{- $sev := dig ($v.severity | default "none") 0 $ranks -}}
 {{- if (and $sev (le $sev $group) $v.enabled) -}}{{ $hasRules = true }}{{- end -}}
 {{- end -}}
 {{- if (and $group $hasRules) -}}{{ $flags.enabled }}{{- end -}}
@@ -110,10 +110,10 @@ Alert Enabled
 {{- $rule := dig $key (dict) $rules -}}
 {{- $severity := dig "severity" "" $rule -}}
 {{- $enabled := dig "enabled" false $rule -}}
-{{- $sev := dig $severity 0 $ranks -}}
+{{- $sev := dig ($severity | default "none") 0 $ranks -}}
 {{- $result := 3 -}}
 {{- range $x := $flags -}}
-{{- $result = min $result (dig $x 0 $ranks) -}}
+{{- $result = min $result (dig ($x | default "none") 0 $ranks) -}}
 {{- end -}}
 {{- if (and $sev (le $sev $result) $enabled) -}}{{ $severity }}{{- end -}}
 {{- end }}

--- a/charts/kubedbcom-mongodb-editor/templates/_helpers.tpl
+++ b/charts/kubedbcom-mongodb-editor/templates/_helpers.tpl
@@ -78,7 +78,7 @@ Alerts Enabled
 */}}
 {{- define "kubedbcom-mongodb-editor.alertsEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
-{{- $result := dig . 0 $ranks -}}
+{{- $result := dig (. | default "none") 0 $ranks -}}
 {{- if $result -}}{{ . }}{{- end -}}
 {{- end }}
 
@@ -88,11 +88,11 @@ Alert Group Enabled
 {{- define "kubedbcom-mongodb-editor.alertGroupEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
 {{- $flags := (mustLast .) -}}
-{{- $group := dig (mustFirst .) 0 $ranks -}}
-{{- $group = min $group (dig $flags.enabled 0 $ranks) -}}
+{{- $group := dig (mustFirst . | default "none") 0 $ranks -}}
+{{- $group = min $group (dig ($flags.enabled | default "none") 0 $ranks) -}}
 {{- $hasRules := false -}}
 {{- range $k, $v := $flags.rules -}}
-{{- $sev := dig $v.severity 0 $ranks -}}
+{{- $sev := dig ($v.severity | default "none") 0 $ranks -}}
 {{- if (and $sev (le $sev $group) $v.enabled) -}}{{ $hasRules = true }}{{- end -}}
 {{- end -}}
 {{- if (and $group $hasRules) -}}{{ $flags.enabled }}{{- end -}}
@@ -110,10 +110,10 @@ Alert Enabled
 {{- $rule := dig $key (dict) $rules -}}
 {{- $severity := dig "severity" "" $rule -}}
 {{- $enabled := dig "enabled" false $rule -}}
-{{- $sev := dig $severity 0 $ranks -}}
+{{- $sev := dig ($severity | default "none") 0 $ranks -}}
 {{- $result := 3 -}}
 {{- range $x := $flags -}}
-{{- $result = min $result (dig $x 0 $ranks) -}}
+{{- $result = min $result (dig ($x | default "none") 0 $ranks) -}}
 {{- end -}}
 {{- if (and $sev (le $sev $result) $enabled) -}}{{ $severity }}{{- end -}}
 {{- end }}

--- a/charts/kubedbcom-mssqlserver-editor-options/templates/_helpers.tpl
+++ b/charts/kubedbcom-mssqlserver-editor-options/templates/_helpers.tpl
@@ -78,7 +78,7 @@ Alerts Enabled
 */}}
 {{- define "kubedbcom-mssqlserver-editor-options.alertsEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
-{{- $result := dig . 0 $ranks -}}
+{{- $result := dig (. | default "none") 0 $ranks -}}
 {{- if $result -}}{{ . }}{{- end -}}
 {{- end }}
 
@@ -88,11 +88,11 @@ Alert Group Enabled
 {{- define "kubedbcom-mssqlserver-editor-options.alertGroupEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
 {{- $flags := (mustLast .) -}}
-{{- $group := dig (mustFirst .) 0 $ranks -}}
-{{- $group = min $group (dig $flags.enabled 0 $ranks) -}}
+{{- $group := dig (mustFirst . | default "none") 0 $ranks -}}
+{{- $group = min $group (dig ($flags.enabled | default "none") 0 $ranks) -}}
 {{- $hasRules := false -}}
 {{- range $k, $v := $flags.rules -}}
-{{- $sev := dig $v.severity 0 $ranks -}}
+{{- $sev := dig ($v.severity | default "none") 0 $ranks -}}
 {{- if (and $sev (le $sev $group) $v.enabled) -}}{{ $hasRules = true }}{{- end -}}
 {{- end -}}
 {{- if (and $group $hasRules) -}}{{ $flags.enabled }}{{- end -}}
@@ -110,10 +110,10 @@ Alert Enabled
 {{- $rule := dig $key (dict) $rules -}}
 {{- $severity := dig "severity" "" $rule -}}
 {{- $enabled := dig "enabled" false $rule -}}
-{{- $sev := dig $severity 0 $ranks -}}
+{{- $sev := dig ($severity | default "none") 0 $ranks -}}
 {{- $result := 3 -}}
 {{- range $x := $flags -}}
-{{- $result = min $result (dig $x 0 $ranks) -}}
+{{- $result = min $result (dig ($x | default "none") 0 $ranks) -}}
 {{- end -}}
 {{- if (and $sev (le $sev $result) $enabled) -}}{{ $severity }}{{- end -}}
 {{- end }}

--- a/charts/kubedbcom-mssqlserver-editor/templates/_helpers.tpl
+++ b/charts/kubedbcom-mssqlserver-editor/templates/_helpers.tpl
@@ -78,7 +78,7 @@ Alerts Enabled
 */}}
 {{- define "kubedbcom-mssqlserver-editor.alertsEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
-{{- $result := dig . 0 $ranks -}}
+{{- $result := dig (. | default "none") 0 $ranks -}}
 {{- if $result -}}{{ . }}{{- end -}}
 {{- end }}
 
@@ -88,11 +88,11 @@ Alert Group Enabled
 {{- define "kubedbcom-mssqlserver-editor.alertGroupEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
 {{- $flags := (mustLast .) -}}
-{{- $group := dig (mustFirst .) 0 $ranks -}}
-{{- $group = min $group (dig $flags.enabled 0 $ranks) -}}
+{{- $group := dig (mustFirst . | default "none") 0 $ranks -}}
+{{- $group = min $group (dig ($flags.enabled | default "none") 0 $ranks) -}}
 {{- $hasRules := false -}}
 {{- range $k, $v := $flags.rules -}}
-{{- $sev := dig $v.severity 0 $ranks -}}
+{{- $sev := dig ($v.severity | default "none") 0 $ranks -}}
 {{- if (and $sev (le $sev $group) $v.enabled) -}}{{ $hasRules = true }}{{- end -}}
 {{- end -}}
 {{- if (and $group $hasRules) -}}{{ $flags.enabled }}{{- end -}}
@@ -110,10 +110,10 @@ Alert Enabled
 {{- $rule := dig $key (dict) $rules -}}
 {{- $severity := dig "severity" "" $rule -}}
 {{- $enabled := dig "enabled" false $rule -}}
-{{- $sev := dig $severity 0 $ranks -}}
+{{- $sev := dig ($severity | default "none") 0 $ranks -}}
 {{- $result := 3 -}}
 {{- range $x := $flags -}}
-{{- $result = min $result (dig $x 0 $ranks) -}}
+{{- $result = min $result (dig ($x | default "none") 0 $ranks) -}}
 {{- end -}}
 {{- if (and $sev (le $sev $result) $enabled) -}}{{ $severity }}{{- end -}}
 {{- end }}

--- a/charts/kubedbcom-mysql-editor-options/templates/_helpers.tpl
+++ b/charts/kubedbcom-mysql-editor-options/templates/_helpers.tpl
@@ -78,7 +78,7 @@ Alerts Enabled
 */}}
 {{- define "kubedbcom-mysql-editor-options.alertsEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
-{{- $result := dig . 0 $ranks -}}
+{{- $result := dig (. | default "none") 0 $ranks -}}
 {{- if $result -}}{{ . }}{{- end -}}
 {{- end }}
 
@@ -88,11 +88,11 @@ Alert Group Enabled
 {{- define "kubedbcom-mysql-editor-options.alertGroupEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
 {{- $flags := (mustLast .) -}}
-{{- $group := dig (mustFirst .) 0 $ranks -}}
-{{- $group = min $group (dig $flags.enabled 0 $ranks) -}}
+{{- $group := dig (mustFirst . | default "none") 0 $ranks -}}
+{{- $group = min $group (dig ($flags.enabled | default "none") 0 $ranks) -}}
 {{- $hasRules := false -}}
 {{- range $k, $v := $flags.rules -}}
-{{- $sev := dig $v.severity 0 $ranks -}}
+{{- $sev := dig ($v.severity | default "none") 0 $ranks -}}
 {{- if (and $sev (le $sev $group) $v.enabled) -}}{{ $hasRules = true }}{{- end -}}
 {{- end -}}
 {{- if (and $group $hasRules) -}}{{ $flags.enabled }}{{- end -}}
@@ -110,10 +110,10 @@ Alert Enabled
 {{- $rule := dig $key (dict) $rules -}}
 {{- $severity := dig "severity" "" $rule -}}
 {{- $enabled := dig "enabled" false $rule -}}
-{{- $sev := dig $severity 0 $ranks -}}
+{{- $sev := dig ($severity | default "none") 0 $ranks -}}
 {{- $result := 3 -}}
 {{- range $x := $flags -}}
-{{- $result = min $result (dig $x 0 $ranks) -}}
+{{- $result = min $result (dig ($x | default "none") 0 $ranks) -}}
 {{- end -}}
 {{- if (and $sev (le $sev $result) $enabled) -}}{{ $severity }}{{- end -}}
 {{- end }}

--- a/charts/kubedbcom-mysql-editor/templates/_helpers.tpl
+++ b/charts/kubedbcom-mysql-editor/templates/_helpers.tpl
@@ -78,7 +78,7 @@ Alerts Enabled
 */}}
 {{- define "kubedbcom-mysql-editor.alertsEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
-{{- $result := dig . 0 $ranks -}}
+{{- $result := dig (. | default "none") 0 $ranks -}}
 {{- if $result -}}{{ . }}{{- end -}}
 {{- end }}
 
@@ -88,11 +88,11 @@ Alert Group Enabled
 {{- define "kubedbcom-mysql-editor.alertGroupEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
 {{- $flags := (mustLast .) -}}
-{{- $group := dig (mustFirst .) 0 $ranks -}}
-{{- $group = min $group (dig $flags.enabled 0 $ranks) -}}
+{{- $group := dig (mustFirst . | default "none") 0 $ranks -}}
+{{- $group = min $group (dig ($flags.enabled | default "none") 0 $ranks) -}}
 {{- $hasRules := false -}}
 {{- range $k, $v := $flags.rules -}}
-{{- $sev := dig $v.severity 0 $ranks -}}
+{{- $sev := dig ($v.severity | default "none") 0 $ranks -}}
 {{- if (and $sev (le $sev $group) $v.enabled) -}}{{ $hasRules = true }}{{- end -}}
 {{- end -}}
 {{- if (and $group $hasRules) -}}{{ $flags.enabled }}{{- end -}}
@@ -110,10 +110,10 @@ Alert Enabled
 {{- $rule := dig $key (dict) $rules -}}
 {{- $severity := dig "severity" "" $rule -}}
 {{- $enabled := dig "enabled" false $rule -}}
-{{- $sev := dig $severity 0 $ranks -}}
+{{- $sev := dig ($severity | default "none") 0 $ranks -}}
 {{- $result := 3 -}}
 {{- range $x := $flags -}}
-{{- $result = min $result (dig $x 0 $ranks) -}}
+{{- $result = min $result (dig ($x | default "none") 0 $ranks) -}}
 {{- end -}}
 {{- if (and $sev (le $sev $result) $enabled) -}}{{ $severity }}{{- end -}}
 {{- end }}

--- a/charts/kubedbcom-neo4j-editor-options/templates/_helpers.tpl
+++ b/charts/kubedbcom-neo4j-editor-options/templates/_helpers.tpl
@@ -78,7 +78,7 @@ Alerts Enabled
 */}}
 {{- define "kubedbcom-neo4j-editor-options.alertsEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
-{{- $result := dig . 0 $ranks -}}
+{{- $result := dig (. | default "none") 0 $ranks -}}
 {{- if $result -}}{{ . }}{{- end -}}
 {{- end }}
 
@@ -88,11 +88,11 @@ Alert Group Enabled
 {{- define "kubedbcom-neo4j-editor-options.alertGroupEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
 {{- $flags := (mustLast .) -}}
-{{- $group := dig (mustFirst .) 0 $ranks -}}
-{{- $group = min $group (dig $flags.enabled 0 $ranks) -}}
+{{- $group := dig (mustFirst . | default "none") 0 $ranks -}}
+{{- $group = min $group (dig ($flags.enabled | default "none") 0 $ranks) -}}
 {{- $hasRules := false -}}
 {{- range $k, $v := $flags.rules -}}
-{{- $sev := dig $v.severity 0 $ranks -}}
+{{- $sev := dig ($v.severity | default "none") 0 $ranks -}}
 {{- if (and $sev (le $sev $group) $v.enabled) -}}{{ $hasRules = true }}{{- end -}}
 {{- end -}}
 {{- if (and $group $hasRules) -}}{{ $flags.enabled }}{{- end -}}
@@ -110,10 +110,10 @@ Alert Enabled
 {{- $rule := dig $key (dict) $rules -}}
 {{- $severity := dig "severity" "" $rule -}}
 {{- $enabled := dig "enabled" false $rule -}}
-{{- $sev := dig $severity 0 $ranks -}}
+{{- $sev := dig ($severity | default "none") 0 $ranks -}}
 {{- $result := 3 -}}
 {{- range $x := $flags -}}
-{{- $result = min $result (dig $x 0 $ranks) -}}
+{{- $result = min $result (dig ($x | default "none") 0 $ranks) -}}
 {{- end -}}
 {{- if (and $sev (le $sev $result) $enabled) -}}{{ $severity }}{{- end -}}
 {{- end }}

--- a/charts/kubedbcom-neo4j-editor/templates/_helpers.tpl
+++ b/charts/kubedbcom-neo4j-editor/templates/_helpers.tpl
@@ -78,7 +78,7 @@ Alerts Enabled
 */}}
 {{- define "kubedbcom-neo4j-editor.alertsEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
-{{- $result := dig . 0 $ranks -}}
+{{- $result := dig (. | default "none") 0 $ranks -}}
 {{- if $result -}}{{ . }}{{- end -}}
 {{- end }}
 
@@ -88,11 +88,11 @@ Alert Group Enabled
 {{- define "kubedbcom-neo4j-editor.alertGroupEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
 {{- $flags := (mustLast .) -}}
-{{- $group := dig (mustFirst .) 0 $ranks -}}
-{{- $group = min $group (dig $flags.enabled 0 $ranks) -}}
+{{- $group := dig (mustFirst . | default "none") 0 $ranks -}}
+{{- $group = min $group (dig ($flags.enabled | default "none") 0 $ranks) -}}
 {{- $hasRules := false -}}
 {{- range $k, $v := $flags.rules -}}
-{{- $sev := dig $v.severity 0 $ranks -}}
+{{- $sev := dig ($v.severity | default "none") 0 $ranks -}}
 {{- if (and $sev (le $sev $group) $v.enabled) -}}{{ $hasRules = true }}{{- end -}}
 {{- end -}}
 {{- if (and $group $hasRules) -}}{{ $flags.enabled }}{{- end -}}
@@ -110,10 +110,10 @@ Alert Enabled
 {{- $rule := dig $key (dict) $rules -}}
 {{- $severity := dig "severity" "" $rule -}}
 {{- $enabled := dig "enabled" false $rule -}}
-{{- $sev := dig $severity 0 $ranks -}}
+{{- $sev := dig ($severity | default "none") 0 $ranks -}}
 {{- $result := 3 -}}
 {{- range $x := $flags -}}
-{{- $result = min $result (dig $x 0 $ranks) -}}
+{{- $result = min $result (dig ($x | default "none") 0 $ranks) -}}
 {{- end -}}
 {{- if (and $sev (le $sev $result) $enabled) -}}{{ $severity }}{{- end -}}
 {{- end }}

--- a/charts/kubedbcom-oracle-editor-options/templates/_helpers.tpl
+++ b/charts/kubedbcom-oracle-editor-options/templates/_helpers.tpl
@@ -78,7 +78,7 @@ Alerts Enabled
 */}}
 {{- define "kubedbcom-oracle-editor-options.alertsEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
-{{- $result := dig . 0 $ranks -}}
+{{- $result := dig (. | default "none") 0 $ranks -}}
 {{- if $result -}}{{ . }}{{- end -}}
 {{- end }}
 
@@ -88,11 +88,11 @@ Alert Group Enabled
 {{- define "kubedbcom-oracle-editor-options.alertGroupEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
 {{- $flags := (mustLast .) -}}
-{{- $group := dig (mustFirst .) 0 $ranks -}}
-{{- $group = min $group (dig $flags.enabled 0 $ranks) -}}
+{{- $group := dig (mustFirst . | default "none") 0 $ranks -}}
+{{- $group = min $group (dig ($flags.enabled | default "none") 0 $ranks) -}}
 {{- $hasRules := false -}}
 {{- range $k, $v := $flags.rules -}}
-{{- $sev := dig $v.severity 0 $ranks -}}
+{{- $sev := dig ($v.severity | default "none") 0 $ranks -}}
 {{- if (and $sev (le $sev $group) $v.enabled) -}}{{ $hasRules = true }}{{- end -}}
 {{- end -}}
 {{- if (and $group $hasRules) -}}{{ $flags.enabled }}{{- end -}}
@@ -110,10 +110,10 @@ Alert Enabled
 {{- $rule := dig $key (dict) $rules -}}
 {{- $severity := dig "severity" "" $rule -}}
 {{- $enabled := dig "enabled" false $rule -}}
-{{- $sev := dig $severity 0 $ranks -}}
+{{- $sev := dig ($severity | default "none") 0 $ranks -}}
 {{- $result := 3 -}}
 {{- range $x := $flags -}}
-{{- $result = min $result (dig $x 0 $ranks) -}}
+{{- $result = min $result (dig ($x | default "none") 0 $ranks) -}}
 {{- end -}}
 {{- if (and $sev (le $sev $result) $enabled) -}}{{ $severity }}{{- end -}}
 {{- end }}

--- a/charts/kubedbcom-oracle-editor/templates/_helpers.tpl
+++ b/charts/kubedbcom-oracle-editor/templates/_helpers.tpl
@@ -78,7 +78,7 @@ Alerts Enabled
 */}}
 {{- define "kubedbcom-oracle-editor.alertsEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
-{{- $result := dig . 0 $ranks -}}
+{{- $result := dig (. | default "none") 0 $ranks -}}
 {{- if $result -}}{{ . }}{{- end -}}
 {{- end }}
 
@@ -88,11 +88,11 @@ Alert Group Enabled
 {{- define "kubedbcom-oracle-editor.alertGroupEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
 {{- $flags := (mustLast .) -}}
-{{- $group := dig (mustFirst .) 0 $ranks -}}
-{{- $group = min $group (dig $flags.enabled 0 $ranks) -}}
+{{- $group := dig (mustFirst . | default "none") 0 $ranks -}}
+{{- $group = min $group (dig ($flags.enabled | default "none") 0 $ranks) -}}
 {{- $hasRules := false -}}
 {{- range $k, $v := $flags.rules -}}
-{{- $sev := dig $v.severity 0 $ranks -}}
+{{- $sev := dig ($v.severity | default "none") 0 $ranks -}}
 {{- if (and $sev (le $sev $group) $v.enabled) -}}{{ $hasRules = true }}{{- end -}}
 {{- end -}}
 {{- if (and $group $hasRules) -}}{{ $flags.enabled }}{{- end -}}
@@ -110,10 +110,10 @@ Alert Enabled
 {{- $rule := dig $key (dict) $rules -}}
 {{- $severity := dig "severity" "" $rule -}}
 {{- $enabled := dig "enabled" false $rule -}}
-{{- $sev := dig $severity 0 $ranks -}}
+{{- $sev := dig ($severity | default "none") 0 $ranks -}}
 {{- $result := 3 -}}
 {{- range $x := $flags -}}
-{{- $result = min $result (dig $x 0 $ranks) -}}
+{{- $result = min $result (dig ($x | default "none") 0 $ranks) -}}
 {{- end -}}
 {{- if (and $sev (le $sev $result) $enabled) -}}{{ $severity }}{{- end -}}
 {{- end }}

--- a/charts/kubedbcom-perconaxtradb-editor-options/templates/_helpers.tpl
+++ b/charts/kubedbcom-perconaxtradb-editor-options/templates/_helpers.tpl
@@ -78,7 +78,7 @@ Alerts Enabled
 */}}
 {{- define "kubedbcom-perconaxtradb-editor-options.alertsEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
-{{- $result := dig . 0 $ranks -}}
+{{- $result := dig (. | default "none") 0 $ranks -}}
 {{- if $result -}}{{ . }}{{- end -}}
 {{- end }}
 
@@ -88,11 +88,11 @@ Alert Group Enabled
 {{- define "kubedbcom-perconaxtradb-editor-options.alertGroupEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
 {{- $flags := (mustLast .) -}}
-{{- $group := dig (mustFirst .) 0 $ranks -}}
-{{- $group = min $group (dig $flags.enabled 0 $ranks) -}}
+{{- $group := dig (mustFirst . | default "none") 0 $ranks -}}
+{{- $group = min $group (dig ($flags.enabled | default "none") 0 $ranks) -}}
 {{- $hasRules := false -}}
 {{- range $k, $v := $flags.rules -}}
-{{- $sev := dig $v.severity 0 $ranks -}}
+{{- $sev := dig ($v.severity | default "none") 0 $ranks -}}
 {{- if (and $sev (le $sev $group) $v.enabled) -}}{{ $hasRules = true }}{{- end -}}
 {{- end -}}
 {{- if (and $group $hasRules) -}}{{ $flags.enabled }}{{- end -}}
@@ -110,10 +110,10 @@ Alert Enabled
 {{- $rule := dig $key (dict) $rules -}}
 {{- $severity := dig "severity" "" $rule -}}
 {{- $enabled := dig "enabled" false $rule -}}
-{{- $sev := dig $severity 0 $ranks -}}
+{{- $sev := dig ($severity | default "none") 0 $ranks -}}
 {{- $result := 3 -}}
 {{- range $x := $flags -}}
-{{- $result = min $result (dig $x 0 $ranks) -}}
+{{- $result = min $result (dig ($x | default "none") 0 $ranks) -}}
 {{- end -}}
 {{- if (and $sev (le $sev $result) $enabled) -}}{{ $severity }}{{- end -}}
 {{- end }}

--- a/charts/kubedbcom-perconaxtradb-editor/templates/_helpers.tpl
+++ b/charts/kubedbcom-perconaxtradb-editor/templates/_helpers.tpl
@@ -78,7 +78,7 @@ Alerts Enabled
 */}}
 {{- define "kubedbcom-perconaxtradb-editor.alertsEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
-{{- $result := dig . 0 $ranks -}}
+{{- $result := dig (. | default "none") 0 $ranks -}}
 {{- if $result -}}{{ . }}{{- end -}}
 {{- end }}
 
@@ -88,11 +88,11 @@ Alert Group Enabled
 {{- define "kubedbcom-perconaxtradb-editor.alertGroupEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
 {{- $flags := (mustLast .) -}}
-{{- $group := dig (mustFirst .) 0 $ranks -}}
-{{- $group = min $group (dig $flags.enabled 0 $ranks) -}}
+{{- $group := dig (mustFirst . | default "none") 0 $ranks -}}
+{{- $group = min $group (dig ($flags.enabled | default "none") 0 $ranks) -}}
 {{- $hasRules := false -}}
 {{- range $k, $v := $flags.rules -}}
-{{- $sev := dig $v.severity 0 $ranks -}}
+{{- $sev := dig ($v.severity | default "none") 0 $ranks -}}
 {{- if (and $sev (le $sev $group) $v.enabled) -}}{{ $hasRules = true }}{{- end -}}
 {{- end -}}
 {{- if (and $group $hasRules) -}}{{ $flags.enabled }}{{- end -}}
@@ -110,10 +110,10 @@ Alert Enabled
 {{- $rule := dig $key (dict) $rules -}}
 {{- $severity := dig "severity" "" $rule -}}
 {{- $enabled := dig "enabled" false $rule -}}
-{{- $sev := dig $severity 0 $ranks -}}
+{{- $sev := dig ($severity | default "none") 0 $ranks -}}
 {{- $result := 3 -}}
 {{- range $x := $flags -}}
-{{- $result = min $result (dig $x 0 $ranks) -}}
+{{- $result = min $result (dig ($x | default "none") 0 $ranks) -}}
 {{- end -}}
 {{- if (and $sev (le $sev $result) $enabled) -}}{{ $severity }}{{- end -}}
 {{- end }}

--- a/charts/kubedbcom-pgbouncer-editor-options/templates/_helpers.tpl
+++ b/charts/kubedbcom-pgbouncer-editor-options/templates/_helpers.tpl
@@ -78,7 +78,7 @@ Alerts Enabled
 */}}
 {{- define "kubedbcom-pgbouncer-editor-options.alertsEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
-{{- $result := dig . 0 $ranks -}}
+{{- $result := dig (. | default "none") 0 $ranks -}}
 {{- if $result -}}{{ . }}{{- end -}}
 {{- end }}
 
@@ -88,11 +88,11 @@ Alert Group Enabled
 {{- define "kubedbcom-pgbouncer-editor-options.alertGroupEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
 {{- $flags := (mustLast .) -}}
-{{- $group := dig (mustFirst .) 0 $ranks -}}
-{{- $group = min $group (dig $flags.enabled 0 $ranks) -}}
+{{- $group := dig (mustFirst . | default "none") 0 $ranks -}}
+{{- $group = min $group (dig ($flags.enabled | default "none") 0 $ranks) -}}
 {{- $hasRules := false -}}
 {{- range $k, $v := $flags.rules -}}
-{{- $sev := dig $v.severity 0 $ranks -}}
+{{- $sev := dig ($v.severity | default "none") 0 $ranks -}}
 {{- if (and $sev (le $sev $group) $v.enabled) -}}{{ $hasRules = true }}{{- end -}}
 {{- end -}}
 {{- if (and $group $hasRules) -}}{{ $flags.enabled }}{{- end -}}
@@ -110,10 +110,10 @@ Alert Enabled
 {{- $rule := dig $key (dict) $rules -}}
 {{- $severity := dig "severity" "" $rule -}}
 {{- $enabled := dig "enabled" false $rule -}}
-{{- $sev := dig $severity 0 $ranks -}}
+{{- $sev := dig ($severity | default "none") 0 $ranks -}}
 {{- $result := 3 -}}
 {{- range $x := $flags -}}
-{{- $result = min $result (dig $x 0 $ranks) -}}
+{{- $result = min $result (dig ($x | default "none") 0 $ranks) -}}
 {{- end -}}
 {{- if (and $sev (le $sev $result) $enabled) -}}{{ $severity }}{{- end -}}
 {{- end }}

--- a/charts/kubedbcom-pgbouncer-editor/templates/_helpers.tpl
+++ b/charts/kubedbcom-pgbouncer-editor/templates/_helpers.tpl
@@ -78,7 +78,7 @@ Alerts Enabled
 */}}
 {{- define "kubedbcom-pgbouncer-editor.alertsEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
-{{- $result := dig . 0 $ranks -}}
+{{- $result := dig (. | default "none") 0 $ranks -}}
 {{- if $result -}}{{ . }}{{- end -}}
 {{- end }}
 
@@ -88,11 +88,11 @@ Alert Group Enabled
 {{- define "kubedbcom-pgbouncer-editor.alertGroupEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
 {{- $flags := (mustLast .) -}}
-{{- $group := dig (mustFirst .) 0 $ranks -}}
-{{- $group = min $group (dig $flags.enabled 0 $ranks) -}}
+{{- $group := dig (mustFirst . | default "none") 0 $ranks -}}
+{{- $group = min $group (dig ($flags.enabled | default "none") 0 $ranks) -}}
 {{- $hasRules := false -}}
 {{- range $k, $v := $flags.rules -}}
-{{- $sev := dig $v.severity 0 $ranks -}}
+{{- $sev := dig ($v.severity | default "none") 0 $ranks -}}
 {{- if (and $sev (le $sev $group) $v.enabled) -}}{{ $hasRules = true }}{{- end -}}
 {{- end -}}
 {{- if (and $group $hasRules) -}}{{ $flags.enabled }}{{- end -}}
@@ -110,10 +110,10 @@ Alert Enabled
 {{- $rule := dig $key (dict) $rules -}}
 {{- $severity := dig "severity" "" $rule -}}
 {{- $enabled := dig "enabled" false $rule -}}
-{{- $sev := dig $severity 0 $ranks -}}
+{{- $sev := dig ($severity | default "none") 0 $ranks -}}
 {{- $result := 3 -}}
 {{- range $x := $flags -}}
-{{- $result = min $result (dig $x 0 $ranks) -}}
+{{- $result = min $result (dig ($x | default "none") 0 $ranks) -}}
 {{- end -}}
 {{- if (and $sev (le $sev $result) $enabled) -}}{{ $severity }}{{- end -}}
 {{- end }}

--- a/charts/kubedbcom-pgpool-editor-options/templates/_helpers.tpl
+++ b/charts/kubedbcom-pgpool-editor-options/templates/_helpers.tpl
@@ -78,7 +78,7 @@ Alerts Enabled
 */}}
 {{- define "kubedbcom-pgpool-editor-options.alertsEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
-{{- $result := dig . 0 $ranks -}}
+{{- $result := dig (. | default "none") 0 $ranks -}}
 {{- if $result -}}{{ . }}{{- end -}}
 {{- end }}
 
@@ -88,11 +88,11 @@ Alert Group Enabled
 {{- define "kubedbcom-pgpool-editor-options.alertGroupEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
 {{- $flags := (mustLast .) -}}
-{{- $group := dig (mustFirst .) 0 $ranks -}}
-{{- $group = min $group (dig $flags.enabled 0 $ranks) -}}
+{{- $group := dig (mustFirst . | default "none") 0 $ranks -}}
+{{- $group = min $group (dig ($flags.enabled | default "none") 0 $ranks) -}}
 {{- $hasRules := false -}}
 {{- range $k, $v := $flags.rules -}}
-{{- $sev := dig $v.severity 0 $ranks -}}
+{{- $sev := dig ($v.severity | default "none") 0 $ranks -}}
 {{- if (and $sev (le $sev $group) $v.enabled) -}}{{ $hasRules = true }}{{- end -}}
 {{- end -}}
 {{- if (and $group $hasRules) -}}{{ $flags.enabled }}{{- end -}}
@@ -110,10 +110,10 @@ Alert Enabled
 {{- $rule := dig $key (dict) $rules -}}
 {{- $severity := dig "severity" "" $rule -}}
 {{- $enabled := dig "enabled" false $rule -}}
-{{- $sev := dig $severity 0 $ranks -}}
+{{- $sev := dig ($severity | default "none") 0 $ranks -}}
 {{- $result := 3 -}}
 {{- range $x := $flags -}}
-{{- $result = min $result (dig $x 0 $ranks) -}}
+{{- $result = min $result (dig ($x | default "none") 0 $ranks) -}}
 {{- end -}}
 {{- if (and $sev (le $sev $result) $enabled) -}}{{ $severity }}{{- end -}}
 {{- end }}

--- a/charts/kubedbcom-pgpool-editor/templates/_helpers.tpl
+++ b/charts/kubedbcom-pgpool-editor/templates/_helpers.tpl
@@ -78,7 +78,7 @@ Alerts Enabled
 */}}
 {{- define "kubedbcom-pgpool-editor.alertsEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
-{{- $result := dig . 0 $ranks -}}
+{{- $result := dig (. | default "none") 0 $ranks -}}
 {{- if $result -}}{{ . }}{{- end -}}
 {{- end }}
 
@@ -88,11 +88,11 @@ Alert Group Enabled
 {{- define "kubedbcom-pgpool-editor.alertGroupEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
 {{- $flags := (mustLast .) -}}
-{{- $group := dig (mustFirst .) 0 $ranks -}}
-{{- $group = min $group (dig $flags.enabled 0 $ranks) -}}
+{{- $group := dig (mustFirst . | default "none") 0 $ranks -}}
+{{- $group = min $group (dig ($flags.enabled | default "none") 0 $ranks) -}}
 {{- $hasRules := false -}}
 {{- range $k, $v := $flags.rules -}}
-{{- $sev := dig $v.severity 0 $ranks -}}
+{{- $sev := dig ($v.severity | default "none") 0 $ranks -}}
 {{- if (and $sev (le $sev $group) $v.enabled) -}}{{ $hasRules = true }}{{- end -}}
 {{- end -}}
 {{- if (and $group $hasRules) -}}{{ $flags.enabled }}{{- end -}}
@@ -110,10 +110,10 @@ Alert Enabled
 {{- $rule := dig $key (dict) $rules -}}
 {{- $severity := dig "severity" "" $rule -}}
 {{- $enabled := dig "enabled" false $rule -}}
-{{- $sev := dig $severity 0 $ranks -}}
+{{- $sev := dig ($severity | default "none") 0 $ranks -}}
 {{- $result := 3 -}}
 {{- range $x := $flags -}}
-{{- $result = min $result (dig $x 0 $ranks) -}}
+{{- $result = min $result (dig ($x | default "none") 0 $ranks) -}}
 {{- end -}}
 {{- if (and $sev (le $sev $result) $enabled) -}}{{ $severity }}{{- end -}}
 {{- end }}

--- a/charts/kubedbcom-postgres-editor-options/templates/_helpers.tpl
+++ b/charts/kubedbcom-postgres-editor-options/templates/_helpers.tpl
@@ -78,7 +78,7 @@ Alerts Enabled
 */}}
 {{- define "kubedbcom-postgres-editor-options.alertsEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
-{{- $result := dig . 0 $ranks -}}
+{{- $result := dig (. | default "none") 0 $ranks -}}
 {{- if $result -}}{{ . }}{{- end -}}
 {{- end }}
 
@@ -88,11 +88,11 @@ Alert Group Enabled
 {{- define "kubedbcom-postgres-editor-options.alertGroupEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
 {{- $flags := (mustLast .) -}}
-{{- $group := dig (mustFirst .) 0 $ranks -}}
-{{- $group = min $group (dig $flags.enabled 0 $ranks) -}}
+{{- $group := dig (mustFirst . | default "none") 0 $ranks -}}
+{{- $group = min $group (dig ($flags.enabled | default "none") 0 $ranks) -}}
 {{- $hasRules := false -}}
 {{- range $k, $v := $flags.rules -}}
-{{- $sev := dig $v.severity 0 $ranks -}}
+{{- $sev := dig ($v.severity | default "none") 0 $ranks -}}
 {{- if (and $sev (le $sev $group) $v.enabled) -}}{{ $hasRules = true }}{{- end -}}
 {{- end -}}
 {{- if (and $group $hasRules) -}}{{ $flags.enabled }}{{- end -}}
@@ -110,10 +110,10 @@ Alert Enabled
 {{- $rule := dig $key (dict) $rules -}}
 {{- $severity := dig "severity" "" $rule -}}
 {{- $enabled := dig "enabled" false $rule -}}
-{{- $sev := dig $severity 0 $ranks -}}
+{{- $sev := dig ($severity | default "none") 0 $ranks -}}
 {{- $result := 3 -}}
 {{- range $x := $flags -}}
-{{- $result = min $result (dig $x 0 $ranks) -}}
+{{- $result = min $result (dig ($x | default "none") 0 $ranks) -}}
 {{- end -}}
 {{- if (and $sev (le $sev $result) $enabled) -}}{{ $severity }}{{- end -}}
 {{- end }}

--- a/charts/kubedbcom-postgres-editor/templates/_helpers.tpl
+++ b/charts/kubedbcom-postgres-editor/templates/_helpers.tpl
@@ -78,7 +78,7 @@ Alerts Enabled
 */}}
 {{- define "kubedbcom-postgres-editor.alertsEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
-{{- $result := dig . 0 $ranks -}}
+{{- $result := dig (. | default "none") 0 $ranks -}}
 {{- if $result -}}{{ . }}{{- end -}}
 {{- end }}
 
@@ -88,11 +88,11 @@ Alert Group Enabled
 {{- define "kubedbcom-postgres-editor.alertGroupEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
 {{- $flags := (mustLast .) -}}
-{{- $group := dig (mustFirst .) 0 $ranks -}}
-{{- $group = min $group (dig $flags.enabled 0 $ranks) -}}
+{{- $group := dig (mustFirst . | default "none") 0 $ranks -}}
+{{- $group = min $group (dig ($flags.enabled | default "none") 0 $ranks) -}}
 {{- $hasRules := false -}}
 {{- range $k, $v := $flags.rules -}}
-{{- $sev := dig $v.severity 0 $ranks -}}
+{{- $sev := dig ($v.severity | default "none") 0 $ranks -}}
 {{- if (and $sev (le $sev $group) $v.enabled) -}}{{ $hasRules = true }}{{- end -}}
 {{- end -}}
 {{- if (and $group $hasRules) -}}{{ $flags.enabled }}{{- end -}}
@@ -110,10 +110,10 @@ Alert Enabled
 {{- $rule := dig $key (dict) $rules -}}
 {{- $severity := dig "severity" "" $rule -}}
 {{- $enabled := dig "enabled" false $rule -}}
-{{- $sev := dig $severity 0 $ranks -}}
+{{- $sev := dig ($severity | default "none") 0 $ranks -}}
 {{- $result := 3 -}}
 {{- range $x := $flags -}}
-{{- $result = min $result (dig $x 0 $ranks) -}}
+{{- $result = min $result (dig ($x | default "none") 0 $ranks) -}}
 {{- end -}}
 {{- if (and $sev (le $sev $result) $enabled) -}}{{ $severity }}{{- end -}}
 {{- end }}

--- a/charts/kubedbcom-proxysql-editor-options/templates/_helpers.tpl
+++ b/charts/kubedbcom-proxysql-editor-options/templates/_helpers.tpl
@@ -78,7 +78,7 @@ Alerts Enabled
 */}}
 {{- define "kubedbcom-proxysql-editor-options.alertsEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
-{{- $result := dig . 0 $ranks -}}
+{{- $result := dig (. | default "none") 0 $ranks -}}
 {{- if $result -}}{{ . }}{{- end -}}
 {{- end }}
 
@@ -88,11 +88,11 @@ Alert Group Enabled
 {{- define "kubedbcom-proxysql-editor-options.alertGroupEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
 {{- $flags := (mustLast .) -}}
-{{- $group := dig (mustFirst .) 0 $ranks -}}
-{{- $group = min $group (dig $flags.enabled 0 $ranks) -}}
+{{- $group := dig (mustFirst . | default "none") 0 $ranks -}}
+{{- $group = min $group (dig ($flags.enabled | default "none") 0 $ranks) -}}
 {{- $hasRules := false -}}
 {{- range $k, $v := $flags.rules -}}
-{{- $sev := dig $v.severity 0 $ranks -}}
+{{- $sev := dig ($v.severity | default "none") 0 $ranks -}}
 {{- if (and $sev (le $sev $group) $v.enabled) -}}{{ $hasRules = true }}{{- end -}}
 {{- end -}}
 {{- if (and $group $hasRules) -}}{{ $flags.enabled }}{{- end -}}
@@ -110,10 +110,10 @@ Alert Enabled
 {{- $rule := dig $key (dict) $rules -}}
 {{- $severity := dig "severity" "" $rule -}}
 {{- $enabled := dig "enabled" false $rule -}}
-{{- $sev := dig $severity 0 $ranks -}}
+{{- $sev := dig ($severity | default "none") 0 $ranks -}}
 {{- $result := 3 -}}
 {{- range $x := $flags -}}
-{{- $result = min $result (dig $x 0 $ranks) -}}
+{{- $result = min $result (dig ($x | default "none") 0 $ranks) -}}
 {{- end -}}
 {{- if (and $sev (le $sev $result) $enabled) -}}{{ $severity }}{{- end -}}
 {{- end }}

--- a/charts/kubedbcom-proxysql-editor/templates/_helpers.tpl
+++ b/charts/kubedbcom-proxysql-editor/templates/_helpers.tpl
@@ -78,7 +78,7 @@ Alerts Enabled
 */}}
 {{- define "kubedbcom-proxysql-editor.alertsEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
-{{- $result := dig . 0 $ranks -}}
+{{- $result := dig (. | default "none") 0 $ranks -}}
 {{- if $result -}}{{ . }}{{- end -}}
 {{- end }}
 
@@ -88,11 +88,11 @@ Alert Group Enabled
 {{- define "kubedbcom-proxysql-editor.alertGroupEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
 {{- $flags := (mustLast .) -}}
-{{- $group := dig (mustFirst .) 0 $ranks -}}
-{{- $group = min $group (dig $flags.enabled 0 $ranks) -}}
+{{- $group := dig (mustFirst . | default "none") 0 $ranks -}}
+{{- $group = min $group (dig ($flags.enabled | default "none") 0 $ranks) -}}
 {{- $hasRules := false -}}
 {{- range $k, $v := $flags.rules -}}
-{{- $sev := dig $v.severity 0 $ranks -}}
+{{- $sev := dig ($v.severity | default "none") 0 $ranks -}}
 {{- if (and $sev (le $sev $group) $v.enabled) -}}{{ $hasRules = true }}{{- end -}}
 {{- end -}}
 {{- if (and $group $hasRules) -}}{{ $flags.enabled }}{{- end -}}
@@ -110,10 +110,10 @@ Alert Enabled
 {{- $rule := dig $key (dict) $rules -}}
 {{- $severity := dig "severity" "" $rule -}}
 {{- $enabled := dig "enabled" false $rule -}}
-{{- $sev := dig $severity 0 $ranks -}}
+{{- $sev := dig ($severity | default "none") 0 $ranks -}}
 {{- $result := 3 -}}
 {{- range $x := $flags -}}
-{{- $result = min $result (dig $x 0 $ranks) -}}
+{{- $result = min $result (dig ($x | default "none") 0 $ranks) -}}
 {{- end -}}
 {{- if (and $sev (le $sev $result) $enabled) -}}{{ $severity }}{{- end -}}
 {{- end }}

--- a/charts/kubedbcom-qdrant-editor-options/templates/_helpers.tpl
+++ b/charts/kubedbcom-qdrant-editor-options/templates/_helpers.tpl
@@ -78,7 +78,7 @@ Alerts Enabled
 */}}
 {{- define "kubedbcom-qdrant-editor-options.alertsEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
-{{- $result := dig . 0 $ranks -}}
+{{- $result := dig (. | default "none") 0 $ranks -}}
 {{- if $result -}}{{ . }}{{- end -}}
 {{- end }}
 
@@ -88,11 +88,11 @@ Alert Group Enabled
 {{- define "kubedbcom-qdrant-editor-options.alertGroupEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
 {{- $flags := (mustLast .) -}}
-{{- $group := dig (mustFirst .) 0 $ranks -}}
-{{- $group = min $group (dig $flags.enabled 0 $ranks) -}}
+{{- $group := dig (mustFirst . | default "none") 0 $ranks -}}
+{{- $group = min $group (dig ($flags.enabled | default "none") 0 $ranks) -}}
 {{- $hasRules := false -}}
 {{- range $k, $v := $flags.rules -}}
-{{- $sev := dig $v.severity 0 $ranks -}}
+{{- $sev := dig ($v.severity | default "none") 0 $ranks -}}
 {{- if (and $sev (le $sev $group) $v.enabled) -}}{{ $hasRules = true }}{{- end -}}
 {{- end -}}
 {{- if (and $group $hasRules) -}}{{ $flags.enabled }}{{- end -}}
@@ -110,10 +110,10 @@ Alert Enabled
 {{- $rule := dig $key (dict) $rules -}}
 {{- $severity := dig "severity" "" $rule -}}
 {{- $enabled := dig "enabled" false $rule -}}
-{{- $sev := dig $severity 0 $ranks -}}
+{{- $sev := dig ($severity | default "none") 0 $ranks -}}
 {{- $result := 3 -}}
 {{- range $x := $flags -}}
-{{- $result = min $result (dig $x 0 $ranks) -}}
+{{- $result = min $result (dig ($x | default "none") 0 $ranks) -}}
 {{- end -}}
 {{- if (and $sev (le $sev $result) $enabled) -}}{{ $severity }}{{- end -}}
 {{- end }}

--- a/charts/kubedbcom-qdrant-editor/templates/_helpers.tpl
+++ b/charts/kubedbcom-qdrant-editor/templates/_helpers.tpl
@@ -78,7 +78,7 @@ Alerts Enabled
 */}}
 {{- define "kubedbcom-qdrant-editor.alertsEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
-{{- $result := dig . 0 $ranks -}}
+{{- $result := dig (. | default "none") 0 $ranks -}}
 {{- if $result -}}{{ . }}{{- end -}}
 {{- end }}
 
@@ -88,11 +88,11 @@ Alert Group Enabled
 {{- define "kubedbcom-qdrant-editor.alertGroupEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
 {{- $flags := (mustLast .) -}}
-{{- $group := dig (mustFirst .) 0 $ranks -}}
-{{- $group = min $group (dig $flags.enabled 0 $ranks) -}}
+{{- $group := dig (mustFirst . | default "none") 0 $ranks -}}
+{{- $group = min $group (dig ($flags.enabled | default "none") 0 $ranks) -}}
 {{- $hasRules := false -}}
 {{- range $k, $v := $flags.rules -}}
-{{- $sev := dig $v.severity 0 $ranks -}}
+{{- $sev := dig ($v.severity | default "none") 0 $ranks -}}
 {{- if (and $sev (le $sev $group) $v.enabled) -}}{{ $hasRules = true }}{{- end -}}
 {{- end -}}
 {{- if (and $group $hasRules) -}}{{ $flags.enabled }}{{- end -}}
@@ -110,10 +110,10 @@ Alert Enabled
 {{- $rule := dig $key (dict) $rules -}}
 {{- $severity := dig "severity" "" $rule -}}
 {{- $enabled := dig "enabled" false $rule -}}
-{{- $sev := dig $severity 0 $ranks -}}
+{{- $sev := dig ($severity | default "none") 0 $ranks -}}
 {{- $result := 3 -}}
 {{- range $x := $flags -}}
-{{- $result = min $result (dig $x 0 $ranks) -}}
+{{- $result = min $result (dig ($x | default "none") 0 $ranks) -}}
 {{- end -}}
 {{- if (and $sev (le $sev $result) $enabled) -}}{{ $severity }}{{- end -}}
 {{- end }}

--- a/charts/kubedbcom-rabbitmq-editor-options/templates/_helpers.tpl
+++ b/charts/kubedbcom-rabbitmq-editor-options/templates/_helpers.tpl
@@ -78,7 +78,7 @@ Alerts Enabled
 */}}
 {{- define "kubedbcom-rabbitmq-editor-options.alertsEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
-{{- $result := dig . 0 $ranks -}}
+{{- $result := dig (. | default "none") 0 $ranks -}}
 {{- if $result -}}{{ . }}{{- end -}}
 {{- end }}
 
@@ -88,11 +88,11 @@ Alert Group Enabled
 {{- define "kubedbcom-rabbitmq-editor-options.alertGroupEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
 {{- $flags := (mustLast .) -}}
-{{- $group := dig (mustFirst .) 0 $ranks -}}
-{{- $group = min $group (dig $flags.enabled 0 $ranks) -}}
+{{- $group := dig (mustFirst . | default "none") 0 $ranks -}}
+{{- $group = min $group (dig ($flags.enabled | default "none") 0 $ranks) -}}
 {{- $hasRules := false -}}
 {{- range $k, $v := $flags.rules -}}
-{{- $sev := dig $v.severity 0 $ranks -}}
+{{- $sev := dig ($v.severity | default "none") 0 $ranks -}}
 {{- if (and $sev (le $sev $group) $v.enabled) -}}{{ $hasRules = true }}{{- end -}}
 {{- end -}}
 {{- if (and $group $hasRules) -}}{{ $flags.enabled }}{{- end -}}
@@ -110,10 +110,10 @@ Alert Enabled
 {{- $rule := dig $key (dict) $rules -}}
 {{- $severity := dig "severity" "" $rule -}}
 {{- $enabled := dig "enabled" false $rule -}}
-{{- $sev := dig $severity 0 $ranks -}}
+{{- $sev := dig ($severity | default "none") 0 $ranks -}}
 {{- $result := 3 -}}
 {{- range $x := $flags -}}
-{{- $result = min $result (dig $x 0 $ranks) -}}
+{{- $result = min $result (dig ($x | default "none") 0 $ranks) -}}
 {{- end -}}
 {{- if (and $sev (le $sev $result) $enabled) -}}{{ $severity }}{{- end -}}
 {{- end }}

--- a/charts/kubedbcom-rabbitmq-editor/templates/_helpers.tpl
+++ b/charts/kubedbcom-rabbitmq-editor/templates/_helpers.tpl
@@ -78,7 +78,7 @@ Alerts Enabled
 */}}
 {{- define "kubedbcom-rabbitmq-editor.alertsEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
-{{- $result := dig . 0 $ranks -}}
+{{- $result := dig (. | default "none") 0 $ranks -}}
 {{- if $result -}}{{ . }}{{- end -}}
 {{- end }}
 
@@ -88,11 +88,11 @@ Alert Group Enabled
 {{- define "kubedbcom-rabbitmq-editor.alertGroupEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
 {{- $flags := (mustLast .) -}}
-{{- $group := dig (mustFirst .) 0 $ranks -}}
-{{- $group = min $group (dig $flags.enabled 0 $ranks) -}}
+{{- $group := dig (mustFirst . | default "none") 0 $ranks -}}
+{{- $group = min $group (dig ($flags.enabled | default "none") 0 $ranks) -}}
 {{- $hasRules := false -}}
 {{- range $k, $v := $flags.rules -}}
-{{- $sev := dig $v.severity 0 $ranks -}}
+{{- $sev := dig ($v.severity | default "none") 0 $ranks -}}
 {{- if (and $sev (le $sev $group) $v.enabled) -}}{{ $hasRules = true }}{{- end -}}
 {{- end -}}
 {{- if (and $group $hasRules) -}}{{ $flags.enabled }}{{- end -}}
@@ -110,10 +110,10 @@ Alert Enabled
 {{- $rule := dig $key (dict) $rules -}}
 {{- $severity := dig "severity" "" $rule -}}
 {{- $enabled := dig "enabled" false $rule -}}
-{{- $sev := dig $severity 0 $ranks -}}
+{{- $sev := dig ($severity | default "none") 0 $ranks -}}
 {{- $result := 3 -}}
 {{- range $x := $flags -}}
-{{- $result = min $result (dig $x 0 $ranks) -}}
+{{- $result = min $result (dig ($x | default "none") 0 $ranks) -}}
 {{- end -}}
 {{- if (and $sev (le $sev $result) $enabled) -}}{{ $severity }}{{- end -}}
 {{- end }}

--- a/charts/kubedbcom-redis-editor-options/templates/_helpers.tpl
+++ b/charts/kubedbcom-redis-editor-options/templates/_helpers.tpl
@@ -78,7 +78,7 @@ Alerts Enabled
 */}}
 {{- define "kubedbcom-redis-editor-options.alertsEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
-{{- $result := dig . 0 $ranks -}}
+{{- $result := dig (. | default "none") 0 $ranks -}}
 {{- if $result -}}{{ . }}{{- end -}}
 {{- end }}
 
@@ -88,11 +88,11 @@ Alert Group Enabled
 {{- define "kubedbcom-redis-editor-options.alertGroupEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
 {{- $flags := (mustLast .) -}}
-{{- $group := dig (mustFirst .) 0 $ranks -}}
-{{- $group = min $group (dig $flags.enabled 0 $ranks) -}}
+{{- $group := dig (mustFirst . | default "none") 0 $ranks -}}
+{{- $group = min $group (dig ($flags.enabled | default "none") 0 $ranks) -}}
 {{- $hasRules := false -}}
 {{- range $k, $v := $flags.rules -}}
-{{- $sev := dig $v.severity 0 $ranks -}}
+{{- $sev := dig ($v.severity | default "none") 0 $ranks -}}
 {{- if (and $sev (le $sev $group) $v.enabled) -}}{{ $hasRules = true }}{{- end -}}
 {{- end -}}
 {{- if (and $group $hasRules) -}}{{ $flags.enabled }}{{- end -}}
@@ -110,10 +110,10 @@ Alert Enabled
 {{- $rule := dig $key (dict) $rules -}}
 {{- $severity := dig "severity" "" $rule -}}
 {{- $enabled := dig "enabled" false $rule -}}
-{{- $sev := dig $severity 0 $ranks -}}
+{{- $sev := dig ($severity | default "none") 0 $ranks -}}
 {{- $result := 3 -}}
 {{- range $x := $flags -}}
-{{- $result = min $result (dig $x 0 $ranks) -}}
+{{- $result = min $result (dig ($x | default "none") 0 $ranks) -}}
 {{- end -}}
 {{- if (and $sev (le $sev $result) $enabled) -}}{{ $severity }}{{- end -}}
 {{- end }}

--- a/charts/kubedbcom-redis-editor/templates/_helpers.tpl
+++ b/charts/kubedbcom-redis-editor/templates/_helpers.tpl
@@ -78,7 +78,7 @@ Alerts Enabled
 */}}
 {{- define "kubedbcom-redis-editor.alertsEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
-{{- $result := dig . 0 $ranks -}}
+{{- $result := dig (. | default "none") 0 $ranks -}}
 {{- if $result -}}{{ . }}{{- end -}}
 {{- end }}
 
@@ -88,11 +88,11 @@ Alert Group Enabled
 {{- define "kubedbcom-redis-editor.alertGroupEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
 {{- $flags := (mustLast .) -}}
-{{- $group := dig (mustFirst .) 0 $ranks -}}
-{{- $group = min $group (dig $flags.enabled 0 $ranks) -}}
+{{- $group := dig (mustFirst . | default "none") 0 $ranks -}}
+{{- $group = min $group (dig ($flags.enabled | default "none") 0 $ranks) -}}
 {{- $hasRules := false -}}
 {{- range $k, $v := $flags.rules -}}
-{{- $sev := dig $v.severity 0 $ranks -}}
+{{- $sev := dig ($v.severity | default "none") 0 $ranks -}}
 {{- if (and $sev (le $sev $group) $v.enabled) -}}{{ $hasRules = true }}{{- end -}}
 {{- end -}}
 {{- if (and $group $hasRules) -}}{{ $flags.enabled }}{{- end -}}
@@ -110,10 +110,10 @@ Alert Enabled
 {{- $rule := dig $key (dict) $rules -}}
 {{- $severity := dig "severity" "" $rule -}}
 {{- $enabled := dig "enabled" false $rule -}}
-{{- $sev := dig $severity 0 $ranks -}}
+{{- $sev := dig ($severity | default "none") 0 $ranks -}}
 {{- $result := 3 -}}
 {{- range $x := $flags -}}
-{{- $result = min $result (dig $x 0 $ranks) -}}
+{{- $result = min $result (dig ($x | default "none") 0 $ranks) -}}
 {{- end -}}
 {{- if (and $sev (le $sev $result) $enabled) -}}{{ $severity }}{{- end -}}
 {{- end }}

--- a/charts/kubedbcom-singlestore-editor-options/templates/_helpers.tpl
+++ b/charts/kubedbcom-singlestore-editor-options/templates/_helpers.tpl
@@ -78,7 +78,7 @@ Alerts Enabled
 */}}
 {{- define "kubedbcom-singlestore-editor-options.alertsEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
-{{- $result := dig . 0 $ranks -}}
+{{- $result := dig (. | default "none") 0 $ranks -}}
 {{- if $result -}}{{ . }}{{- end -}}
 {{- end }}
 
@@ -88,11 +88,11 @@ Alert Group Enabled
 {{- define "kubedbcom-singlestore-editor-options.alertGroupEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
 {{- $flags := (mustLast .) -}}
-{{- $group := dig (mustFirst .) 0 $ranks -}}
-{{- $group = min $group (dig $flags.enabled 0 $ranks) -}}
+{{- $group := dig (mustFirst . | default "none") 0 $ranks -}}
+{{- $group = min $group (dig ($flags.enabled | default "none") 0 $ranks) -}}
 {{- $hasRules := false -}}
 {{- range $k, $v := $flags.rules -}}
-{{- $sev := dig $v.severity 0 $ranks -}}
+{{- $sev := dig ($v.severity | default "none") 0 $ranks -}}
 {{- if (and $sev (le $sev $group) $v.enabled) -}}{{ $hasRules = true }}{{- end -}}
 {{- end -}}
 {{- if (and $group $hasRules) -}}{{ $flags.enabled }}{{- end -}}
@@ -110,10 +110,10 @@ Alert Enabled
 {{- $rule := dig $key (dict) $rules -}}
 {{- $severity := dig "severity" "" $rule -}}
 {{- $enabled := dig "enabled" false $rule -}}
-{{- $sev := dig $severity 0 $ranks -}}
+{{- $sev := dig ($severity | default "none") 0 $ranks -}}
 {{- $result := 3 -}}
 {{- range $x := $flags -}}
-{{- $result = min $result (dig $x 0 $ranks) -}}
+{{- $result = min $result (dig ($x | default "none") 0 $ranks) -}}
 {{- end -}}
 {{- if (and $sev (le $sev $result) $enabled) -}}{{ $severity }}{{- end -}}
 {{- end }}

--- a/charts/kubedbcom-singlestore-editor/templates/_helpers.tpl
+++ b/charts/kubedbcom-singlestore-editor/templates/_helpers.tpl
@@ -78,7 +78,7 @@ Alerts Enabled
 */}}
 {{- define "kubedbcom-singlestore-editor.alertsEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
-{{- $result := dig . 0 $ranks -}}
+{{- $result := dig (. | default "none") 0 $ranks -}}
 {{- if $result -}}{{ . }}{{- end -}}
 {{- end }}
 
@@ -88,11 +88,11 @@ Alert Group Enabled
 {{- define "kubedbcom-singlestore-editor.alertGroupEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
 {{- $flags := (mustLast .) -}}
-{{- $group := dig (mustFirst .) 0 $ranks -}}
-{{- $group = min $group (dig $flags.enabled 0 $ranks) -}}
+{{- $group := dig (mustFirst . | default "none") 0 $ranks -}}
+{{- $group = min $group (dig ($flags.enabled | default "none") 0 $ranks) -}}
 {{- $hasRules := false -}}
 {{- range $k, $v := $flags.rules -}}
-{{- $sev := dig $v.severity 0 $ranks -}}
+{{- $sev := dig ($v.severity | default "none") 0 $ranks -}}
 {{- if (and $sev (le $sev $group) $v.enabled) -}}{{ $hasRules = true }}{{- end -}}
 {{- end -}}
 {{- if (and $group $hasRules) -}}{{ $flags.enabled }}{{- end -}}
@@ -110,10 +110,10 @@ Alert Enabled
 {{- $rule := dig $key (dict) $rules -}}
 {{- $severity := dig "severity" "" $rule -}}
 {{- $enabled := dig "enabled" false $rule -}}
-{{- $sev := dig $severity 0 $ranks -}}
+{{- $sev := dig ($severity | default "none") 0 $ranks -}}
 {{- $result := 3 -}}
 {{- range $x := $flags -}}
-{{- $result = min $result (dig $x 0 $ranks) -}}
+{{- $result = min $result (dig ($x | default "none") 0 $ranks) -}}
 {{- end -}}
 {{- if (and $sev (le $sev $result) $enabled) -}}{{ $severity }}{{- end -}}
 {{- end }}

--- a/charts/kubedbcom-solr-editor-options/templates/_helpers.tpl
+++ b/charts/kubedbcom-solr-editor-options/templates/_helpers.tpl
@@ -78,7 +78,7 @@ Alerts Enabled
 */}}
 {{- define "kubedbcom-solr-editor-options.alertsEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
-{{- $result := dig . 0 $ranks -}}
+{{- $result := dig (. | default "none") 0 $ranks -}}
 {{- if $result -}}{{ . }}{{- end -}}
 {{- end }}
 
@@ -88,11 +88,11 @@ Alert Group Enabled
 {{- define "kubedbcom-solr-editor-options.alertGroupEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
 {{- $flags := (mustLast .) -}}
-{{- $group := dig (mustFirst .) 0 $ranks -}}
-{{- $group = min $group (dig $flags.enabled 0 $ranks) -}}
+{{- $group := dig (mustFirst . | default "none") 0 $ranks -}}
+{{- $group = min $group (dig ($flags.enabled | default "none") 0 $ranks) -}}
 {{- $hasRules := false -}}
 {{- range $k, $v := $flags.rules -}}
-{{- $sev := dig $v.severity 0 $ranks -}}
+{{- $sev := dig ($v.severity | default "none") 0 $ranks -}}
 {{- if (and $sev (le $sev $group) $v.enabled) -}}{{ $hasRules = true }}{{- end -}}
 {{- end -}}
 {{- if (and $group $hasRules) -}}{{ $flags.enabled }}{{- end -}}
@@ -110,10 +110,10 @@ Alert Enabled
 {{- $rule := dig $key (dict) $rules -}}
 {{- $severity := dig "severity" "" $rule -}}
 {{- $enabled := dig "enabled" false $rule -}}
-{{- $sev := dig $severity 0 $ranks -}}
+{{- $sev := dig ($severity | default "none") 0 $ranks -}}
 {{- $result := 3 -}}
 {{- range $x := $flags -}}
-{{- $result = min $result (dig $x 0 $ranks) -}}
+{{- $result = min $result (dig ($x | default "none") 0 $ranks) -}}
 {{- end -}}
 {{- if (and $sev (le $sev $result) $enabled) -}}{{ $severity }}{{- end -}}
 {{- end }}

--- a/charts/kubedbcom-solr-editor/templates/_helpers.tpl
+++ b/charts/kubedbcom-solr-editor/templates/_helpers.tpl
@@ -78,7 +78,7 @@ Alerts Enabled
 */}}
 {{- define "kubedbcom-solr-editor.alertsEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
-{{- $result := dig . 0 $ranks -}}
+{{- $result := dig (. | default "none") 0 $ranks -}}
 {{- if $result -}}{{ . }}{{- end -}}
 {{- end }}
 
@@ -88,11 +88,11 @@ Alert Group Enabled
 {{- define "kubedbcom-solr-editor.alertGroupEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
 {{- $flags := (mustLast .) -}}
-{{- $group := dig (mustFirst .) 0 $ranks -}}
-{{- $group = min $group (dig $flags.enabled 0 $ranks) -}}
+{{- $group := dig (mustFirst . | default "none") 0 $ranks -}}
+{{- $group = min $group (dig ($flags.enabled | default "none") 0 $ranks) -}}
 {{- $hasRules := false -}}
 {{- range $k, $v := $flags.rules -}}
-{{- $sev := dig $v.severity 0 $ranks -}}
+{{- $sev := dig ($v.severity | default "none") 0 $ranks -}}
 {{- if (and $sev (le $sev $group) $v.enabled) -}}{{ $hasRules = true }}{{- end -}}
 {{- end -}}
 {{- if (and $group $hasRules) -}}{{ $flags.enabled }}{{- end -}}
@@ -110,10 +110,10 @@ Alert Enabled
 {{- $rule := dig $key (dict) $rules -}}
 {{- $severity := dig "severity" "" $rule -}}
 {{- $enabled := dig "enabled" false $rule -}}
-{{- $sev := dig $severity 0 $ranks -}}
+{{- $sev := dig ($severity | default "none") 0 $ranks -}}
 {{- $result := 3 -}}
 {{- range $x := $flags -}}
-{{- $result = min $result (dig $x 0 $ranks) -}}
+{{- $result = min $result (dig ($x | default "none") 0 $ranks) -}}
 {{- end -}}
 {{- if (and $sev (le $sev $result) $enabled) -}}{{ $severity }}{{- end -}}
 {{- end }}

--- a/charts/kubedbcom-weaviate-editor-options/templates/_helpers.tpl
+++ b/charts/kubedbcom-weaviate-editor-options/templates/_helpers.tpl
@@ -78,7 +78,7 @@ Alerts Enabled
 */}}
 {{- define "kubedbcom-weaviate-editor-options.alertsEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
-{{- $result := dig . 0 $ranks -}}
+{{- $result := dig (. | default "none") 0 $ranks -}}
 {{- if $result -}}{{ . }}{{- end -}}
 {{- end }}
 
@@ -88,11 +88,11 @@ Alert Group Enabled
 {{- define "kubedbcom-weaviate-editor-options.alertGroupEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
 {{- $flags := (mustLast .) -}}
-{{- $group := dig (mustFirst .) 0 $ranks -}}
-{{- $group = min $group (dig $flags.enabled 0 $ranks) -}}
+{{- $group := dig (mustFirst . | default "none") 0 $ranks -}}
+{{- $group = min $group (dig ($flags.enabled | default "none") 0 $ranks) -}}
 {{- $hasRules := false -}}
 {{- range $k, $v := $flags.rules -}}
-{{- $sev := dig $v.severity 0 $ranks -}}
+{{- $sev := dig ($v.severity | default "none") 0 $ranks -}}
 {{- if (and $sev (le $sev $group) $v.enabled) -}}{{ $hasRules = true }}{{- end -}}
 {{- end -}}
 {{- if (and $group $hasRules) -}}{{ $flags.enabled }}{{- end -}}
@@ -110,10 +110,10 @@ Alert Enabled
 {{- $rule := dig $key (dict) $rules -}}
 {{- $severity := dig "severity" "" $rule -}}
 {{- $enabled := dig "enabled" false $rule -}}
-{{- $sev := dig $severity 0 $ranks -}}
+{{- $sev := dig ($severity | default "none") 0 $ranks -}}
 {{- $result := 3 -}}
 {{- range $x := $flags -}}
-{{- $result = min $result (dig $x 0 $ranks) -}}
+{{- $result = min $result (dig ($x | default "none") 0 $ranks) -}}
 {{- end -}}
 {{- if (and $sev (le $sev $result) $enabled) -}}{{ $severity }}{{- end -}}
 {{- end }}

--- a/charts/kubedbcom-zookeeper-editor-options/templates/_helpers.tpl
+++ b/charts/kubedbcom-zookeeper-editor-options/templates/_helpers.tpl
@@ -78,7 +78,7 @@ Alerts Enabled
 */}}
 {{- define "kubedbcom-zookeeper-editor-options.alertsEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
-{{- $result := dig . 0 $ranks -}}
+{{- $result := dig (. | default "none") 0 $ranks -}}
 {{- if $result -}}{{ . }}{{- end -}}
 {{- end }}
 
@@ -88,11 +88,11 @@ Alert Group Enabled
 {{- define "kubedbcom-zookeeper-editor-options.alertGroupEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
 {{- $flags := (mustLast .) -}}
-{{- $group := dig (mustFirst .) 0 $ranks -}}
-{{- $group = min $group (dig $flags.enabled 0 $ranks) -}}
+{{- $group := dig (mustFirst . | default "none") 0 $ranks -}}
+{{- $group = min $group (dig ($flags.enabled | default "none") 0 $ranks) -}}
 {{- $hasRules := false -}}
 {{- range $k, $v := $flags.rules -}}
-{{- $sev := dig $v.severity 0 $ranks -}}
+{{- $sev := dig ($v.severity | default "none") 0 $ranks -}}
 {{- if (and $sev (le $sev $group) $v.enabled) -}}{{ $hasRules = true }}{{- end -}}
 {{- end -}}
 {{- if (and $group $hasRules) -}}{{ $flags.enabled }}{{- end -}}
@@ -110,10 +110,10 @@ Alert Enabled
 {{- $rule := dig $key (dict) $rules -}}
 {{- $severity := dig "severity" "" $rule -}}
 {{- $enabled := dig "enabled" false $rule -}}
-{{- $sev := dig $severity 0 $ranks -}}
+{{- $sev := dig ($severity | default "none") 0 $ranks -}}
 {{- $result := 3 -}}
 {{- range $x := $flags -}}
-{{- $result = min $result (dig $x 0 $ranks) -}}
+{{- $result = min $result (dig ($x | default "none") 0 $ranks) -}}
 {{- end -}}
 {{- if (and $sev (le $sev $result) $enabled) -}}{{ $severity }}{{- end -}}
 {{- end }}

--- a/charts/kubedbcom-zookeeper-editor/templates/_helpers.tpl
+++ b/charts/kubedbcom-zookeeper-editor/templates/_helpers.tpl
@@ -78,7 +78,7 @@ Alerts Enabled
 */}}
 {{- define "kubedbcom-zookeeper-editor.alertsEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
-{{- $result := dig . 0 $ranks -}}
+{{- $result := dig (. | default "none") 0 $ranks -}}
 {{- if $result -}}{{ . }}{{- end -}}
 {{- end }}
 
@@ -88,11 +88,11 @@ Alert Group Enabled
 {{- define "kubedbcom-zookeeper-editor.alertGroupEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
 {{- $flags := (mustLast .) -}}
-{{- $group := dig (mustFirst .) 0 $ranks -}}
-{{- $group = min $group (dig $flags.enabled 0 $ranks) -}}
+{{- $group := dig (mustFirst . | default "none") 0 $ranks -}}
+{{- $group = min $group (dig ($flags.enabled | default "none") 0 $ranks) -}}
 {{- $hasRules := false -}}
 {{- range $k, $v := $flags.rules -}}
-{{- $sev := dig $v.severity 0 $ranks -}}
+{{- $sev := dig ($v.severity | default "none") 0 $ranks -}}
 {{- if (and $sev (le $sev $group) $v.enabled) -}}{{ $hasRules = true }}{{- end -}}
 {{- end -}}
 {{- if (and $group $hasRules) -}}{{ $flags.enabled }}{{- end -}}
@@ -110,10 +110,10 @@ Alert Enabled
 {{- $rule := dig $key (dict) $rules -}}
 {{- $severity := dig "severity" "" $rule -}}
 {{- $enabled := dig "enabled" false $rule -}}
-{{- $sev := dig $severity 0 $ranks -}}
+{{- $sev := dig ($severity | default "none") 0 $ranks -}}
 {{- $result := 3 -}}
 {{- range $x := $flags -}}
-{{- $result = min $result (dig $x 0 $ranks) -}}
+{{- $result = min $result (dig ($x | default "none") 0 $ranks) -}}
 {{- end -}}
 {{- if (and $sev (le $sev $result) $enabled) -}}{{ $severity }}{{- end -}}
 {{- end }}

--- a/charts/kubevaultcom-vaultserver-editor-options/templates/_helpers.tpl
+++ b/charts/kubevaultcom-vaultserver-editor-options/templates/_helpers.tpl
@@ -78,7 +78,7 @@ Alerts Enabled
 */}}
 {{- define "kubevaultcom-vaultserver-editor-options.alertsEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
-{{- $result := dig . 0 $ranks -}}
+{{- $result := dig (. | default "none") 0 $ranks -}}
 {{- if $result -}}{{ . }}{{- end -}}
 {{- end }}
 
@@ -88,11 +88,11 @@ Alert Group Enabled
 {{- define "kubevaultcom-vaultserver-editor-options.alertGroupEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
 {{- $flags := (mustLast .) -}}
-{{- $group := dig (mustFirst .) 0 $ranks -}}
-{{- $group = min $group (dig $flags.enabled 0 $ranks) -}}
+{{- $group := dig (mustFirst . | default "none") 0 $ranks -}}
+{{- $group = min $group (dig ($flags.enabled | default "none") 0 $ranks) -}}
 {{- $hasRules := false -}}
 {{- range $k, $v := $flags.rules -}}
-{{- $sev := dig $v.severity 0 $ranks -}}
+{{- $sev := dig ($v.severity | default "none") 0 $ranks -}}
 {{- if (and $sev (le $sev $group) $v.enabled) -}}{{ $hasRules = true }}{{- end -}}
 {{- end -}}
 {{- if (and $group $hasRules) -}}{{ $flags.enabled }}{{- end -}}
@@ -103,13 +103,13 @@ Alert Enabled
 */}}
 {{- define "kubevaultcom-vaultserver-editor-options.alertEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
-{{- $sev := dig (mustLast .) 0 $ranks -}}
+{{- $sev := dig (mustLast . | default "none") 0 $ranks -}}
 {{- $flags := mustInitial . -}}
 {{- $enabled := mustLast $flags -}}
 {{- $flags = mustInitial $flags -}}
 {{- $result := 3 -}}
 {{- range $x := $flags -}}
-{{- $result = min $result (dig $x 0 $ranks) -}}
+{{- $result = min $result (dig ($x | default "none") 0 $ranks) -}}
 {{- end -}}
 {{- if (and $sev (le $sev $result) $enabled) -}}{{ (mustLast .) }}{{- end -}}
 {{- end }}

--- a/charts/kubevaultcom-vaultserver-editor/templates/_helpers.tpl
+++ b/charts/kubevaultcom-vaultserver-editor/templates/_helpers.tpl
@@ -78,7 +78,7 @@ Alerts Enabled
 */}}
 {{- define "kubevaultcom-vaultserver-editor.alertsEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
-{{- $result := dig . 0 $ranks -}}
+{{- $result := dig (. | default "none") 0 $ranks -}}
 {{- if $result -}}{{ . }}{{- end -}}
 {{- end }}
 
@@ -88,11 +88,11 @@ Alert Group Enabled
 {{- define "kubevaultcom-vaultserver-editor.alertGroupEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
 {{- $flags := (mustLast .) -}}
-{{- $group := dig (mustFirst .) 0 $ranks -}}
-{{- $group = min $group (dig $flags.enabled 0 $ranks) -}}
+{{- $group := dig (mustFirst . | default "none") 0 $ranks -}}
+{{- $group = min $group (dig ($flags.enabled | default "none") 0 $ranks) -}}
 {{- $hasRules := false -}}
 {{- range $k, $v := $flags.rules -}}
-{{- $sev := dig $v.severity 0 $ranks -}}
+{{- $sev := dig ($v.severity | default "none") 0 $ranks -}}
 {{- if (and $sev (le $sev $group) $v.enabled) -}}{{ $hasRules = true }}{{- end -}}
 {{- end -}}
 {{- if (and $group $hasRules) -}}{{ $flags.enabled }}{{- end -}}
@@ -103,13 +103,13 @@ Alert Enabled
 */}}
 {{- define "kubevaultcom-vaultserver-editor.alertEnabled" -}}
 {{- $ranks := dict "critical" 1 "warning" 2 "info" 3 -}}
-{{- $sev := dig (mustLast .) 0 $ranks -}}
+{{- $sev := dig (mustLast . | default "none") 0 $ranks -}}
 {{- $flags := mustInitial . -}}
 {{- $enabled := mustLast $flags -}}
 {{- $flags = mustInitial $flags -}}
 {{- $result := 3 -}}
 {{- range $x := $flags -}}
-{{- $result = min $result (dig $x 0 $ranks) -}}
+{{- $result = min $result (dig ($x | default "none") 0 $ranks) -}}
 {{- end -}}
 {{- if (and $sev (le $sev $result) $enabled) -}}{{ (mustLast .) }}{{- end -}}
 {{- end }}


### PR DESCRIPTION
Creating a database with monitoring disabled failed to render:

```
template: kubedbcom-neo4j-editor-options/templates/monitoring/alert.yaml:3:7 ...
error calling dig: interface conversion: interface {} is nil, not string
```

The console can send `form.alert.enabled` as null; an explicit null in the model also drops the chart's own default during Helm coalesce. `dig` panics on a nil key, so every chart with a `monitoring/alert.yaml` template broke.

Every severity lookup in `alertsEnabled` / `alertGroupEnabled` / `alertEnabled` now falls back to `"none"`, which the rank table already treats as disabled. Applied to all 61 charts that define these helpers.

Also documents the `charts_pattern` globs added in 8839601ac.

### Verification

`helm template` over all 61 affected charts:

- with `--set-json 'form.alert.enabled=null'`: 56 charts failed with the error above before, 0 after (the other 5 have no `monitoring/alert.yaml`, so their alert helpers are unreachable).
- with default values: rendered output is byte-identical before and after for all 61 charts.

`make fmt` could not run locally (Docker daemon down); the change is template text only, no Go or formatting-sensitive files.