### PR TITLE
Rename spec.configSecret.name to spec.configuration.secretName in db editor options

### DIFF
--- a/charts/kubedbcom-cassandra-editor-options/templates/db.yaml
+++ b/charts/kubedbcom-cassandra-editor-options/templates/db.yaml
@@ -157,8 +157,8 @@ spec:
     kind: Secret
 {{- end }}
 {{- if .Values.spec.configuration }}
-  configSecret:
-    name: {{ include "kubedbcom-cassandra-editor-options.fullname" . }}-config
+  configuration:
+    secretName: {{ include "kubedbcom-cassandra-editor-options.fullname" . }}-config
 {{- end }}
 {{- if .Values.spec.admin.tls.default }}
   tls:

--- a/charts/kubedbcom-clickhouse-editor-options/templates/db.yaml
+++ b/charts/kubedbcom-clickhouse-editor-options/templates/db.yaml
@@ -197,8 +197,8 @@ spec:
     kind: Secret
 {{- end }}
 {{- if .Values.spec.configuration }}
-  configSecret:
-    name: {{ include "kubedbcom-clickhouse-editor-options.fullname" . }}-config
+  configuration:
+    secretName: {{ include "kubedbcom-clickhouse-editor-options.fullname" . }}-config
 {{- end }}
 {{- if (and .Values.spec.admin.monitoring .Values.spec.admin.monitoring.agent) }}
   monitor:

--- a/charts/kubedbcom-druid-editor-options/templates/db.yaml
+++ b/charts/kubedbcom-druid-editor-options/templates/db.yaml
@@ -190,8 +190,8 @@ spec:
     kind: Secret
 {{- end }}
 {{- if .Values.spec.configuration }}
-  configSecret:
-    name: {{ include "kubedbcom-druid-editor-options.fullname" . }}-config
+  configuration:
+    secretName: {{ include "kubedbcom-druid-editor-options.fullname" . }}-config
 {{- end }}
 {{- if .Values.spec.admin.tls.default }}
   tls:

--- a/charts/kubedbcom-elasticsearch-editor-options/templates/db.yaml
+++ b/charts/kubedbcom-elasticsearch-editor-options/templates/db.yaml
@@ -191,8 +191,8 @@ spec:
     kind: Secret
 {{- end }}
 {{- if .Values.spec.configuration }}
-  configSecret:
-    name: {{ include "kubedbcom-elasticsearch-editor-options.fullname" . }}-user-config
+  configuration:
+    secretName: {{ include "kubedbcom-elasticsearch-editor-options.fullname" . }}-user-config
 {{- end }}
 {{- if .Values.spec.admin.tls.default }}
   tls:

--- a/charts/kubedbcom-hazelcast-editor-options/templates/db.yaml
+++ b/charts/kubedbcom-hazelcast-editor-options/templates/db.yaml
@@ -125,8 +125,8 @@ spec:
     kind: Secret
 {{- end }}
 {{- if .Values.spec.configuration }}
-  configSecret:
-    name: {{ include "kubedbcom-hazelcast-editor-options.fullname" . }}-config
+  configuration:
+    secretName: {{ include "kubedbcom-hazelcast-editor-options.fullname" . }}-config
 {{- end }}
 {{- if .Values.spec.admin.tls.default }}
   tls:

--- a/charts/kubedbcom-ignite-editor-options/templates/db.yaml
+++ b/charts/kubedbcom-ignite-editor-options/templates/db.yaml
@@ -123,8 +123,8 @@ spec:
     kind: Secret
 {{- end }}
 {{- if .Values.spec.configuration }}
-  configSecret:
-    name: {{ include "kubedbcom-ignite-editor-options.fullname" . }}-config
+  configuration:
+    secretName: {{ include "kubedbcom-ignite-editor-options.fullname" . }}-config
 {{- end }}
 {{- if .Values.spec.admin.tls.default }}
   tls:

--- a/charts/kubedbcom-kafka-editor-options/templates/db.yaml
+++ b/charts/kubedbcom-kafka-editor-options/templates/db.yaml
@@ -147,8 +147,8 @@ spec:
     kind: Secret
 {{- end }}
 {{- if .Values.spec.configuration }}
-  configSecret:
-    name: {{ include "kubedbcom-kafka-editor-options.fullname" . }}-config
+  configuration:
+    secretName: {{ include "kubedbcom-kafka-editor-options.fullname" . }}-config
 {{- end }}
 {{- if .Values.spec.admin.tls.default }}
   tls:

--- a/charts/kubedbcom-mariadb-editor-options/templates/db.yaml
+++ b/charts/kubedbcom-mariadb-editor-options/templates/db.yaml
@@ -136,8 +136,8 @@ spec:
     kind: Secret
 {{- end }}
 {{- if .Values.spec.configuration }}
-  configSecret:
-    name: {{ include "kubedbcom-mariadb-editor-options.fullname" . }}-config
+  configuration:
+    secretName: {{ include "kubedbcom-mariadb-editor-options.fullname" . }}-config
 {{- end }}
 {{- if .Values.spec.admin.tls.default }}
   tls:

