### PR TITLE
Resolve the tag Charts marker only from a real annotated tag

### DIFF
--- a/.github/workflows/publish-oci.yml
+++ b/.github/workflows/publish-oci.yml
@@ -77,13 +77,27 @@ jobs:
           CHART_REPOSITORY: ${{ secrets.CHART_REPOSITORY }}
           CHARTS_PATTERN: ${{ inputs.charts_pattern }}
         run: |
-          GIT_TAG=${GITHUB_REF#"refs/tags/"}
+          GIT_TAG=""
+          case "$GITHUB_REF" in refs/tags/*) GIT_TAG=${GITHUB_REF#refs/tags/} ;; esac
           # tag pushes carry no inputs; an annotated tag can scope itself with a
           # "Charts: <glob>" body marker, same convention as ProductLine/Release
-          if [ -z "$CHARTS_PATTERN" ]; then
-            CHARTS_PATTERN=$(git -C $GITHUB_WORKSPACE tag -l --format='%(body)' "$GIT_TAG" |
-              sed -n 's/^Charts:[[:space:]]*//p' | tr -d '\r\t' | head -1)
+          if [ -z "$CHARTS_PATTERN" ] && [ -n "$GIT_TAG" ]; then
+            # actions/checkout fetches the tag by sha, leaving refs/tags/$GIT_TAG
+            # lightweight; without the real tag object %(body) yields the commit
+            # message and the marker matches wrapped prose in it
+            git -C $GITHUB_WORKSPACE fetch --force origin "refs/tags/$GIT_TAG:refs/tags/$GIT_TAG" || true
+            if [ "$(git -C $GITHUB_WORKSPACE cat-file -t "$GIT_TAG" 2>/dev/null)" = tag ]; then
+              CHARTS_PATTERN=$(git -C $GITHUB_WORKSPACE tag -l --format='%(body)' "$GIT_TAG" |
+                sed -n 's/^Charts:[[:space:]]*//p' | tr -d '\r\t' | head -1)
+            fi
           fi
+          # a glob is one shell word; whitespace means the marker matched prose
+          case "$CHARTS_PATTERN" in
+            *[[:space:]]*)
+              echo "::error::ignoring non-glob Charts marker: $CHARTS_PATTERN"
+              exit 1
+              ;;
+          esac
           echo "publishing charts matching: ${CHARTS_PATTERN:-<all>}"
           CHARTS_DIR=charts
           if [ -n "$CHARTS_PATTERN" ]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,13 +62,27 @@ jobs:
           CHART_REPOSITORY: ${{ secrets.CHART_REPOSITORY }}
           CHARTS_PATTERN: ${{ inputs.charts_pattern }}
         run: |
-          GIT_TAG=${GITHUB_REF#"refs/tags/"}
+          GIT_TAG=""
+          case "$GITHUB_REF" in refs/tags/*) GIT_TAG=${GITHUB_REF#refs/tags/} ;; esac
           # tag pushes carry no inputs; an annotated tag can scope itself with a
           # "Charts: <glob>" body marker, same convention as ProductLine/Release
-          if [ -z "$CHARTS_PATTERN" ]; then
-            CHARTS_PATTERN=$(git -C $GITHUB_WORKSPACE tag -l --format='%(body)' "$GIT_TAG" |
-              sed -n 's/^Charts:[[:space:]]*//p' | tr -d '\r\t' | head -1)
+          if [ -z "$CHARTS_PATTERN" ] && [ -n "$GIT_TAG" ]; then
+            # actions/checkout fetches the tag by sha, leaving refs/tags/$GIT_TAG
+            # lightweight; without the real tag object %(body) yields the commit
+            # message and the marker matches wrapped prose in it
+            git -C $GITHUB_WORKSPACE fetch --force origin "refs/tags/$GIT_TAG:refs/tags/$GIT_TAG" || true
+            if [ "$(git -C $GITHUB_WORKSPACE cat-file -t "$GIT_TAG" 2>/dev/null)" = tag ]; then
+              CHARTS_PATTERN=$(git -C $GITHUB_WORKSPACE tag -l --format='%(body)' "$GIT_TAG" |
+                sed -n 's/^Charts:[[:space:]]*//p' | tr -d '\r\t' | head -1)
+            fi
           fi
+          # a glob is one shell word; whitespace means the marker matched prose
+          case "$CHARTS_PATTERN" in
+            *[[:space:]]*)
+              echo "::error::ignoring non-glob Charts marker: $CHARTS_PATTERN"
+              exit 1
+              ;;
+          esac
           echo "publishing charts matching: ${CHARTS_PATTERN:-<all>}"
           CHARTS_DIR=charts
           if [ -n "$CHARTS_PATTERN" ]; then

