### PR TITLE
Use namespaced backupstorages/retentionpolicies list for client-org users

### DIFF
--- a/charts/corekubestashcom-backupconfiguration-editor-options/ui/functions.js
+++ b/charts/corekubestashcom-backupconfiguration-editor-options/ui/functions.js
@@ -268,9 +268,17 @@ export const useFunc = (model) => {
   async function getData(ctx, type) {
     const user = storeGet('/route/params/user')
     const cluster = storeGet('/route/params/cluster')
-    let url = `/clusters/${user}/${cluster}/proxy/storage.kubestash.com/v1alpha1/${
-      type === 'retentionPolicy' ? 'retentionpolicies' : 'backupstorages'
-    }`
+    const namespace =
+      getValue(model, '/metadata/release/namespace') || storeGet('/route/query/namespace') || ''
+    const activeOrg = storeGet('/activeOrganization') || ''
+    const orgList = storeGet('/organizations') || []
+    const orgType = orgList.find((item) => item.username === activeOrg)?.orgType
+
+    const resource = type === 'retentionPolicy' ? 'retentionpolicies' : 'backupstorages'
+    let url = `/clusters/${user}/${cluster}/proxy/storage.kubestash.com/v1alpha1/${resource}`
+    if (orgType === 3 && namespace) {
+      url = `/clusters/${user}/${cluster}/proxy/storage.kubestash.com/v1alpha1/namespaces/${namespace}/${resource}`
+    }
     try {
       const data = await axios.get(url)
       const items = data.data?.items || []


### PR DESCRIPTION
Follow-up to #1101 for the kubestash options charts.

`getData` in `corekubestashcom-backupconfiguration-editor-options` listed `storage.kubestash.com/v1alpha1/{retentionpolicies,backupstorages}` cluster-scoped, which client-org users (`orgType === 3`) are not allowed to do. It now falls back to the namespaced URL when the org is a client org and a namespace is known.

The other kubestash `*-editor-options` charts were checked and need no change: `restoresession`'s `getRepositories` already has this check, `backupsession`/`repository` already use namespaced URLs, `backupstorage`'s `getResources` is only called for namespaced secrets, and `addons`/`clusterchartpresets` are cluster-scoped kinds.