--- a/charts/kubedbcom-memcached-editor-options/templates/db.yaml
+++ b/charts/kubedbcom-memcached-editor-options/templates/db.yaml
@@ -95,8 +95,8 @@ spec:
     kind: Secret
 {{- end }}
 {{- if .Values.spec.configuration }}
-  configSecret:
-    name: {{ include "kubedbcom-memcached-editor-options.fullname" . }}-config
+  configuration:
+    secretName: {{ include "kubedbcom-memcached-editor-options.fullname" . }}-config
 {{- end }}
 {{- if .Values.spec.admin.tls.default }}
   tls:

--- a/charts/kubedbcom-mongodb-editor-options/templates/db.yaml
+++ b/charts/kubedbcom-mongodb-editor-options/templates/db.yaml
@@ -266,8 +266,8 @@ spec:
     kind: Secret
 {{- end }}
 {{- if .Values.spec.configuration }}
-  configSecret:
-    name: {{ include "kubedbcom-mongodb-editor-options.fullname" . }}-config
+  configuration:
+    secretName: {{ include "kubedbcom-mongodb-editor-options.fullname" . }}-config
 {{- end }}
 {{- if .Values.spec.admin.tls.default }}
   tls:

--- a/charts/kubedbcom-mssqlserver-editor-options/templates/db.yaml
+++ b/charts/kubedbcom-mssqlserver-editor-options/templates/db.yaml
@@ -141,8 +141,8 @@ spec:
     kind: Secret
 {{- end }}
 {{- if .Values.spec.configuration }}
-  configSecret:
-    name: {{ include "kubedbcom-mssqlserver-editor-options.fullname" . }}-config
+  configuration:
+    secretName: {{ include "kubedbcom-mssqlserver-editor-options.fullname" . }}-config
 {{- end }}
   tls:
     issuerRef:

--- a/charts/kubedbcom-mysql-editor-options/templates/db.yaml
+++ b/charts/kubedbcom-mysql-editor-options/templates/db.yaml
@@ -167,8 +167,8 @@ spec:
     kind: Secret
 {{- end }}
 {{- if .Values.spec.configuration }}
-  configSecret:
-    name: {{ include "kubedbcom-mysql-editor-options.fullname" . }}-config
+  configuration:
+    secretName: {{ include "kubedbcom-mysql-editor-options.fullname" . }}-config
 {{- end }}
 {{- if .Values.spec.admin.tls.default }}
   tls:

--- a/charts/kubedbcom-oracle-editor-options/templates/db.yaml
+++ b/charts/kubedbcom-oracle-editor-options/templates/db.yaml
@@ -175,8 +175,8 @@ spec:
     kind: Secret
 {{- end }}
 {{- if .Values.spec.configuration }}
-  configSecret:
-    name: {{ include "kubedbcom-oracle-editor-options.fullname" . }}-config
+  configuration:
+    secretName: {{ include "kubedbcom-oracle-editor-options.fullname" . }}-config
 {{- end }}
 {{- if .Values.spec.admin.tls.default }}
   tls:

--- a/charts/kubedbcom-perconaxtradb-editor-options/templates/db.yaml
+++ b/charts/kubedbcom-perconaxtradb-editor-options/templates/db.yaml
@@ -116,8 +116,8 @@ spec:
     kind: Secret
 {{- end }}
 {{- if .Values.spec.configuration }}
-  configSecret:
-    name: {{ include "kubedbcom-perconaxtradb-editor-options.fullname" . }}-config
+  configuration:
+    secretName: {{ include "kubedbcom-perconaxtradb-editor-options.fullname" . }}-config
 {{- end }}
 {{- if .Values.spec.admin.tls.default }}
   tls:

--- a/charts/kubedbcom-pgbouncer-editor-options/templates/db.yaml
+++ b/charts/kubedbcom-pgbouncer-editor-options/templates/db.yaml
@@ -103,8 +103,8 @@ spec:
     kind: Secret
 {{- end }}
 {{- if .Values.spec.configuration }}
-  configSecret:
-    name: {{ include "kubedbcom-pgbouncer-editor-options.fullname" . }}-config
+  configuration:
+    secretName: {{ include "kubedbcom-pgbouncer-editor-options.fullname" . }}-config
 {{- end }}
 {{- if .Values.spec.admin.tls.default }}
   tls:

--- a/charts/kubedbcom-pgpool-editor-options/templates/db.yaml
+++ b/charts/kubedbcom-pgpool-editor-options/templates/db.yaml
@@ -99,8 +99,8 @@ spec:
     kind: Secret
 {{- end }}
 {{- if .Values.spec.configuration }}
-  configSecret:
-    name: {{ include "kubedbcom-pgpool-editor-options.fullname" . }}-config
+  configuration:
+    secretName: {{ include "kubedbcom-pgpool-editor-options.fullname" . }}-config
 {{- end }}
 {{- if .Values.spec.admin.tls.default }}
   tls:

--- a/charts/kubedbcom-postgres-editor-options/templates/db.yaml
+++ b/charts/kubedbcom-postgres-editor-options/templates/db.yaml
@@ -147,8 +147,8 @@ spec:
     kind: Secret
 {{- end }}
 {{- if .Values.spec.configuration }}
-  configSecret:
-    name: {{ include "kubedbcom-postgres-editor-options.fullname" . }}-config
+  configuration:
+    secretName: {{ include "kubedbcom-postgres-editor-options.fullname" . }}-config
 {{- end }}
 {{- if .Values.spec.admin.tls.default }}
   tls:

--- a/charts/kubedbcom-proxysql-editor-options/templates/db.yaml
+++ b/charts/kubedbcom-proxysql-editor-options/templates/db.yaml
@@ -104,8 +104,8 @@ spec:
     kind: Secret
 {{- end }}
 {{- if .Values.spec.configuration }}
-  configSecret:
-    name: {{ include "kubedbcom-proxysql-editor-options.fullname" . }}-config
+  configuration:
+    secretName: {{ include "kubedbcom-proxysql-editor-options.fullname" . }}-config
 {{- end }}
 {{- if .Values.spec.admin.tls.default }}
   tls:

--- a/charts/kubedbcom-rabbitmq-editor-options/templates/db.yaml
+++ b/charts/kubedbcom-rabbitmq-editor-options/templates/db.yaml
@@ -99,8 +99,8 @@ spec:
     kind: Secret
 {{- end }}
 {{- if .Values.spec.configuration }}
-  configSecret:
-    name: {{ include "kubedbcom-rabbitmq-editor-options.fullname" . }}-config
+  configuration:
+    secretName: {{ include "kubedbcom-rabbitmq-editor-options.fullname" . }}-config
 {{- end }}
 {{- if .Values.spec.admin.tls.default }}
   tls:

--- a/charts/kubedbcom-redis-editor-options/templates/db.yaml
+++ b/charts/kubedbcom-redis-editor-options/templates/db.yaml
@@ -140,8 +140,8 @@ spec:
     kind: Secret
 {{- end }}
 {{- if .Values.spec.configuration }}
-  configSecret:
-    name: {{ include "kubedbcom-redis-editor-options.fullname" . }}-config
+  configuration:
+    secretName: {{ include "kubedbcom-redis-editor-options.fullname" . }}-config
 {{- end }}
 {{- if .Values.spec.admin.tls.default }}
   tls:

--- a/charts/kubedbcom-singlestore-editor-options/templates/db.yaml
+++ b/charts/kubedbcom-singlestore-editor-options/templates/db.yaml
@@ -166,8 +166,8 @@ spec:
     kind: Secret
 {{- end }}
 {{- if .Values.spec.configuration }}
-  configSecret:
-    name: {{ include "kubedbcom-singlestore-editor-options.fullname" . }}-config
+  configuration:
+    secretName: {{ include "kubedbcom-singlestore-editor-options.fullname" . }}-config
 {{- end }}
 {{- if .Values.spec.admin.tls.default }}
   tls:

--- a/charts/kubedbcom-solr-editor-options/templates/db.yaml
+++ b/charts/kubedbcom-solr-editor-options/templates/db.yaml
@@ -156,8 +156,8 @@ spec:
     kind: Secret
 {{- end }}
 {{- if .Values.spec.configuration }}
-  configSecret:
-    name: {{ include "kubedbcom-solr-editor-options.fullname" . }}-config
+  configuration:
+    secretName: {{ include "kubedbcom-solr-editor-options.fullname" . }}-config
 {{- end }}
 {{- if .Values.spec.admin.tls.default }}
   tls:

--- a/charts/kubedbcom-zookeeper-editor-options/templates/db.yaml
+++ b/charts/kubedbcom-zookeeper-editor-options/templates/db.yaml
@@ -108,8 +108,8 @@ spec:
     kind: Secret
 {{- end }}
 {{- if .Values.spec.configuration }}
-  configSecret:
-    name: {{ include "kubedbcom-zookeeper-editor-options.fullname" . }}-config
+  configuration:
+    secretName: {{ include "kubedbcom-zookeeper-editor-options.fullname" . }}-config
 {{- end }}
 {{- if .Values.spec.admin.tls.default }}
   tls:


### PR DESCRIPTION
The KubeDB CRD field `spec.configSecret.name` is now `spec.configuration.secretName`. Updated the rendered field in all `charts/kubedbcom-<db>-editor-options/templates/db.yaml`.

Nested fields with a different meaning were left untouched:
- `spec.objectStorage.configSecret.name` (milvus)
- `spec.deepStorage.configSecret.name` (druid)

Milvus's top-level field was already migrated. No schema regeneration needed — the values key `spec.configuration` is unchanged; only the rendered CRD field name differs.