### PR TITLE
Filter authSecret dropdown to secrets with only username & password keys

### DIFF
--- a/charts/kubedbcom-cassandra-editor-options/ui/functions.js
+++ b/charts/kubedbcom-cassandra-editor-options/ui/functions.js
@@ -349,10 +349,16 @@ export const useFunc = (model) => {
 
     const options = []
     try {
-      const resp = await axios.get(url)
-      const items = resp.data?.items
+      const resp = await axios.get(url, {
+        params: {
+          filter: { items: { metadata: { name: null }, data: null } },
+        },
+      })
+      const items = resp.data?.items || []
       items.forEach((ele) => {
-        options.push(ele.metadata?.name)
+        const keys = Object.keys(ele.data || {})
+        if (keys.length === 2 && keys.includes('username') && keys.includes('password'))
+          options.push(ele.metadata?.name)
       })
     } catch (e) {
       console.log(e)

--- a/charts/kubedbcom-clickhouse-editor-options/ui/functions.js
+++ b/charts/kubedbcom-clickhouse-editor-options/ui/functions.js
@@ -1254,10 +1254,16 @@ export const useFunc = (model) => {
 
     const options = []
     try {
-      const resp = await axios.get(url)
-      const items = resp.data?.items
+      const resp = await axios.get(url, {
+        params: {
+          filter: { items: { metadata: { name: null }, data: null } },
+        },
+      })
+      const items = resp.data?.items || []
       items.forEach((ele) => {
-        options.push(ele.metadata?.name)
+        const keys = Object.keys(ele.data || {})
+        if (keys.length === 2 && keys.includes('username') && keys.includes('password'))
+          options.push(ele.metadata?.name)
       })
     } catch (e) {
       console.log(e)

--- a/charts/kubedbcom-db2-editor-options/ui/functions.js
+++ b/charts/kubedbcom-db2-editor-options/ui/functions.js
@@ -1304,10 +1304,16 @@ export const useFunc = (model) => {
 
     const options = []
     try {
-      const resp = await axios.get(url)
-      const items = resp.data?.items
+      const resp = await axios.get(url, {
+        params: {
+          filter: { items: { metadata: { name: null }, data: null } },
+        },
+      })
+      const items = resp.data?.items || []
       items.forEach((ele) => {
-        options.push(ele.metadata?.name)
+        const keys = Object.keys(ele.data || {})
+        if (keys.length === 2 && keys.includes('username') && keys.includes('password'))
+          options.push(ele.metadata?.name)
       })
     } catch (e) {
       console.log(e)

--- a/charts/kubedbcom-documentdb-editor-options/ui/functions.js
+++ b/charts/kubedbcom-documentdb-editor-options/ui/functions.js
@@ -345,10 +345,16 @@ export const useFunc = (model) => {
 
     const options = []
     try {
-      const resp = await axios.get(url)
-      const items = resp.data?.items
+      const resp = await axios.get(url, {
+        params: {
+          filter: { items: { metadata: { name: null }, data: null } },
+        },
+      })
+      const items = resp.data?.items || []
       items.forEach((ele) => {
-        options.push(ele.metadata?.name)
+        const keys = Object.keys(ele.data || {})
+        if (keys.length === 2 && keys.includes('username') && keys.includes('password'))
+          options.push(ele.metadata?.name)
       })
     } catch (e) {
       console.log(e)

--- a/charts/kubedbcom-druid-editor-options/ui/functions.js
+++ b/charts/kubedbcom-druid-editor-options/ui/functions.js
@@ -1085,10 +1085,16 @@ export const useFunc = (model) => {
 
     const options = []
     try {
-      const resp = await axios.get(url)
-      const items = resp.data?.items
+      const resp = await axios.get(url, {
+        params: {
+          filter: { items: { metadata: { name: null }, data: null } },
+        },
+      })
+      const items = resp.data?.items || []
       items.forEach((ele) => {
-        options.push(ele.metadata?.name)
+        const keys = Object.keys(ele.data || {})
+        if (keys.length === 2 && keys.includes('username') && keys.includes('password'))
+          options.push(ele.metadata?.name)
       })
     } catch (e) {
       console.log(e)

--- a/charts/kubedbcom-elasticsearch-editor-options/ui/functions.js
+++ b/charts/kubedbcom-elasticsearch-editor-options/ui/functions.js
@@ -1092,10 +1092,16 @@ export const useFunc = (model) => {
 
     const options = []
     try {
-      const resp = await axios.get(url)
-      const items = resp.data?.items
+      const resp = await axios.get(url, {
+        params: {
+          filter: { items: { metadata: { name: null }, data: null } },
+        },
+      })
+      const items = resp.data?.items || []
       items.forEach((ele) => {
-        options.push(ele.metadata?.name)
+        const keys = Object.keys(ele.data || {})
+        if (keys.length === 2 && keys.includes('username') && keys.includes('password'))
+          options.push(ele.metadata?.name)
       })
     } catch (e) {
       console.log(e)

--- a/charts/kubedbcom-hanadb-editor-options/ui/functions.js
+++ b/charts/kubedbcom-hanadb-editor-options/ui/functions.js
@@ -1108,10 +1108,16 @@ export const useFunc = (model) => {
 
     const options = []
     try {
-      const resp = await axios.get(url)
-      const items = resp.data?.items
+      const resp = await axios.get(url, {
+        params: {
+          filter: { items: { metadata: { name: null }, data: null } },
+        },
+      })
+      const items = resp.data?.items || []
       items.forEach((ele) => {
-        options.push(ele.metadata?.name)
+        const keys = Object.keys(ele.data || {})
+        if (keys.length === 2 && keys.includes('username') && keys.includes('password'))
+          options.push(ele.metadata?.name)
       })
     } catch (e) {
       console.log(e)

--- a/charts/kubedbcom-hazelcast-editor-options/ui/functions.js
+++ b/charts/kubedbcom-hazelcast-editor-options/ui/functions.js
@@ -1325,10 +1325,16 @@ export const useFunc = (model) => {
 
     const options = []
     try {
-      const resp = await axios.get(url)
-      const items = resp.data?.items
+      const resp = await axios.get(url, {
+        params: {
+          filter: { items: { metadata: { name: null }, data: null } },
+        },
+      })
+      const items = resp.data?.items || []
       items.forEach((ele) => {
-        options.push(ele.metadata?.name)
+        const keys = Object.keys(ele.data || {})
+        if (keys.length === 2 && keys.includes('username') && keys.includes('password'))
+          options.push(ele.metadata?.name)
       })
     } catch (e) {
       console.log(e)

--- a/charts/kubedbcom-ignite-editor-options/ui/functions.js
+++ b/charts/kubedbcom-ignite-editor-options/ui/functions.js
@@ -1316,10 +1316,16 @@ export const useFunc = (model) => {
 
     const options = []
     try {
-      const resp = await axios.get(url)
-      const items = resp.data?.items
+      const resp = await axios.get(url, {
+        params: {
+          filter: { items: { metadata: { name: null }, data: null } },
+        },
+      })
+      const items = resp.data?.items || []
       items.forEach((ele) => {
-        options.push(ele.metadata?.name)
+        const keys = Object.keys(ele.data || {})
+        if (keys.length === 2 && keys.includes('username') && keys.includes('password'))
+          options.push(ele.metadata?.name)
       })
     } catch (e) {
       console.log(e)

--- a/charts/kubedbcom-kafka-editor-options/ui/functions.js
+++ b/charts/kubedbcom-kafka-editor-options/ui/functions.js
@@ -999,10 +999,16 @@ export const useFunc = (model) => {
 
     const options = []
     try {
-      const resp = await axios.get(url)
-      const items = resp.data?.items
+      const resp = await axios.get(url, {
+        params: {
+          filter: { items: { metadata: { name: null }, data: null } },
+        },
+      })
+      const items = resp.data?.items || []
       items.forEach((ele) => {
-        options.push(ele.metadata?.name)
+        const keys = Object.keys(ele.data || {})
+        if (keys.length === 2 && keys.includes('username') && keys.includes('password'))
+          options.push(ele.metadata?.name)
       })
     } catch (e) {
       console.log(e)

--- a/charts/kubedbcom-mariadb-editor-options/ui/functions.js
+++ b/charts/kubedbcom-mariadb-editor-options/ui/functions.js
@@ -1360,10 +1360,16 @@ export const useFunc = (model) => {
 
     const options = []
     try {
-      const resp = await axios.get(url)
-      const items = resp.data?.items
+      const resp = await axios.get(url, {
+        params: {
+          filter: { items: { metadata: { name: null }, data: null } },
+        },
+      })
+      const items = resp.data?.items || []
       items.forEach((ele) => {
-        options.push(ele.metadata?.name)
+        const keys = Object.keys(ele.data || {})
+        if (keys.length === 2 && keys.includes('username') && keys.includes('password'))
+          options.push(ele.metadata?.name)
       })
     } catch (e) {
       console.log(e)

--- a/charts/kubedbcom-memcached-editor-options/ui/functions.js
+++ b/charts/kubedbcom-memcached-editor-options/ui/functions.js
@@ -1021,10 +1021,16 @@ export const useFunc = (model) => {
 
     const options = []
     try {
-      const resp = await axios.get(url)
-      const items = resp.data?.items
+      const resp = await axios.get(url, {
+        params: {
+          filter: { items: { metadata: { name: null }, data: null } },
+        },
+      })
+      const items = resp.data?.items || []
       items.forEach((ele) => {
-        options.push(ele.metadata?.name)
+        const keys = Object.keys(ele.data || {})
+        if (keys.length === 2 && keys.includes('username') && keys.includes('password'))
+          options.push(ele.metadata?.name)
       })
     } catch (e) {
       console.log(e)

--- a/charts/kubedbcom-milvus-editor-options/ui/functions.js
+++ b/charts/kubedbcom-milvus-editor-options/ui/functions.js
@@ -1109,10 +1109,16 @@ export const useFunc = (model) => {
 
     const options = []
     try {
-      const resp = await axios.get(url)
-      const items = resp.data?.items
+      const resp = await axios.get(url, {
+        params: {
+          filter: { items: { metadata: { name: null }, data: null } },
+        },
+      })
+      const items = resp.data?.items || []
       items.forEach((ele) => {
-        options.push(ele.metadata?.name)
+        const keys = Object.keys(ele.data || {})
+        if (keys.length === 2 && keys.includes('username') && keys.includes('password'))
+          options.push(ele.metadata?.name)
       })
     } catch (e) {
       console.log(e)

--- a/charts/kubedbcom-mongodb-editor-options/ui/functions.js
+++ b/charts/kubedbcom-mongodb-editor-options/ui/functions.js
@@ -350,10 +350,16 @@ export const useFunc = (model) => {
 
     const options = []
     try {
-      const resp = await axios.get(url)
-      const items = resp.data?.items
+      const resp = await axios.get(url, {
+        params: {
+          filter: { items: { metadata: { name: null }, data: null } },
+        },
+      })
+      const items = resp.data?.items || []
       items.forEach((ele) => {
-        options.push(ele.metadata?.name)
+        const keys = Object.keys(ele.data || {})
+        if (keys.length === 2 && keys.includes('username') && keys.includes('password'))
+          options.push(ele.metadata?.name)
       })
     } catch (e) {
       console.log(e)

--- a/charts/kubedbcom-mssqlserver-editor-options/ui/functions.js
+++ b/charts/kubedbcom-mssqlserver-editor-options/ui/functions.js
@@ -1395,10 +1395,16 @@ export const useFunc = (model) => {
 
     const options = []
     try {
-      const resp = await axios.get(url)
-      const items = resp.data?.items
+      const resp = await axios.get(url, {
+        params: {
+          filter: { items: { metadata: { name: null }, data: null } },
+        },
+      })
+      const items = resp.data?.items || []
       items.forEach((ele) => {
-        options.push(ele.metadata?.name)
+        const keys = Object.keys(ele.data || {})
+        if (keys.length === 2 && keys.includes('username') && keys.includes('password'))
+          options.push(ele.metadata?.name)
       })
     } catch (e) {
       console.log(e)

--- a/charts/kubedbcom-mysql-editor-options/ui/functions.js
+++ b/charts/kubedbcom-mysql-editor-options/ui/functions.js
@@ -1362,10 +1362,16 @@ export const useFunc = (model) => {
 
     const options = []
     try {
-      const resp = await axios.get(url)
-      const items = resp.data?.items
+      const resp = await axios.get(url, {
+        params: {
+          filter: { items: { metadata: { name: null }, data: null } },
+        },
+      })
+      const items = resp.data?.items || []
       items.forEach((ele) => {
-        options.push(ele.metadata?.name)
+        const keys = Object.keys(ele.data || {})
+        if (keys.length === 2 && keys.includes('username') && keys.includes('password'))
+          options.push(ele.metadata?.name)
       })
     } catch (e) {
       console.log(e)

--- a/charts/kubedbcom-neo4j-editor-options/ui/functions.js
+++ b/charts/kubedbcom-neo4j-editor-options/ui/functions.js
@@ -926,10 +926,16 @@ export const useFunc = (model) => {
 
     const options = []
     try {
-      const resp = await axios.get(url)
-      const items = resp.data?.items
+      const resp = await axios.get(url, {
+        params: {
+          filter: { items: { metadata: { name: null }, data: null } },
+        },
+      })
+      const items = resp.data?.items || []
       items.forEach((ele) => {
-        options.push(ele.metadata?.name)
+        const keys = Object.keys(ele.data || {})
+        if (keys.length === 2 && keys.includes('username') && keys.includes('password'))
+          options.push(ele.metadata?.name)
       })
     } catch (e) {
       console.log(e)

--- a/charts/kubedbcom-oracle-editor-options/ui/functions.js
+++ b/charts/kubedbcom-oracle-editor-options/ui/functions.js
@@ -1292,10 +1292,16 @@ export const useFunc = (model) => {
 
     const options = []
     try {
-      const resp = await axios.get(url)
-      const items = resp.data?.items
+      const resp = await axios.get(url, {
+        params: {
+          filter: { items: { metadata: { name: null }, data: null } },
+        },
+      })
+      const items = resp.data?.items || []
       items.forEach((ele) => {
-        options.push(ele.metadata?.name)
+        const keys = Object.keys(ele.data || {})
+        if (keys.length === 2 && keys.includes('username') && keys.includes('password'))
+          options.push(ele.metadata?.name)
       })
     } catch (e) {
       console.log(e)

--- a/charts/kubedbcom-perconaxtradb-editor-options/ui/functions.js
+++ b/charts/kubedbcom-perconaxtradb-editor-options/ui/functions.js
@@ -1276,10 +1276,16 @@ export const useFunc = (model) => {
 
     const options = []
     try {
-      const resp = await axios.get(url)
-      const items = resp.data?.items
+      const resp = await axios.get(url, {
+        params: {
+          filter: { items: { metadata: { name: null }, data: null } },
+        },
+      })
+      const items = resp.data?.items || []
       items.forEach((ele) => {
-        options.push(ele.metadata?.name)
+        const keys = Object.keys(ele.data || {})
+        if (keys.length === 2 && keys.includes('username') && keys.includes('password'))
+          options.push(ele.metadata?.name)
       })
     } catch (e) {
       console.log(e)

--- a/charts/kubedbcom-pgbouncer-editor-options/ui/functions.js
+++ b/charts/kubedbcom-pgbouncer-editor-options/ui/functions.js
@@ -1006,10 +1006,16 @@ export const useFunc = (model) => {
 
     const options = []
     try {
-      const resp = await axios.get(url)
-      const items = resp.data?.items
+      const resp = await axios.get(url, {
+        params: {
+          filter: { items: { metadata: { name: null }, data: null } },
+        },
+      })
+      const items = resp.data?.items || []
       items.forEach((ele) => {
-        options.push(ele.metadata?.name)
+        const keys = Object.keys(ele.data || {})
+        if (keys.length === 2 && keys.includes('username') && keys.includes('password'))
+          options.push(ele.metadata?.name)
       })
     } catch (e) {
       console.log(e)

--- a/charts/kubedbcom-pgpool-editor-options/ui/functions.js
+++ b/charts/kubedbcom-pgpool-editor-options/ui/functions.js
@@ -1222,10 +1222,16 @@ export const useFunc = (model) => {
 
     const options = []
     try {
-      const resp = await axios.get(url)
-      const items = resp.data?.items
+      const resp = await axios.get(url, {
+        params: {
+          filter: { items: { metadata: { name: null }, data: null } },
+        },
+      })
+      const items = resp.data?.items || []
       items.forEach((ele) => {
-        options.push(ele.metadata?.name)
+        const keys = Object.keys(ele.data || {})
+        if (keys.length === 2 && keys.includes('username') && keys.includes('password'))
+          options.push(ele.metadata?.name)
       })
     } catch (e) {
       console.log(e)

--- a/charts/kubedbcom-postgres-editor-options/ui/functions.js
+++ b/charts/kubedbcom-postgres-editor-options/ui/functions.js
@@ -1545,10 +1545,16 @@ export const useFunc = (model) => {
 
     const options = []
     try {
-      const resp = await axios.get(url)
-      const items = resp.data?.items
+      const resp = await axios.get(url, {
+        params: {
+          filter: { items: { metadata: { name: null }, data: null } },
+        },
+      })
+      const items = resp.data?.items || []
       items.forEach((ele) => {
-        options.push(ele.metadata?.name)
+        const keys = Object.keys(ele.data || {})
+        if (keys.length === 2 && keys.includes('username') && keys.includes('password'))
+          options.push(ele.metadata?.name)
       })
     } catch (e) {
       console.log(e)

--- a/charts/kubedbcom-proxysql-editor-options/ui/functions.js
+++ b/charts/kubedbcom-proxysql-editor-options/ui/functions.js
@@ -1274,10 +1274,16 @@ export const useFunc = (model) => {
 
     const options = []
     try {
-      const resp = await axios.get(url)
-      const items = resp.data?.items
+      const resp = await axios.get(url, {
+        params: {
+          filter: { items: { metadata: { name: null }, data: null } },
+        },
+      })
+      const items = resp.data?.items || []
       items.forEach((ele) => {
-        options.push(ele.metadata?.name)
+        const keys = Object.keys(ele.data || {})
+        if (keys.length === 2 && keys.includes('username') && keys.includes('password'))
+          options.push(ele.metadata?.name)
       })
     } catch (e) {
       console.log(e)

--- a/charts/kubedbcom-qdrant-editor-options/ui/functions.js
+++ b/charts/kubedbcom-qdrant-editor-options/ui/functions.js
@@ -981,10 +981,16 @@ export const useFunc = (model) => {
 
     const options = []
     try {
-      const resp = await axios.get(url)
-      const items = resp.data?.items
+      const resp = await axios.get(url, {
+        params: {
+          filter: { items: { metadata: { name: null }, data: null } },
+        },
+      })
+      const items = resp.data?.items || []
       items.forEach((ele) => {
-        options.push(ele.metadata?.name)
+        const keys = Object.keys(ele.data || {})
+        if (keys.length === 2 && keys.includes('username') && keys.includes('password'))
+          options.push(ele.metadata?.name)
       })
     } catch (e) {
       console.log(e)

--- a/charts/kubedbcom-rabbitmq-editor-options/ui/functions.js
+++ b/charts/kubedbcom-rabbitmq-editor-options/ui/functions.js
@@ -1282,10 +1282,16 @@ export const useFunc = (model) => {
 
     const options = []
     try {
-      const resp = await axios.get(url)
-      const items = resp.data?.items
+      const resp = await axios.get(url, {
+        params: {
+          filter: { items: { metadata: { name: null }, data: null } },
+        },
+      })
+      const items = resp.data?.items || []
       items.forEach((ele) => {
-        options.push(ele.metadata?.name)
+        const keys = Object.keys(ele.data || {})
+        if (keys.length === 2 && keys.includes('username') && keys.includes('password'))
+          options.push(ele.metadata?.name)
       })
     } catch (e) {
       console.log(e)

--- a/charts/kubedbcom-redis-editor-options/ui/functions.js
+++ b/charts/kubedbcom-redis-editor-options/ui/functions.js
@@ -710,10 +710,16 @@ export const useFunc = (model) => {
 
     const options = []
     try {
-      const resp = await axios.get(url)
-      const items = resp.data?.items
+      const resp = await axios.get(url, {
+        params: {
+          filter: { items: { metadata: { name: null }, data: null } },
+        },
+      })
+      const items = resp.data?.items || []
       items.forEach((ele) => {
-        options.push(ele.metadata?.name)
+        const keys = Object.keys(ele.data || {})
+        if (keys.length === 2 && keys.includes('username') && keys.includes('password'))
+          options.push(ele.metadata?.name)
       })
     } catch (e) {
       console.log(e)

--- a/charts/kubedbcom-singlestore-editor-options/ui/functions.js
+++ b/charts/kubedbcom-singlestore-editor-options/ui/functions.js
@@ -558,10 +558,16 @@ export const useFunc = (model) => {
 
     const options = []
     try {
-      const resp = await axios.get(url)
-      const items = resp.data?.items
+      const resp = await axios.get(url, {
+        params: {
+          filter: { items: { metadata: { name: null }, data: null } },
+        },
+      })
+      const items = resp.data?.items || []
       items.forEach((ele) => {
-        options.push(ele.metadata?.name)
+        const keys = Object.keys(ele.data || {})
+        if (keys.length === 2 && keys.includes('username') && keys.includes('password'))
+          options.push(ele.metadata?.name)
       })
     } catch (e) {
       console.log(e)

--- a/charts/kubedbcom-solr-editor-options/ui/functions.js
+++ b/charts/kubedbcom-solr-editor-options/ui/functions.js
@@ -539,10 +539,16 @@ export const useFunc = (model) => {
 
     const options = []
     try {
-      const resp = await axios.get(url)
-      const items = resp.data?.items
+      const resp = await axios.get(url, {
+        params: {
+          filter: { items: { metadata: { name: null }, data: null } },
+        },
+      })
+      const items = resp.data?.items || []
       items.forEach((ele) => {
-        options.push(ele.metadata?.name)
+        const keys = Object.keys(ele.data || {})
+        if (keys.length === 2 && keys.includes('username') && keys.includes('password'))
+          options.push(ele.metadata?.name)
       })
     } catch (e) {
       console.log(e)

--- a/charts/kubedbcom-weaviate-editor-options/ui/functions.js
+++ b/charts/kubedbcom-weaviate-editor-options/ui/functions.js
@@ -890,10 +890,16 @@ export const useFunc = (model) => {
 
     const options = []
     try {
-      const resp = await axios.get(url)
-      const items = resp.data?.items
+      const resp = await axios.get(url, {
+        params: {
+          filter: { items: { metadata: { name: null }, data: null } },
+        },
+      })
+      const items = resp.data?.items || []
       items.forEach((ele) => {
-        options.push(ele.metadata?.name)
+        const keys = Object.keys(ele.data || {})
+        if (keys.length === 2 && keys.includes('username') && keys.includes('password'))
+          options.push(ele.metadata?.name)
       })
     } catch (e) {
       console.log(e)

--- a/charts/kubedbcom-zookeeper-editor-options/ui/functions.js
+++ b/charts/kubedbcom-zookeeper-editor-options/ui/functions.js
@@ -1232,10 +1232,16 @@ export const useFunc = (model) => {
 
     const options = []
     try {
-      const resp = await axios.get(url)
-      const items = resp.data?.items
+      const resp = await axios.get(url, {
+        params: {
+          filter: { items: { metadata: { name: null }, data: null } },
+        },
+      })
+      const items = resp.data?.items || []
       items.forEach((ele) => {
-        options.push(ele.metadata?.name)
+        const keys = Object.keys(ele.data || {})
+        if (keys.length === 2 && keys.includes('username') && keys.includes('password'))
+          options.push(ele.metadata?.name)
       })
     } catch (e) {
       console.log(e)


### PR DESCRIPTION
The "Refer existing Secret?" dropdown in all `kubedbcom-*-editor-options` charts listed every secret in the release namespace.

It now lists only secrets whose `data` contains exactly the two keys `username` and `password`. The list request also asks for just `metadata.name` and `data` via the `filter` param.

Applied to all 30 `kubedbcom-*-editor-options` charts (`getReferSecrets` in `ui/functions.js`).

Also hardens the loader: `resp.data?.items || []` and `Object.keys(ele.data || {})` — the previous `items.forEach` would throw on a response without `items`.