--- a/Makefile
+++ b/Makefile
@@ -284,7 +284,13 @@ stage-charts:
 	@rm -rf $(STAGE_DIR)
 	@mkdir -p $(STAGE_DIR)
 	@find charts -maxdepth 1 -mindepth 1 -type d -name '$(CHARTS_PATTERN)' -exec cp -r {} $(STAGE_DIR)/ \;
-	@echo "staged $$(ls -1 $(STAGE_DIR) | wc -l) chart(s) matching '$(CHARTS_PATTERN)' in $(STAGE_DIR)"
+	@n=$$(ls -1 $(STAGE_DIR) | wc -l | tr -d ' '); \
+	if [ "$$n" -eq 0 ]; then \
+	  echo "no charts matched '$(CHARTS_PATTERN)'"; \
+	  rm -rf $(STAGE_DIR); \
+	  exit 1; \
+	fi; \
+	echo "staged $$n chart(s) matching '$(CHARTS_PATTERN)' in $(STAGE_DIR)"
 
 .PHONY: package-charts
 package-charts:


### PR DESCRIPTION
## Problem

The OCI publish job for `v0.36.1` failed:

```
publishing charts matching: annotated-tag body marker resolve to a glob that make stage-charts
staged 0 chart(s) matching '...' in .charts-subset
Error: /home/runner/work/ui-wizards/ui-wizards/.oci/*: no such file
```

Two bugs compounded:

1. **The tag is lightweight on the runner.** `actions/checkout` fetches a tag push by commit sha, so `refs/tags/<tag>` points at the commit rather than the annotated tag object. `git tag -l --format='%(body)'` then falls back to the **commit** message. Locally the tag is fine — `git cat-file -t v0.36.1` reports `tag` and the body is `Charts: kubedbcom-*-editor-options`.
2. **The commit body of 4bb0e8dc4 has a wrapped line starting with `Charts:`** — `Charts: annotated-tag body marker resolve to a glob that make stage-charts`. The marker sed matched that prose, `find -name` matched no dirs, and `publish-oci-charts.sh` globbed an empty `.oci/`.

## Fix

`publish-oci.yml` and `release.yml` (identical block in both):

- Only treat `GITHUB_REF` as a tag when it is one. On `workflow_dispatch` the old code fed `refs/heads/master` to `git tag -l`.
- Refetch `refs/tags/$GIT_TAG` explicitly so the annotated tag object exists, then gate the body read on `git cat-file -t "$GIT_TAG" = tag`. A lightweight tag now yields no pattern instead of a commit message.
- Reject a resolved pattern containing whitespace with `::error::` + exit 1. A glob is one shell word; whitespace means the marker matched prose.

`Makefile` — `stage-charts` exits 1 with `no charts matched '<glob>'` instead of staging zero charts and letting the publish script fail later with an opaque `.oci/*: no such file`.

## Verification

```
$ make stage-charts CHARTS_PATTERN='kubedbcom-mongodb-*' STAGE_DIR=/tmp/sc-ok
staged 2 chart(s) matching 'kubedbcom-mongodb-*' in /tmp/sc-ok      exit=0

$ make stage-charts CHARTS_PATTERN='annotated-tag body marker resolve to a glob' ...
no charts matched 'annotated-tag body marker resolve to a glob'
make: *** [stage-charts] Error 1                                     exit=2
```

The whitespace guard was exercised standalone under `bash -e`: errors on prose, passes `kubedbcom-*-editor-options` through.

## Note

`v0.36.1` still points at 4bb0e8dc4, whose commit body contains that prose `Charts:` line. With this fix the annotated body is read correctly so it no longer matters, but the tag needs to be moved to include this commit before the workflow behaves differently.