### PR TITLE
Drop service-account-token from secret dropdown type filter

### DIFF
--- a/charts/kubedbcom-cassandra-editor/ui/functions.js
+++ b/charts/kubedbcom-cassandra-editor/ui/functions.js
@@ -1208,7 +1208,7 @@ export const useFunc = (model) => {
 
     if (resource === 'secrets') {
       resources = resources.filter((item) => {
-        const validType = ['kubernetes.io/service-account-token', 'Opaque']
+        const validType = ['Opaque']
         return validType.includes(item.type)
       })
     }
@@ -1275,7 +1275,7 @@ export const useFunc = (model) => {
       const secrets = (resp && resp.data && resp.data.items) || []
 
       const filteredSecrets = secrets.filter((item) => {
-        const validType = ['kubernetes.io/service-account-token', 'Opaque']
+        const validType = ['Opaque']
         return validType.includes(item.type)
       })
 

--- a/charts/kubedbcom-clickhouse-editor/ui/functions.js
+++ b/charts/kubedbcom-clickhouse-editor/ui/functions.js
@@ -1242,7 +1242,7 @@ export const useFunc = (model) => {
 
     if (resource === 'secrets') {
       resources = resources.filter((item) => {
-        const validType = ['kubernetes.io/service-account-token', 'Opaque']
+        const validType = ['Opaque']
         return validType.includes(item.type)
       })
     }
@@ -1309,7 +1309,7 @@ export const useFunc = (model) => {
       const secrets = (resp && resp.data && resp.data.items) || []
 
       const filteredSecrets = secrets.filter((item) => {
-        const validType = ['kubernetes.io/service-account-token', 'Opaque']
+        const validType = ['Opaque']
         return validType.includes(item.type)
       })
 

--- a/charts/kubedbcom-documentdb-editor/ui/functions.js
+++ b/charts/kubedbcom-documentdb-editor/ui/functions.js
@@ -1224,7 +1224,7 @@ export const useFunc = (model) => {
 
     if (resource === 'secrets') {
       resources = resources.filter((item) => {
-        const validType = ['kubernetes.io/service-account-token', 'Opaque']
+        const validType = ['Opaque']
         return validType.includes(item.type)
       })
     }
@@ -1291,7 +1291,7 @@ export const useFunc = (model) => {
       const secrets = (resp && resp.data && resp.data.items) || []
 
       const filteredSecrets = secrets.filter((item) => {
-        const validType = ['kubernetes.io/service-account-token', 'Opaque']
+        const validType = ['Opaque']
         return validType.includes(item.type)
       })
 

--- a/charts/kubedbcom-druid-editor-options/ui/functions.js
+++ b/charts/kubedbcom-druid-editor-options/ui/functions.js
@@ -347,7 +347,7 @@ export const useFunc = (model) => {
     const secrets = (resp && resp.data && resp.data.items) || []
 
     const filteredSecrets = secrets.filter((item) => {
-      const validType = ['kubernetes.io/service-account-token', 'Opaque']
+      const validType = ['Opaque']
       return validType.includes(item.type)
     })
 

--- a/charts/kubedbcom-druid-editor/ui/functions.js
+++ b/charts/kubedbcom-druid-editor/ui/functions.js
@@ -172,7 +172,7 @@ export const useFunc = (model) => {
 
     if (resource === 'secrets') {
       resources = resources.filter((item) => {
-        const validType = ['kubernetes.io/service-account-token', 'Opaque']
+        const validType = ['Opaque']
         return validType.includes(item.type)
       })
     }
@@ -1413,7 +1413,7 @@ export const useFunc = (model) => {
       const secrets = (resp && resp.data && resp.data.items) || []
 
       const filteredSecrets = secrets.filter((item) => {
-        const validType = ['kubernetes.io/service-account-token', 'Opaque']
+        const validType = ['Opaque']
         return validType.includes(item.type)
       })
 

--- a/charts/kubedbcom-elasticsearch-editor/ui/functions.js
+++ b/charts/kubedbcom-elasticsearch-editor/ui/functions.js
@@ -1314,7 +1314,7 @@ export const useFunc = (model) => {
 
     if (resource === 'secrets') {
       resources = resources.filter((item) => {
-        const validType = ['kubernetes.io/service-account-token', 'Opaque']
+        const validType = ['Opaque']
         return validType.includes(item.type)
       })
     }
@@ -1376,7 +1376,7 @@ export const useFunc = (model) => {
       const secrets = (resp && resp.data && resp.data.items) || []
 
       const filteredSecrets = secrets.filter((item) => {
-        const validType = ['kubernetes.io/service-account-token', 'Opaque']
+        const validType = ['Opaque']
         return validType.includes(item.type)
       })
 

--- a/charts/kubedbcom-hanadb-editor/ui/functions.js
+++ b/charts/kubedbcom-hanadb-editor/ui/functions.js
@@ -425,7 +425,7 @@ export const useFunc = (model) => {
       let items = (resp && resp.data && resp.data.items) || []
       if (resource === 'secrets') {
         items = items.filter((item) => {
-          const validType = ['kubernetes.io/service-account-token', 'Opaque']
+          const validType = ['Opaque']
           return validType.includes(item.type)
         })
       }
@@ -471,7 +471,7 @@ export const useFunc = (model) => {
       )
       const items = (resp && resp.data && resp.data.items) || []
       return items
-        .filter((item) => ['kubernetes.io/service-account-token', 'Opaque'].includes(item.type))
+        .filter((item) => ['Opaque'].includes(item.type))
         .map((item) => {
           const name = (item.metadata && item.metadata.name) || ''
           return { text: name, value: name }

--- a/charts/kubedbcom-hazelcast-editor-options/ui/functions.js
+++ b/charts/kubedbcom-hazelcast-editor-options/ui/functions.js
@@ -360,11 +360,7 @@ export const useFunc = (model) => {
         const secrets = (resp && resp.data && resp.data.items) || []
 
         const filteredSecrets = secrets.filter((item) => {
-          const validType = [
-            'kubernetes.io/service-account-token',
-            'Opaque',
-            'kubernetes.io/basic-auth',
-          ]
+          const validType = ['Opaque', 'kubernetes.io/basic-auth']
           return validType.includes(item.type)
         })
 

--- a/charts/kubedbcom-hazelcast-editor/ui/functions.js
+++ b/charts/kubedbcom-hazelcast-editor/ui/functions.js
@@ -1200,7 +1200,7 @@ export const useFunc = (model) => {
 
     if (resource === 'secrets') {
       resources = resources.filter((item) => {
-        const validType = ['kubernetes.io/service-account-token', 'Opaque']
+        const validType = ['Opaque']
         return validType.includes(item.type)
       })
     }
@@ -1267,7 +1267,7 @@ export const useFunc = (model) => {
       const secrets = (resp && resp.data && resp.data.items) || []
 
       const filteredSecrets = secrets.filter((item) => {
-        const validType = ['kubernetes.io/service-account-token', 'Opaque']
+        const validType = ['Opaque']
         return validType.includes(item.type)
       })
 

--- a/charts/kubedbcom-ignite-editor/ui/functions.js
+++ b/charts/kubedbcom-ignite-editor/ui/functions.js
@@ -722,7 +722,7 @@ export const useFunc = (model) => {
 
     if (resource === 'secrets') {
       resources = resources.filter((item) => {
-        const validType = ['kubernetes.io/service-account-token', 'Opaque']
+        const validType = ['Opaque']
         return validType.includes(item.type)
       })
     }
@@ -789,7 +789,7 @@ export const useFunc = (model) => {
       const secrets = (resp && resp.data && resp.data.items) || []
 
       const filteredSecrets = secrets.filter((item) => {
-        const validType = ['kubernetes.io/service-account-token', 'Opaque']
+        const validType = ['Opaque']
         return validType.includes(item.type)
       })
 

--- a/charts/kubedbcom-kafka-editor/ui/functions.js
+++ b/charts/kubedbcom-kafka-editor/ui/functions.js
@@ -731,7 +731,7 @@ export const useFunc = (model) => {
 
     if (resource === 'secrets') {
       resources = resources.filter((item) => {
-        const validType = ['kubernetes.io/service-account-token', 'Opaque']
+        const validType = ['Opaque']
         return validType.includes(item.type)
       })
     }
@@ -798,7 +798,7 @@ export const useFunc = (model) => {
       const secrets = (resp && resp.data && resp.data.items) || []
 
       const filteredSecrets = secrets.filter((item) => {
-        const validType = ['kubernetes.io/service-account-token', 'Opaque']
+        const validType = ['Opaque']
         return validType.includes(item.type)
       })
 

--- a/charts/kubedbcom-mariadb-editor/ui/functions.js
+++ b/charts/kubedbcom-mariadb-editor/ui/functions.js
@@ -785,7 +785,7 @@ export const useFunc = (model) => {
       const secrets = (resp && resp.data && resp.data.items) || []
 
       const filteredSecrets = secrets.filter((item) => {
-        const validType = ['kubernetes.io/service-account-token', 'Opaque']
+        const validType = ['Opaque']
         return validType.includes(item.type)
       })
 
@@ -1300,7 +1300,7 @@ export const useFunc = (model) => {
 
     if (resource === 'secrets') {
       resources = resources.filter((item) => {
-        const validType = ['kubernetes.io/service-account-token', 'Opaque']
+        const validType = ['Opaque']
         return validType.includes(item.type)
       })
     }
@@ -1367,7 +1367,7 @@ export const useFunc = (model) => {
       const secrets = (resp && resp.data && resp.data.items) || []
 
       const filteredSecrets = secrets.filter((item) => {
-        const validType = ['kubernetes.io/service-account-token', 'Opaque']
+        const validType = ['Opaque']
         return validType.includes(item.type)
       })
 

--- a/charts/kubedbcom-memcached-editor/ui/functions.js
+++ b/charts/kubedbcom-memcached-editor/ui/functions.js
@@ -481,7 +481,7 @@ export const useFunc = (model) => {
 
     if (resource === 'secrets') {
       resources = resources.filter((item) => {
-        const validType = ['kubernetes.io/service-account-token', 'Opaque']
+        const validType = ['Opaque']
         return validType.includes(item.type)
       })
     }
@@ -617,11 +617,7 @@ export const useFunc = (model) => {
         const secrets = (resp && resp.data && resp.data.items) || []
 
         const filteredSecrets = secrets.filter((item) => {
-          const validType = [
-            'kubernetes.io/service-account-token',
-            'Opaque',
-            'kubernetes.io/basic-auth',
-          ]
+          const validType = ['Opaque', 'kubernetes.io/basic-auth']
           return validType.includes(item.type)
         })
 

--- a/charts/kubedbcom-milvus-editor-options/ui/functions.js
+++ b/charts/kubedbcom-milvus-editor-options/ui/functions.js
@@ -1071,7 +1071,7 @@ export const useFunc = (model) => {
       const secrets = (resp && resp.data && resp.data.items) || []
 
       const filteredSecrets = secrets.filter((item) => {
-        const validType = ['kubernetes.io/service-account-token', 'Opaque']
+        const validType = ['Opaque']
         return validType.includes(item.type) && Object.keys(item.data || {}).includes('config.env')
       })
 

--- a/charts/kubedbcom-milvus-editor/ui/functions.js
+++ b/charts/kubedbcom-milvus-editor/ui/functions.js
@@ -102,7 +102,7 @@ export const useFunc = (model) => {
       )
       const items = (resp && resp.data && resp.data.items) || []
       return items
-        .filter((item) => ['kubernetes.io/service-account-token', 'Opaque'].includes(item.type))
+        .filter((item) => ['Opaque'].includes(item.type))
         .map((item) => {
           const name = (item.metadata && item.metadata.name) || ''
           return { text: name, value: name }

--- a/charts/kubedbcom-mongodb-editor/ui/functions.js
+++ b/charts/kubedbcom-mongodb-editor/ui/functions.js
@@ -278,7 +278,7 @@ export const useFunc = (model) => {
 
     if (resource === 'secrets') {
       resources = resources.filter((item) => {
-        const validType = ['kubernetes.io/service-account-token', 'Opaque']
+        const validType = ['Opaque']
         return validType.includes(item.type)
       })
     }
@@ -301,7 +301,7 @@ export const useFunc = (model) => {
 
     if (resource === 'secrets') {
       resources = resources.filter((item) => {
-        const validType = ['kubernetes.io/service-account-token', 'Opaque']
+        const validType = ['Opaque']
         return validType.includes(item.type)
       })
     }
@@ -2040,7 +2040,7 @@ export const useFunc = (model) => {
       const secrets = (resp && resp.data && resp.data.items) || []
 
       const filteredSecrets = secrets.filter((item) => {
-        const validType = ['kubernetes.io/service-account-token', 'Opaque']
+        const validType = ['Opaque']
         return validType.includes(item.type)
       })
 

--- a/charts/kubedbcom-mssqlserver-editor/ui/functions.js
+++ b/charts/kubedbcom-mssqlserver-editor/ui/functions.js
@@ -1311,7 +1311,7 @@ export const useFunc = (model) => {
 
     if (resource === 'secrets') {
       resources = resources.filter((item) => {
-        const validType = ['kubernetes.io/service-account-token', 'Opaque']
+        const validType = ['Opaque']
         return validType.includes(item.type)
       })
     }
@@ -1378,7 +1378,7 @@ export const useFunc = (model) => {
       const secrets = (resp && resp.data && resp.data.items) || []
 
       const filteredSecrets = secrets.filter((item) => {
-        const validType = ['kubernetes.io/service-account-token', 'Opaque']
+        const validType = ['Opaque']
         return validType.includes(item.type)
       })
 

--- a/charts/kubedbcom-mysql-editor/ui/functions.js
+++ b/charts/kubedbcom-mysql-editor/ui/functions.js
@@ -1208,7 +1208,7 @@ export const useFunc = (model) => {
 
     if (resource === 'secrets') {
       resources = resources.filter((item) => {
-        const validType = ['kubernetes.io/service-account-token', 'Opaque']
+        const validType = ['Opaque']
         return validType.includes(item.type)
       })
     }
@@ -1275,7 +1275,7 @@ export const useFunc = (model) => {
       const secrets = (resp && resp.data && resp.data.items) || []
 
       const filteredSecrets = secrets.filter((item) => {
-        const validType = ['kubernetes.io/service-account-token', 'Opaque']
+        const validType = ['Opaque']
         return validType.includes(item.type)
       })
 

--- a/charts/kubedbcom-neo4j-editor/ui/functions.js
+++ b/charts/kubedbcom-neo4j-editor/ui/functions.js
@@ -1208,7 +1208,7 @@ export const useFunc = (model) => {
 
     if (resource === 'secrets') {
       resources = resources.filter((item) => {
-        const validType = ['kubernetes.io/service-account-token', 'Opaque']
+        const validType = ['Opaque']
         return validType.includes(item.type)
       })
     }
@@ -1275,7 +1275,7 @@ export const useFunc = (model) => {
       const secrets = (resp && resp.data && resp.data.items) || []
 
       const filteredSecrets = secrets.filter((item) => {
-        const validType = ['kubernetes.io/service-account-token', 'Opaque']
+        const validType = ['Opaque']
         return validType.includes(item.type)
       })
 

--- a/charts/kubedbcom-oracle-editor/ui/functions.js
+++ b/charts/kubedbcom-oracle-editor/ui/functions.js
@@ -734,7 +734,7 @@ export const useFunc = (model) => {
 
     if (resource === 'secrets') {
       resources = resources.filter((item) => {
-        const validType = ['kubernetes.io/service-account-token', 'Opaque']
+        const validType = ['Opaque']
         return validType.includes(item.type)
       })
     }
@@ -801,7 +801,7 @@ export const useFunc = (model) => {
       const secrets = (resp && resp.data && resp.data.items) || []
 
       const filteredSecrets = secrets.filter((item) => {
-        const validType = ['kubernetes.io/service-account-token', 'Opaque']
+        const validType = ['Opaque']
         return validType.includes(item.type)
       })
 

--- a/charts/kubedbcom-perconaxtradb-editor/ui/functions.js
+++ b/charts/kubedbcom-perconaxtradb-editor/ui/functions.js
@@ -741,7 +741,7 @@ export const useFunc = (model) => {
 
     if (resource === 'secrets') {
       resources = resources.filter((item) => {
-        const validType = ['kubernetes.io/service-account-token', 'Opaque']
+        const validType = ['Opaque']
         return validType.includes(item.type)
       })
     }
@@ -808,7 +808,7 @@ export const useFunc = (model) => {
       const secrets = (resp && resp.data && resp.data.items) || []
 
       const filteredSecrets = secrets.filter((item) => {
-        const validType = ['kubernetes.io/service-account-token', 'Opaque']
+        const validType = ['Opaque']
         return validType.includes(item.type)
       })
 

--- a/charts/kubedbcom-pgbouncer-editor/ui/functions.js
+++ b/charts/kubedbcom-pgbouncer-editor/ui/functions.js
@@ -645,7 +645,7 @@ export const useFunc = (model) => {
 
     if (resource === 'secrets') {
       resources = resources.filter((item) => {
-        const validType = ['kubernetes.io/service-account-token', 'Opaque']
+        const validType = ['Opaque']
         return validType.includes(item.type)
       })
     }
@@ -739,7 +739,7 @@ export const useFunc = (model) => {
       const secrets = (resp && resp.data && resp.data.items) || []
 
       const filteredSecrets = secrets.filter((item) => {
-        const validType = ['kubernetes.io/service-account-token', 'Opaque']
+        const validType = ['Opaque']
         return validType.includes(item.type)
       })
 

--- a/charts/kubedbcom-pgpool-editor/ui/functions.js
+++ b/charts/kubedbcom-pgpool-editor/ui/functions.js
@@ -691,7 +691,7 @@ export const useFunc = (model) => {
 
     if (resource === 'secrets') {
       resources = resources.filter((item) => {
-        const validType = ['kubernetes.io/service-account-token', 'Opaque']
+        const validType = ['Opaque']
         return validType.includes(item.type)
       })
     }
@@ -758,7 +758,7 @@ export const useFunc = (model) => {
       const secrets = (resp && resp.data && resp.data.items) || []
 
       const filteredSecrets = secrets.filter((item) => {
-        const validType = ['kubernetes.io/service-account-token', 'Opaque']
+        const validType = ['Opaque']
         return validType.includes(item.type)
       })
 

--- a/charts/kubedbcom-postgres-editor/ui/functions.js
+++ b/charts/kubedbcom-postgres-editor/ui/functions.js
@@ -1217,7 +1217,7 @@ export const useFunc = (model) => {
       const secrets = (resp && resp.data && resp.data.items) || []
 
       const filteredSecrets = secrets.filter((item) => {
-        const validType = ['kubernetes.io/service-account-token', 'Opaque']
+        const validType = ['Opaque']
         return validType.includes(item.type)
       })
 
@@ -1346,7 +1346,7 @@ export const useFunc = (model) => {
 
     if (resource === 'secrets') {
       resources = resources.filter((item) => {
-        const validType = ['kubernetes.io/service-account-token', 'Opaque']
+        const validType = ['Opaque']
         return validType.includes(item.type)
       })
     }

--- a/charts/kubedbcom-proxysql-editor/ui/functions.js
+++ b/charts/kubedbcom-proxysql-editor/ui/functions.js
@@ -665,7 +665,7 @@ export const useFunc = (model) => {
 
     if (resource === 'secrets') {
       resources = resources.filter((item) => {
-        const validType = ['kubernetes.io/service-account-token', 'Opaque']
+        const validType = ['Opaque']
         return validType.includes(item.type)
       })
     }
@@ -732,7 +732,7 @@ export const useFunc = (model) => {
       const secrets = (resp && resp.data && resp.data.items) || []
 
       const filteredSecrets = secrets.filter((item) => {
-        const validType = ['kubernetes.io/service-account-token', 'Opaque']
+        const validType = ['Opaque']
         return validType.includes(item.type)
       })
 

--- a/charts/kubedbcom-qdrant-editor/ui/functions.js
+++ b/charts/kubedbcom-qdrant-editor/ui/functions.js
@@ -626,7 +626,7 @@ export const useFunc = (model) => {
 
     if (resource === 'secrets') {
       resources = resources.filter((item) => {
-        const validType = ['kubernetes.io/service-account-token', 'Opaque']
+        const validType = ['Opaque']
         return validType.includes(item.type)
       })
     }
@@ -693,7 +693,7 @@ export const useFunc = (model) => {
       const secrets = (resp && resp.data && resp.data.items) || []
 
       const filteredSecrets = secrets.filter((item) => {
-        const validType = ['kubernetes.io/service-account-token', 'Opaque']
+        const validType = ['Opaque']
         return validType.includes(item.type)
       })
 

--- a/charts/kubedbcom-rabbitmq-editor/ui/functions.js
+++ b/charts/kubedbcom-rabbitmq-editor/ui/functions.js
@@ -311,7 +311,7 @@ export const useFunc = (model) => {
 
     if (resource === 'secrets') {
       resources = resources.filter((item) => {
-        const validType = ['kubernetes.io/service-account-token', 'Opaque']
+        const validType = ['Opaque']
         return validType.includes(item.type)
       })
     }
@@ -378,7 +378,7 @@ export const useFunc = (model) => {
       const secrets = (resp && resp.data && resp.data.items) || []
 
       const filteredSecrets = secrets.filter((item) => {
-        const validType = ['kubernetes.io/service-account-token', 'Opaque']
+        const validType = ['Opaque']
         return validType.includes(item.type)
       })
 

--- a/charts/kubedbcom-redis-editor/ui/functions.js
+++ b/charts/kubedbcom-redis-editor/ui/functions.js
@@ -1355,7 +1355,7 @@ export const useFunc = (model) => {
 
     if (resource === 'secrets') {
       resources = resources.filter((item) => {
-        const validType = ['kubernetes.io/service-account-token', 'Opaque']
+        const validType = ['Opaque']
         return validType.includes(item.type)
       })
     }
@@ -1422,7 +1422,7 @@ export const useFunc = (model) => {
       const secrets = (resp && resp.data && resp.data.items) || []
 
       const filteredSecrets = secrets.filter((item) => {
-        const validType = ['kubernetes.io/service-account-token', 'Opaque']
+        const validType = ['Opaque']
         return validType.includes(item.type)
       })
 

--- a/charts/kubedbcom-singlestore-editor-options/ui/functions.js
+++ b/charts/kubedbcom-singlestore-editor-options/ui/functions.js
@@ -502,11 +502,7 @@ export const useFunc = (model) => {
         const secrets = (resp && resp.data && resp.data.items) || []
 
         const filteredSecrets = secrets.filter((item) => {
-          const validType = [
-            'kubernetes.io/service-account-token',
-            'Opaque',
-            'kubernetes.io/basic-auth',
-          ]
+          const validType = ['Opaque', 'kubernetes.io/basic-auth']
           return validType.includes(item.type)
         })
 

--- a/charts/kubedbcom-singlestore-editor/ui/functions.js
+++ b/charts/kubedbcom-singlestore-editor/ui/functions.js
@@ -1315,7 +1315,7 @@ export const useFunc = (model) => {
 
     if (resource === 'secrets') {
       resources = resources.filter((item) => {
-        const validType = ['kubernetes.io/service-account-token', 'Opaque']
+        const validType = ['Opaque']
         return validType.includes(item.type)
       })
     }
@@ -1382,7 +1382,7 @@ export const useFunc = (model) => {
       const secrets = (resp && resp.data && resp.data.items) || []
 
       const filteredSecrets = secrets.filter((item) => {
-        const validType = ['kubernetes.io/service-account-token', 'Opaque']
+        const validType = ['Opaque']
         return validType.includes(item.type)
       })
 

--- a/charts/kubedbcom-solr-editor/ui/functions.js
+++ b/charts/kubedbcom-solr-editor/ui/functions.js
@@ -1240,7 +1240,7 @@ export const useFunc = (model) => {
 
     if (resource === 'secrets') {
       resources = resources.filter((item) => {
-        const validType = ['kubernetes.io/service-account-token', 'Opaque']
+        const validType = ['Opaque']
         return validType.includes(item.type)
       })
     }
@@ -1307,7 +1307,7 @@ export const useFunc = (model) => {
       const secrets = (resp && resp.data && resp.data.items) || []
 
       const filteredSecrets = secrets.filter((item) => {
-        const validType = ['kubernetes.io/service-account-token', 'Opaque']
+        const validType = ['Opaque']
         return validType.includes(item.type)
       })
 

--- a/charts/kubedbcom-weaviate-editor/ui/functions.js
+++ b/charts/kubedbcom-weaviate-editor/ui/functions.js
@@ -446,7 +446,7 @@ export const useFunc = (model) => {
 
     if (resource === 'secrets') {
       resources = resources.filter((item) => {
-        const validType = ['kubernetes.io/service-account-token', 'Opaque']
+        const validType = ['Opaque']
         return validType.includes(item.type)
       })
     }
@@ -479,7 +479,7 @@ export const useFunc = (model) => {
       const secrets = (resp && resp.data && resp.data.items) || []
 
       const filteredSecrets = secrets.filter((item) => {
-        const validType = ['kubernetes.io/service-account-token', 'Opaque']
+        const validType = ['Opaque']
         return validType.includes(item.type)
       })
 

--- a/charts/kubedbcom-zookeeper-editor/ui/functions.js
+++ b/charts/kubedbcom-zookeeper-editor/ui/functions.js
@@ -720,7 +720,7 @@ export const useFunc = (model) => {
 
     if (resource === 'secrets') {
       resources = resources.filter((item) => {
-        const validType = ['kubernetes.io/service-account-token', 'Opaque']
+        const validType = ['Opaque']
         return validType.includes(item.type)
       })
     }
@@ -814,7 +814,7 @@ export const useFunc = (model) => {
       const secrets = (resp && resp.data && resp.data.items) || []
 
       const filteredSecrets = secrets.filter((item) => {
-        const validType = ['kubernetes.io/service-account-token', 'Opaque']
+        const validType = ['Opaque']
         return validType.includes(item.type)
       })
 


### PR DESCRIPTION
Secret dropdowns in the db editor charts filtered the namespace's secrets with:

```js
const validType = ['kubernetes.io/service-account-token', 'Opaque']
```

A `kubernetes.io/service-account-token` secret is minted by Kubernetes and holds only `ca.crt`, `namespace` and `token` ([docs](https://kubernetes.io/docs/concepts/configuration/secret/#service-account-token-secrets)), so it can never be a valid init-script volume, config source, or auth secret — offering it only invites a database that fails to start.

Removed that entry from all 63 live filters across 33 `charts/kubedbcom-*-editor{,-options}/ui/functions.js` (`resourceNames`, `getSecrets`, auth-secret filters). Three charts (memcached, hazelcast-editor-options, singlestore-editor-options) keep `kubernetes.io/basic-auth` alongside `Opaque`.

Not in scope: 3 kubevault charts and 5 `uibytebuildersdev-component-*` charts still carry the entry; their code paths haven't been checked for liveness yet.