### PR TITLE
Clear spec.tls when TLS operation changes in ops request editors

### DIFF
--- a/charts/opskubedbcom-kafkaopsrequest-editor/ui/create-ui.yaml
+++ b/charts/opskubedbcom-kafkaopsrequest-editor/ui/create-ui.yaml
@@ -689,6 +689,10 @@ step:
         value: remove
       schema: temp/properties/tlsOperation
       type: radio
+      watcher:
+        func: onTlsOperationChange
+        paths:
+        - temp/properties/tlsOperation
     - fullwidth: true
       if:
         name: isTlsEnabled

--- a/charts/opskubedbcom-kafkaopsrequest-editor/ui/functions.js
+++ b/charts/opskubedbcom-kafkaopsrequest-editor/ui/functions.js
@@ -1277,6 +1277,26 @@ export const useFunc = (model) => {
   function initTlsOperation() {
     return 'update'
   }
+  function onTlsOperationChange() {
+    const tlsOperation = getValue(discriminator, '/tlsOperation')
+
+    commit('wizard/model$delete', '/spec/tls')
+
+    if (tlsOperation === 'rotate') {
+      commit('wizard/model$update', {
+        path: '/spec/tls/rotateCertificates',
+        value: true,
+        force: true,
+      })
+    } else if (tlsOperation === 'remove') {
+      commit('wizard/model$update', {
+        path: '/spec/tls/remove',
+        value: true,
+        force: true,
+      })
+    }
+  }
+
   function showIssuerRefAndCertificates() {
     const tlsOperation = getValue(discriminator, '/tlsOperation')
     // watchDependency('discriminator#/tlsOperation')
@@ -1476,6 +1496,7 @@ export const useFunc = (model) => {
     initIssuerRefApiGroup,
     getIssuerRefsName,
     initTlsOperation,
+    onTlsOperationChange,
     showIssuerRefAndCertificates,
     isIssuerRefRequired,
     getRequestTypeFromRoute,

--- a/charts/opskubedbcom-mariadbopsrequest-editor/ui/create-ui.yaml
+++ b/charts/opskubedbcom-mariadbopsrequest-editor/ui/create-ui.yaml
@@ -487,6 +487,10 @@ step:
         value: remove
       schema: temp/properties/tlsOperation
       type: radio
+      watcher:
+        func: onTlsOperationChange
+        paths:
+        - temp/properties/tlsOperation
     - fullwidth: true
       if:
         name: isTlsEnabled

--- a/charts/opskubedbcom-mariadbopsrequest-editor/ui/functions.js
+++ b/charts/opskubedbcom-mariadbopsrequest-editor/ui/functions.js
@@ -1217,6 +1217,26 @@ export const useFunc = (model) => {
   function initTlsOperation() {
     return 'update'
   }
+  function onTlsOperationChange() {
+    const tlsOperation = getValue(discriminator, '/tlsOperation')
+
+    commit('wizard/model$delete', '/spec/tls')
+
+    if (tlsOperation === 'rotate') {
+      commit('wizard/model$update', {
+        path: '/spec/tls/rotateCertificates',
+        value: true,
+        force: true,
+      })
+    } else if (tlsOperation === 'remove') {
+      commit('wizard/model$update', {
+        path: '/spec/tls/remove',
+        value: true,
+        force: true,
+      })
+    }
+  }
+
   function showIssuerRefAndCertificates() {
     const tlsOperation = getValue(discriminator, '/tlsOperation')
     // watchDependency('discriminator#/tlsOperation')
@@ -1441,6 +1461,7 @@ export const useFunc = (model) => {
     initIssuerRefApiGroup,
     getIssuerRefsName,
     initTlsOperation,
+    onTlsOperationChange,
     showIssuerRefAndCertificates,
     isIssuerRefRequired,
     getRequestTypeFromRoute,

--- a/charts/opskubedbcom-postgresopsrequest-editor/ui/create-ui.yaml
+++ b/charts/opskubedbcom-postgresopsrequest-editor/ui/create-ui.yaml
@@ -507,6 +507,10 @@ step:
         value: remove
       schema: temp/properties/tlsOperation
       type: radio
+      watcher:
+        func: onTlsOperationChange
+        paths:
+        - temp/properties/tlsOperation
     - fullwidth: true
       if:
         name: isTlsEnabled

--- a/charts/opskubedbcom-postgresopsrequest-editor/ui/functions.js
+++ b/charts/opskubedbcom-postgresopsrequest-editor/ui/functions.js
@@ -1229,6 +1229,26 @@ export const useFunc = (model) => {
   function initTlsOperation() {
     return 'update'
   }
+  function onTlsOperationChange() {
+    const tlsOperation = getValue(discriminator, '/tlsOperation')
+
+    commit('wizard/model$delete', '/spec/tls')
+
+    if (tlsOperation === 'rotate') {
+      commit('wizard/model$update', {
+        path: '/spec/tls/rotateCertificates',
+        value: true,
+        force: true,
+      })
+    } else if (tlsOperation === 'remove') {
+      commit('wizard/model$update', {
+        path: '/spec/tls/remove',
+        value: true,
+        force: true,
+      })
+    }
+  }
+
   function showIssuerRefAndCertificates() {
     const tlsOperation = getValue(discriminator, '/tlsOperation')
     // watchDependency('discriminator#/tlsOperation')
@@ -1497,6 +1517,7 @@ export const useFunc = (model) => {
     initIssuerRefApiGroup,
     getIssuerRefsName,
     initTlsOperation,
+    onTlsOperationChange,
     showIssuerRefAndCertificates,
     isIssuerRefRequired,
     getClientAuthModes,

--- a/charts/opskubedbcom-proxysqlopsrequest-editor/ui/create-ui.yaml
+++ b/charts/opskubedbcom-proxysqlopsrequest-editor/ui/create-ui.yaml
@@ -370,6 +370,10 @@ step:
         value: remove
       schema: temp/properties/tlsOperation
       type: radio
+      watcher:
+        func: onTlsOperationChange
+        paths:
+        - temp/properties/tlsOperation
     - fullwidth: true
       if:
         name: isTlsEnabled

--- a/charts/opskubedbcom-proxysqlopsrequest-editor/ui/functions.js
+++ b/charts/opskubedbcom-proxysqlopsrequest-editor/ui/functions.js
@@ -926,6 +926,26 @@ export const useFunc = (model) => {
   function initTlsOperation() {
     return 'update'
   }
+  function onTlsOperationChange() {
+    const tlsOperation = getValue(discriminator, '/tlsOperation')
+
+    commit('wizard/model$delete', '/spec/tls')
+
+    if (tlsOperation === 'rotate') {
+      commit('wizard/model$update', {
+        path: '/spec/tls/rotateCertificates',
+        value: true,
+        force: true,
+      })
+    } else if (tlsOperation === 'remove') {
+      commit('wizard/model$update', {
+        path: '/spec/tls/remove',
+        value: true,
+        force: true,
+      })
+    }
+  }
+
   function showIssuerRefAndCertificates() {
     const tlsOperation = getValue(discriminator, '/tlsOperation')
     // watchDependency('discriminator#/tlsOperation')
@@ -1092,6 +1112,7 @@ export const useFunc = (model) => {
     initIssuerRefApiGroup,
     getIssuerRefsName,
     initTlsOperation,
+    onTlsOperationChange,
     showIssuerRefAndCertificates,
     isIssuerRefRequired,
     getRequestTypeFromRoute,

--- a/charts/opskubedbcom-rabbitmqopsrequest-editor/ui/create-ui.yaml
+++ b/charts/opskubedbcom-rabbitmqopsrequest-editor/ui/create-ui.yaml
@@ -476,6 +476,10 @@ step:
         value: remove
       schema: temp/properties/tlsOperation
       type: radio
+      watcher:
+        func: onTlsOperationChange
+        paths:
+        - temp/properties/tlsOperation
     - fullwidth: true
       if:
         name: isTlsEnabled

--- a/charts/opskubedbcom-rabbitmqopsrequest-editor/ui/functions.js
+++ b/charts/opskubedbcom-rabbitmqopsrequest-editor/ui/functions.js
@@ -1217,6 +1217,26 @@ export const useFunc = (model) => {
     return 'update'
   }
 
+  function onTlsOperationChange() {
+    const tlsOperation = getValue(discriminator, '/tlsOperation')
+
+    commit('wizard/model$delete', '/spec/tls')
+
+    if (tlsOperation === 'rotate') {
+      commit('wizard/model$update', {
+        path: '/spec/tls/rotateCertificates',
+        value: true,
+        force: true,
+      })
+    } else if (tlsOperation === 'remove') {
+      commit('wizard/model$update', {
+        path: '/spec/tls/remove',
+        value: true,
+        force: true,
+      })
+    }
+  }
+
   function showIssuerRefAndCertificates() {
     const tlsOperation = getValue(discriminator, '/tlsOperation')
     // watchDependency('discriminator#/tlsOperation')
@@ -1429,6 +1449,7 @@ export const useFunc = (model) => {
     initIssuerRefApiGroup,
     getIssuerRefsName,
     initTlsOperation,
+    onTlsOperationChange,
     showIssuerRefAndCertificates,
     isIssuerRefRequired,
     getRequestTypeFromRoute,

--- a/charts/opskubedbcom-redisopsrequest-editor/ui/create-ui.yaml
+++ b/charts/opskubedbcom-redisopsrequest-editor/ui/create-ui.yaml
@@ -509,6 +509,10 @@ step:
         value: remove
       schema: temp/properties/tlsOperation
       type: radio
+      watcher:
+        func: onTlsOperationChange
+        paths:
+        - temp/properties/tlsOperation
     - fullwidth: true
       if:
         name: isTlsEnabled

--- a/charts/opskubedbcom-redisopsrequest-editor/ui/functions.js
+++ b/charts/opskubedbcom-redisopsrequest-editor/ui/functions.js
@@ -1210,6 +1210,26 @@ export const useFunc = (model) => {
   function initTlsOperation() {
     return 'update'
   }
+  function onTlsOperationChange() {
+    const tlsOperation = getValue(discriminator, '/tlsOperation')
+
+    commit('wizard/model$delete', '/spec/tls')
+
+    if (tlsOperation === 'rotate') {
+      commit('wizard/model$update', {
+        path: '/spec/tls/rotateCertificates',
+        value: true,
+        force: true,
+      })
+    } else if (tlsOperation === 'remove') {
+      commit('wizard/model$update', {
+        path: '/spec/tls/remove',
+        value: true,
+        force: true,
+      })
+    }
+  }
+
   function showIssuerRefAndCertificates() {
     const tlsOperation = getValue(discriminator, '/tlsOperation')
     // watchDependency('discriminator#/tlsOperation')
@@ -1445,6 +1465,7 @@ export const useFunc = (model) => {
     initIssuerRefApiGroup,
     getIssuerRefsName,
     initTlsOperation,
+    onTlsOperationChange,
     showIssuerRefAndCertificates,
     isIssuerRefRequired,
     getRequestTypeFromRoute,


### PR DESCRIPTION
Selecting **Rotate** (or **Remove**) under Reconfigure TLS produced an invalid ops request:

```yaml
spec:
  type: ReconfigureTLS
  tls:
    issuerRef: {}          # <- fails validation
    rotateCertificates: true
```

```
/spec/tls/issuerRef must have required property 'kind'
/spec/tls/issuerRef must have required property 'name'
```

The TLS Operation radio only *hides* the issuerRef fields for `rotate`/`remove` (`showIssuerRefAndCertificates`), so the empty `issuerRef` object the form materialized while in `update` mode stayed in the model.

Fix: wire an `onTlsOperationChange` watcher on the radio that deletes `/spec/tls` and then sets only `rotateCertificates: true` or `remove: true`. This is the same pattern already present in the mongodb, mysql, elasticsearch, and 16 other ops editors — these 6 were the ones missing it.

Charts touched: rabbitmq, kafka, mariadb, postgres, proxysql, redis (opsrequest editors).

Note: `make fmt` could not be run locally (docker daemon down); the added code is copied verbatim from the existing mongodb editor, so formatting matches.