### PR TITLE
Add TelemetryStack editor options wizard

### DIFF
--- a/charts/monitoringk8sappscodecom-telemetrystack-editor-options/templates/_helpers.tpl
+++ b/charts/monitoringk8sappscodecom-telemetrystack-editor-options/templates/_helpers.tpl
@@ -44,6 +44,7 @@ Call with a dict: {"root": $, "pillar": .Values.spec.logs}
 {{- $root := .root -}}
 {{- $pillar := .pillar -}}
 enabled: {{ $pillar.enabled }}
+{{- if $pillar.enabled }}
 deploymentMode: {{ $pillar.deploymentMode }}
 version: {{ $pillar.version | quote }}
 deletionPolicy: {{ $pillar.deletionPolicy }}
@@ -86,5 +87,6 @@ clusterTopology:
       resources:
         requests:
           storage: {{ $pillar.clusterTopology.clickHouseKeeper.persistence.size }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/monitoringk8sappscodecom-telemetrystack-editor-options/ui/create-ui.yaml
+++ b/charts/monitoringk8sappscodecom-telemetrystack-editor-options/ui/create-ui.yaml
@@ -1,0 +1,570 @@
+step:
+- elements:
+  - elements:
+    - elements:
+      - hasIcon: true
+        isClickable: true
+        label: ClickHouse for Logs
+        loader: pillarStatus|logs
+        switchInfo:
+          schema: schema/properties/spec/properties/logs/properties/enabled
+          type: switch
+        type: neutral
+        watcher:
+          func: pillarStatus|logs
+          paths:
+          - schema/properties/spec/properties/logs/properties/enabled
+      - elements:
+        - elements:
+          - label: Version
+            schema: schema/properties/spec/properties/logs/properties/version
+            type: input
+          - label: Deployment Mode
+            schema: schema/properties/spec/properties/logs/properties/deploymentMode
+            type: select
+          - label: Deletion Policy
+            schema: schema/properties/spec/properties/logs/properties/deletionPolicy
+            type: select
+          type: horizontal-layout
+        if:
+          name: isPillarEnabled|logs
+          type: function
+        label: General
+        showLabels: true
+        type: block-layout
+      - elements:
+        - elements:
+          - label: Bucket
+            schema: schema/properties/spec/properties/logs/properties/s3/properties/bucket
+            type: input
+          - label: Region
+            schema: schema/properties/spec/properties/logs/properties/s3/properties/region
+            type: input
+          type: horizontal-layout
+        - elements:
+          - label: Endpoint
+            schema: schema/properties/spec/properties/logs/properties/s3/properties/endpoint
+            type: input
+          - label: Prefix
+            schema: schema/properties/spec/properties/logs/properties/s3/properties/prefix
+            type: input
+          type: horizontal-layout
+        - elements:
+          - label: Access Key
+            schema: schema/properties/spec/properties/logs/properties/s3/properties/accessKey
+            type: input
+          - isSecret: true
+            label: Secret Key
+            schema: schema/properties/spec/properties/logs/properties/s3/properties/secretKey
+            type: input
+          type: horizontal-layout
+        if:
+          name: isPillarEnabled|logs
+          type: function
+        label: S3 Storage
+        showLabels: true
+        type: block-layout
+      - elements:
+        - elements:
+          - label: Storage Class
+            loader: getStorageClasses
+            schema: schema/properties/spec/properties/logs/properties/storage/properties/storageClassName
+            type: select
+          - label: Storage Size
+            schema: schema/properties/spec/properties/logs/properties/storage/properties/size
+            type: input
+          type: horizontal-layout
+        if:
+          name: isPillarEnabled|logs
+          type: function
+        label: Persistent Storage
+        showLabels: true
+        type: block-layout
+      - elements:
+        - elements:
+          - elements:
+            - label: Name
+              schema: schema/properties/spec/properties/logs/properties/clusterTopology/properties/cluster/properties/name
+              type: input
+            - label: Replicas
+              schema: schema/properties/spec/properties/logs/properties/clusterTopology/properties/cluster/properties/replicas
+              type: input
+            type: horizontal-layout
+          - elements:
+            - label: Shards
+              schema: schema/properties/spec/properties/logs/properties/clusterTopology/properties/cluster/properties/shards
+              type: input
+            - label: Storage Size
+              schema: schema/properties/spec/properties/logs/properties/clusterTopology/properties/cluster/properties/persistence/properties/size
+              type: input
+            type: horizontal-layout
+          label: Cluster
+          showLabels: true
+          type: block-layout
+        - elements:
+          - label: Externally Managed
+            schema: schema/properties/spec/properties/logs/properties/clusterTopology/properties/clickHouseKeeper/properties/externallyManaged
+            type: switch
+          - elements:
+            - label: Replicas
+              schema: schema/properties/spec/properties/logs/properties/clusterTopology/properties/clickHouseKeeper/properties/replicas
+              type: input
+            - label: Storage Size
+              schema: schema/properties/spec/properties/logs/properties/clusterTopology/properties/clickHouseKeeper/properties/persistence/properties/size
+              type: input
+            type: horizontal-layout
+          label: ClickHouse Keeper
+          showLabels: true
+          type: block-layout
+        if:
+          name: isClusterTopology|logs
+          type: function
+        label: Cluster Topology
+        showLabels: true
+        type: block-layout
+      - elements:
+        - elements:
+          - label: Secret Name
+            schema: name
+            type: input
+          - label: Key
+            schema: key
+            type: input
+          label: Certificates
+          schema: schema/properties/spec/properties/logs/properties/clientCaCertificates
+          type: array-object-form
+        hideBlock: true
+        if:
+          name: isPillarEnabled|logs
+          type: function
+        label: Client CA Certificates
+        showLabels: true
+        type: block-layout
+      if:
+        name: isActivePage|logs-clickhouse
+        type: function
+      type: block-layout
+    - elements:
+      - elements:
+        - label: Bucket
+          schema: schema/properties/spec/properties/metrics/properties/thanos/properties/s3/properties/bucket
+          type: input
+        - label: Region
+          schema: schema/properties/spec/properties/metrics/properties/thanos/properties/s3/properties/region
+          type: input
+        type: horizontal-layout
+      - elements:
+        - label: Endpoint
+          schema: schema/properties/spec/properties/metrics/properties/thanos/properties/s3/properties/endpoint
+          type: input
+        - label: Prefix
+          schema: schema/properties/spec/properties/metrics/properties/thanos/properties/s3/properties/prefix
+          type: input
+        type: horizontal-layout
+      - elements:
+        - label: Access Key
+          schema: schema/properties/spec/properties/metrics/properties/thanos/properties/s3/properties/accessKey
+          type: input
+        - isSecret: true
+          label: Secret Key
+          schema: schema/properties/spec/properties/metrics/properties/thanos/properties/s3/properties/secretKey
+          type: input
+        type: horizontal-layout
+      if:
+        name: isActivePage|metrics-thanos-s3
+        type: function
+      label: S3 Object Storage
+      showLabels: true
+      type: block-layout
+    - elements:
+      - elements:
+        - label: Storage Size
+          schema: schema/properties/spec/properties/metrics/properties/thanos/properties/compact/properties/storageSize
+          type: input
+        type: horizontal-layout
+      - elements:
+        - label: Raw
+          schema: raw
+          type: input
+        - label: 5m Downsampled
+          schema: fiveMinutes
+          type: input
+        - label: 1h Downsampled
+          schema: oneHour
+          type: input
+        label: Retention Config
+        schema: schema/properties/spec/properties/metrics/properties/thanos/properties/compact/properties/retentionConfig
+        type: array-object-form
+      if:
+        name: isActivePage|metrics-thanos-compact
+        type: function
+      label: Compact
+      showLabels: true
+      type: block-layout
+    - elements:
+      - elements:
+        - label: Storage Size
+          schema: schema/properties/spec/properties/metrics/properties/thanos/properties/store/properties/storageSize
+          type: input
+        - label: Ignore Deletion Marks Delay
+          schema: schema/properties/spec/properties/metrics/properties/thanos/properties/store/properties/ignoreDeletionMarksDelay
+          type: input
+        type: horizontal-layout
+      - elements:
+        - elements:
+          - label: Type
+            schema: schema/properties/spec/properties/metrics/properties/thanos/properties/store/properties/shardingStrategy/properties/type
+            type: input
+          - label: Shards
+            schema: schema/properties/spec/properties/metrics/properties/thanos/properties/store/properties/shardingStrategy/properties/shards
+            type: input
+          type: horizontal-layout
+        label: Sharding Strategy
+        showLabels: true
+        type: block-layout
+      if:
+        name: isActivePage|metrics-thanos-store
+        type: function
+      label: Store
+      showLabels: true
+      type: block-layout
+    - elements:
+      - elements:
+        - label: Replicas
+          schema: schema/properties/spec/properties/metrics/properties/thanos/properties/query/properties/replicas
+          type: input
+        type: horizontal-layout
+      if:
+        name: isActivePage|metrics-thanos-query
+        type: function
+      label: Query
+      showLabels: true
+      type: block-layout
+    - elements:
+      - elements:
+        - elements:
+          - label: Hashring Name
+            schema: schema/properties/spec/properties/metrics/properties/thanos/properties/receive/properties/ingesterSpec/properties/name
+            type: input
+          - label: Replicas
+            schema: schema/properties/spec/properties/metrics/properties/thanos/properties/receive/properties/ingesterSpec/properties/replicas
+            type: input
+          type: horizontal-layout
+        - elements:
+          - label: Storage Size
+            schema: schema/properties/spec/properties/metrics/properties/thanos/properties/receive/properties/ingesterSpec/properties/storageSize
+            type: input
+          - label: TSDB Retention
+            schema: schema/properties/spec/properties/metrics/properties/thanos/properties/receive/properties/ingesterSpec/properties/tsdbRetention
+            type: input
+          type: horizontal-layout
+        - elements:
+          - elements:
+            - label: Matcher Type
+              schema: schema/properties/spec/properties/metrics/properties/thanos/properties/receive/properties/ingesterSpec/properties/tenancyConfig/properties/tenantMatcherType
+              type: select
+            - label: Tenant Header
+              schema: schema/properties/spec/properties/metrics/properties/thanos/properties/receive/properties/ingesterSpec/properties/tenancyConfig/properties/tenantHeader
+              type: input
+            type: horizontal-layout
+          - elements:
+            - label: Default Tenant ID
+              schema: schema/properties/spec/properties/metrics/properties/thanos/properties/receive/properties/ingesterSpec/properties/tenancyConfig/properties/defaultTenantID
+              type: input
+            - label: Tenant Label Name
+              schema: schema/properties/spec/properties/metrics/properties/thanos/properties/receive/properties/ingesterSpec/properties/tenancyConfig/properties/tenantLabelName
+              type: input
+            type: horizontal-layout
+          label: Tenancy Config
+          showLabels: true
+          type: block-layout
+        label: Ingester
+        showLabels: true
+        type: block-layout
+      - elements:
+        - elements:
+          - label: Replicas
+            schema: schema/properties/spec/properties/metrics/properties/thanos/properties/receive/properties/routerSpec/properties/replicas
+            type: input
+          - label: Replication Factor
+            schema: schema/properties/spec/properties/metrics/properties/thanos/properties/receive/properties/routerSpec/properties/replicationFactor
+            type: input
+          type: horizontal-layout
+        - buttonClass: is-light is-outlined
+          label: External Labels
+          schema: schema/properties/spec/properties/metrics/properties/thanos/properties/receive/properties/routerSpec/properties/externalLabels
+          type: object-item
+        label: Router
+        showLabels: true
+        type: block-layout
+      if:
+        name: isActivePage|metrics-thanos-receive
+        type: function
+      label: Receive
+      showLabels: true
+      type: block-layout
+    - elements:
+      - elements:
+        - label: Replicas
+          schema: schema/properties/spec/properties/metrics/properties/thanos/properties/ruler/properties/replicas
+          type: input
+        - label: Storage Size
+          schema: schema/properties/spec/properties/metrics/properties/thanos/properties/ruler/properties/storageSize
+          type: input
+        type: horizontal-layout
+      - label: Alertmanager URL
+        schema: schema/properties/spec/properties/metrics/properties/thanos/properties/ruler/properties/alertmanagerURL
+        type: input
+      - elements:
+        - element:
+            label: Argument
+            type: input
+          label: Additional Args
+          schema: schema/properties/spec/properties/metrics/properties/thanos/properties/ruler/properties/additionalConfig/properties/additionalArgs
+          type: array-item-form
+        - elements:
+          - label: Volume Type
+            options:
+            - text: Secret
+              value: Secret
+            - text: ConfigMap
+              value: ConfigMap
+            schema: volumeType
+            type: select
+          - label: Name
+            schema: name
+            type: input
+          - label: Secret Name
+            schema: secretName
+            type: input
+          - label: Key
+            schema: key
+            type: input
+          - label: Path
+            schema: path
+            type: input
+          - label: Mode
+            schema: mode
+            type: input
+          label: Additional Volumes
+          schema: schema/properties/spec/properties/metrics/properties/thanos/properties/ruler/properties/additionalConfig/properties/additionalVolumes
+          type: array-object-form
+        - elements:
+          - label: Name
+            schema: name
+            type: input
+          - label: Mount Path
+            schema: mountPath
+            type: input
+          - label: Read Only
+            schema: readOnly
+            type: switch
+          label: Additional Volume Mounts
+          schema: schema/properties/spec/properties/metrics/properties/thanos/properties/ruler/properties/additionalConfig/properties/additionalVolumeMounts
+          type: array-object-form
+        hideBlock: true
+        label: Additional Config
+        showLabels: true
+        type: block-layout
+      if:
+        name: isActivePage|metrics-thanos-ruler
+        type: function
+      label: Ruler
+      showLabels: true
+      type: block-layout
+    - elements:
+      - hasIcon: true
+        isClickable: true
+        label: ClickHouse for Traces
+        loader: pillarStatus|traces
+        switchInfo:
+          schema: schema/properties/spec/properties/traces/properties/enabled
+          type: switch
+        type: neutral
+        watcher:
+          func: pillarStatus|traces
+          paths:
+          - schema/properties/spec/properties/traces/properties/enabled
+      - elements:
+        - elements:
+          - label: Version
+            schema: schema/properties/spec/properties/traces/properties/version
+            type: input
+          - label: Deployment Mode
+            schema: schema/properties/spec/properties/traces/properties/deploymentMode
+            type: select
+          - label: Deletion Policy
+            schema: schema/properties/spec/properties/traces/properties/deletionPolicy
+            type: select
+          type: horizontal-layout
+        if:
+          name: isPillarEnabled|traces
+          type: function
+        label: General
+        showLabels: true
+        type: block-layout
+      - elements:
+        - elements:
+          - label: Bucket
+            schema: schema/properties/spec/properties/traces/properties/s3/properties/bucket
+            type: input
+          - label: Region
+            schema: schema/properties/spec/properties/traces/properties/s3/properties/region
+            type: input
+          type: horizontal-layout
+        - elements:
+          - label: Endpoint
+            schema: schema/properties/spec/properties/traces/properties/s3/properties/endpoint
+            type: input
+          - label: Prefix
+            schema: schema/properties/spec/properties/traces/properties/s3/properties/prefix
+            type: input
+          type: horizontal-layout
+        - elements:
+          - label: Access Key
+            schema: schema/properties/spec/properties/traces/properties/s3/properties/accessKey
+            type: input
+          - isSecret: true
+            label: Secret Key
+            schema: schema/properties/spec/properties/traces/properties/s3/properties/secretKey
+            type: input
+          type: horizontal-layout
+        if:
+          name: isPillarEnabled|traces
+          type: function
+        label: S3 Storage
+        showLabels: true
+        type: block-layout
+      - elements:
+        - elements:
+          - label: Storage Class
+            loader: getStorageClasses
+            schema: schema/properties/spec/properties/traces/properties/storage/properties/storageClassName
+            type: select
+          - label: Storage Size
+            schema: schema/properties/spec/properties/traces/properties/storage/properties/size
+            type: input
+          type: horizontal-layout
+        if:
+          name: isPillarEnabled|traces
+          type: function
+        label: Persistent Storage
+        showLabels: true
+        type: block-layout
+      - elements:
+        - elements:
+          - elements:
+            - label: Name
+              schema: schema/properties/spec/properties/traces/properties/clusterTopology/properties/cluster/properties/name
+              type: input
+            - label: Replicas
+              schema: schema/properties/spec/properties/traces/properties/clusterTopology/properties/cluster/properties/replicas
+              type: input
+            type: horizontal-layout
+          - elements:
+            - label: Shards
+              schema: schema/properties/spec/properties/traces/properties/clusterTopology/properties/cluster/properties/shards
+              type: input
+            - label: Storage Size
+              schema: schema/properties/spec/properties/traces/properties/clusterTopology/properties/cluster/properties/persistence/properties/size
+              type: input
+            type: horizontal-layout
+          label: Cluster
+          showLabels: true
+          type: block-layout
+        - elements:
+          - label: Externally Managed
+            schema: schema/properties/spec/properties/traces/properties/clusterTopology/properties/clickHouseKeeper/properties/externallyManaged
+            type: switch
+          - elements:
+            - label: Replicas
+              schema: schema/properties/spec/properties/traces/properties/clusterTopology/properties/clickHouseKeeper/properties/replicas
+              type: input
+            - label: Storage Size
+              schema: schema/properties/spec/properties/traces/properties/clusterTopology/properties/clickHouseKeeper/properties/persistence/properties/size
+              type: input
+            type: horizontal-layout
+          label: ClickHouse Keeper
+          showLabels: true
+          type: block-layout
+        if:
+          name: isClusterTopology|traces
+          type: function
+        label: Cluster Topology
+        showLabels: true
+        type: block-layout
+      - elements:
+        - elements:
+          - label: Secret Name
+            schema: name
+            type: input
+          - label: Key
+            schema: key
+            type: input
+          label: Certificates
+          schema: schema/properties/spec/properties/traces/properties/clientCaCertificates
+          type: array-object-form
+        hideBlock: true
+        if:
+          name: isPillarEnabled|traces
+          type: function
+        label: Client CA Certificates
+        showLabels: true
+        type: block-layout
+      if:
+        name: isActivePage|traces-clickhouse
+        type: function
+      type: block-layout
+    label: Telemetry Stack
+    options:
+    - options:
+      - activeIcon: radio-button
+        checkIcon: success
+        checkIf:
+          name: isPillarEnabled|logs
+          type: function
+        icon: circle
+        tag: Recommended
+        text: ClickHouse
+        value: logs-clickhouse
+      text: Logs
+    - options:
+      - icon: circle
+        options:
+        - icon: cloud
+          text: S3 Storage
+          value: metrics-thanos-s3
+        - icon: arrow-shrink-02
+          text: Compact
+          value: metrics-thanos-compact
+        - icon: cube
+          text: Store
+          value: metrics-thanos-store
+        - icon: search-01
+          text: Query
+          value: metrics-thanos-query
+        - icon: download-04
+          text: Receive
+          value: metrics-thanos-receive
+        - icon: ruler
+          text: Ruler
+          value: metrics-thanos-ruler
+        tag: Recommended
+        text: Thanos
+      text: Metrics
+    - options:
+      - activeIcon: radio-button
+        checkIcon: success
+        checkIf:
+          name: isPillarEnabled|traces
+          type: function
+        icon: circle
+        text: ClickHouse
+        value: traces-clickhouse
+      text: Traces
+    schema: temp/properties/telemetryPage
+    subtitle: Configuration
+    type: sidebar-layout
+  id: options
+  type: single-step-form
+type: multi-step-form

--- a/charts/monitoringk8sappscodecom-telemetrystack-editor-options/ui/functions.js
+++ b/charts/monitoringk8sappscodecom-telemetrystack-editor-options/ui/functions.js
@@ -1,0 +1,63 @@
+const { axios, useOperator, store } = window.vueHelpers || {}
+
+const pillarNames = {
+  logs: 'Logs',
+  traces: 'Traces',
+}
+
+export const useFunc = (model) => {
+  const { getValue, setDiscriminatorValue, storeGet, discriminator } = useOperator(
+    model,
+    store.state,
+  )
+
+  // the sidebar writes the active page here, keep the first page selected on load
+  setDiscriminatorValue('/telemetryPage', 'logs-clickhouse')
+
+  function isActivePage(page) {
+    return getValue(discriminator, '/telemetryPage') === page
+  }
+
+  function isPillarEnabled(pillar) {
+    return !!getValue(model, `/spec/${pillar}/enabled`)
+  }
+
+  function pillarStatus(pillar) {
+    const name = pillarNames[pillar] || pillar
+    return isPillarEnabled(pillar)
+      ? `ClickHouse is collecting ${name.toLowerCase()}. Turn it off to remove the backend from this stack.`
+      : `ClickHouse is not collecting ${name.toLowerCase()}. Turn it on to configure the backend.`
+  }
+
+  function isClusterTopology(pillar) {
+    return (
+      isPillarEnabled(pillar) &&
+      getValue(model, `/spec/${pillar}/deploymentMode`) === 'ClusterTopology'
+    )
+  }
+
+  async function getStorageClasses() {
+    const owner = storeGet('/route/params/user')
+    const cluster = storeGet('/route/params/cluster')
+
+    try {
+      const resp = await axios.get(
+        `/clusters/${owner}/${cluster}/proxy/storage.k8s.io/v1/storageclasses`,
+        { params: { filter: { items: { metadata: { name: null } } } } },
+      )
+      const items = (resp && resp.data && resp.data.items) || []
+      return items.map((item) => item?.metadata?.name).filter(Boolean)
+    } catch (e) {
+      console.log(e)
+      return []
+    }
+  }
+
+  return {
+    getStorageClasses,
+    isActivePage,
+    isClusterTopology,
+    isPillarEnabled,
+    pillarStatus,
+  }
+}

--- a/charts/monitoringk8sappscodecom-telemetrystack-editor-options/ui/language.yaml
+++ b/charts/monitoringk8sappscodecom-telemetrystack-editor-options/ui/language.yaml
@@ -1,0 +1,35 @@
+en:
+  labels:
+    logs:
+      title: Logs
+      clickhouse: ClickHouse
+    metrics:
+      title: Metrics
+      thanos:
+        title: Thanos
+        compact: Compact
+        query: Query
+        receive: Receive
+        ruler: Ruler
+        s3: S3 Storage
+        store: Store
+    traces:
+      title: Traces
+      clickhouse: ClickHouse
+    clickhouse:
+      clusterTopology: Cluster Topology
+      clientCaCertificates: Client CA Certificates
+      deletionPolicy: Deletion Policy
+      deploymentMode: Deployment Mode
+      general: General
+      storage: Persistent Storage
+      version: Version
+    s3:
+      accessKey: Access Key
+      bucket: Bucket
+      endpoint: Endpoint
+      prefix: Prefix
+      region: Region
+      secretKey: Secret Key
+  steps:
+  - label: Options


### PR DESCRIPTION
Renders the TelemetryStack options as a sidebar layout with a page per pillar: ClickHouse for logs and traces, and one page per Thanos component for metrics. All fields are bound to values.openapiv3_schema.yaml, so the form only exposes what the chart can actually render.

Pillar configuration is gated on spec.<pillar>.enabled, and the ClickHouse helper now skips the rest of the block when a pillar is disabled so the generated CR stays valid.