### PR TITLE
Add ReconfigureTLS form to weaviate ops request editor

### DIFF
--- a/charts/opskubedbcom-weaviateopsrequest-editor/ui/create-ui.yaml
+++ b/charts/opskubedbcom-weaviateopsrequest-editor/ui/create-ui.yaml
@@ -427,6 +427,167 @@ step:
       - schema/properties/metadata/properties/namespace
     type: block-layout
   - elements:
+    - if:
+        name: hasTlsField
+        type: function
+      init:
+        type: func
+        value: initTlsOperation
+      label: TLS Operation
+      options:
+      - text: Update
+        value: update
+        description: 'Modify the TLS configuration, such as issuer or certificate details'
+      - text: Rotate
+        value: rotate
+        description: 'Generate new certificates and rotate existing TLS credentials'
+      - text: Remove
+        value: remove
+        description: 'Disable TLS and remove existing certificates from the database'
+      isHorizontal: true
+      schema: temp/properties/tlsOperation
+      type: radio
+      watcher:
+        func: onTlsOperationChange
+        paths:
+        - temp/properties/tlsOperation
+    - fullwidth: true
+      if:
+        name: isTlsEnabled|remove
+        type: function
+      label: Remove TLS
+      schema: schema/properties/spec/properties/tls/properties/remove
+      type: switch
+    - fullwidth: true
+      if:
+        name: isTlsEnabled|rotate
+        type: function
+      label: Rotate Certificates
+      schema: schema/properties/spec/properties/tls/properties/rotateCertificates
+      type: switch
+    - elements:
+      - disable: true
+        init:
+          type: func
+          value: initIssuerRefApiGroup
+        label: API Group
+        schema: schema/properties/spec/properties/tls/properties/issuerRef/properties/apiGroup
+        type: input
+        watcher:
+          func: initIssuerRefApiGroup
+          paths:
+          - schema/properties/spec/properties/tls/properties/issuerRef/properties/kind
+      - init:
+          type: func
+          value: setValueFromDbDetails|/spec/tls/issuerRef/kind
+        label: Kind
+        options:
+        - text: Issuer
+          value: Issuer
+        - text: ClusterIssuer
+          value: ClusterIssuer
+        schema: schema/properties/spec/properties/tls/properties/issuerRef/properties/kind
+        type: select
+        validation:
+          name: isIssuerRefRequired
+          type: custom
+      - init:
+          type: func
+          value: setValueFromDbDetails|/spec/tls/issuerRef/name
+        label: Name
+        loader:
+          name: getIssuerRefsName
+          watchPaths:
+          - schema/properties/spec/properties/tls/properties/issuerRef/properties/kind
+          - schema/properties/metadata/properties/namespace
+        schema: schema/properties/spec/properties/tls/properties/issuerRef/properties/name
+        type: select
+        validation:
+          name: isIssuerRefRequired
+          type: custom
+      if:
+        name: showIssuerRefAndCertificates
+        type: function
+      label: Issuer Reference
+      showLabels: true
+      type: block-layout
+    - elements:
+      - buttonClass: is-light is-outlined
+        elements:
+        - disable: disableAlias
+          label: Alias
+          loader: fetchAliasOptions
+          schema: alias
+          type: select
+          validation:
+            type: required
+        - label: Secret Name
+          schema: secretName
+          type: input
+        - label: Duration
+          schema: duration
+          type: input
+        - label: Renew Before
+          schema: renewBefore
+          type: input
+        - buttonClass: is-light is-outlined
+          element:
+            label: Organization
+            type: input
+          label: Organizations
+          schema: subject/properties/organizations
+          type: array-item-form
+        - buttonClass: is-light is-outlined
+          element:
+            label: Country
+            type: input
+          label: Countries
+          schema: subject/properties/countries
+          type: array-item-form
+        - buttonClass: is-light is-outlined
+          element:
+            label: Organizational Unit
+            type: input
+          label: Organizational Units
+          schema: subject/properties/organizationalUnits
+          type: array-item-form
+        - buttonClass: is-light is-outlined
+          element:
+            label: Province
+            type: input
+          label: Provinces
+          schema: subject/properties/provinces
+          type: array-item-form
+        - buttonClass: is-light  is-outlined
+          element:
+            label: DNS Name
+            type: input
+          label: DNS Names
+          schema: dnsNames
+          type: array-item-form
+        - buttonClass: is-light is-outlined
+          element:
+            label: IP Address
+            type: input
+          label: IP Addresses
+          schema: ipAddresses
+          type: array-item-form
+        label: Certificates
+        schema: schema/properties/spec/properties/tls/properties/certificates
+        type: array-object-form
+      if:
+        name: showIssuerRefAndCertificates
+        type: function
+      label: Certificates
+      loader: setValueFromDbDetails|/spec/tls/certificates|/spec/tls/certificates
+      showLabels: false
+      type: block-layout
+    if:
+      name: ifRequestTypeEqualsTo|ReconfigureTLS
+      type: function
+    label: TLS
+    type: block-layout
+  - elements:
     - label: Timeout
       schema: schema/properties/spec/properties/timeout
       subtitle: Specify the maximum time allowed for the operation to complete before

--- a/charts/opskubedbcom-weaviateopsrequest-editor/ui/functions.js
+++ b/charts/opskubedbcom-weaviateopsrequest-editor/ui/functions.js
@@ -414,6 +414,138 @@ export const useFunc = (model) => {
     })
   }
 
+  function getDbTls() {
+    // watchDependency'discriminator#/dbDetails')
+    const dbDetails = getValue(discriminator, '/dbDetails')
+
+    const { spec } = dbDetails || {}
+    return spec?.tls || undefined
+  }
+
+  // for tls
+  function hasTlsField() {
+    const tls = getDbTls()
+
+    return !!tls
+  }
+
+  function initIssuerRefApiGroup() {
+    const kind = getValue(model, '/spec/tls/issuerRef/kind')
+    // watchDependency('model#/spec/tls/issuerRef/kind')
+
+    if (kind) {
+      return 'cert-manager.io'
+    } else return undefined
+  }
+
+  async function getIssuerRefsName() {
+    const owner = storeGet('/route/params/user')
+    const cluster = storeGet('/route/params/cluster')
+    // watchDependency('model#/spec/tls/issuerRef/kind')
+    // watchDependency('model#/metadata/namespace')
+    const kind = getValue(model, '/spec/tls/issuerRef/kind')
+    const namespace = getValue(model, '/metadata/namespace')
+
+    if (kind === 'Issuer') {
+      const url = `/clusters/${owner}/${cluster}/proxy/cert-manager.io/v1/namespaces/${namespace}/issuers`
+      return getIssuer(url)
+    } else if (kind === 'ClusterIssuer') {
+      const url = `/clusters/${owner}/${cluster}/proxy/charts.x-helm.dev/v1alpha1/clusterchartpresets/kubedb-ui-presets`
+
+      let presets = storeGet('/kubedbuiPresets') || {}
+      if (!storeGet('/route/params/actions')) {
+        try {
+          const presetResp = await axios.get(url)
+          presets = presetResp.data?.spec?.values?.spec
+        } catch (e) {
+          console.log(e)
+          presets.status = String(e.status)
+        }
+      }
+      let clusterIssuers = presets.admin?.clusterIssuers?.available || []
+      if (presets.status === '404') {
+        const url = `/clusters/${owner}/${cluster}/proxy/cert-manager.io/v1/clusterissuers`
+        return getIssuer(url)
+      }
+      return clusterIssuers
+    } else if (!kind) {
+      commit('wizard/model$delete', '/spec/tls/issuerRef/name')
+      return []
+    }
+
+    async function getIssuer(url) {
+      try {
+        const resp = await axios.get(url)
+        const resources = (resp && resp.data && resp.data.items) || []
+
+        resources.map((item) => {
+          const name = (item.metadata && item.metadata.name) || ''
+          item.text = name
+          item.value = name
+          return true
+        })
+        return resources
+      } catch (e) {
+        console.log(e)
+        return []
+      }
+    }
+  }
+
+  function initTlsOperation() {
+    return 'update'
+  }
+
+  function isTlsEnabled(type) {
+    const selectedOpsType = getValue(discriminator, '/tlsOperation')
+    return selectedOpsType === type
+  }
+
+  function onTlsOperationChange() {
+    const tlsOperation = getValue(discriminator, '/tlsOperation')
+
+    commit('wizard/model$delete', '/spec/tls')
+
+    if (tlsOperation === 'rotate') {
+      commit('wizard/model$update', {
+        path: '/spec/tls/rotateCertificates',
+        value: true,
+        force: true,
+      })
+    } else if (tlsOperation === 'remove') {
+      commit('wizard/model$update', {
+        path: '/spec/tls/remove',
+        value: true,
+        force: true,
+      })
+    }
+  }
+
+  function showIssuerRefAndCertificates() {
+    const tlsOperation = getValue(discriminator, '/tlsOperation')
+    // watchDependency('discriminator#/tlsOperation')
+    const verd = tlsOperation !== 'remove' && tlsOperation !== 'rotate'
+
+    return verd
+  }
+
+  function isIssuerRefRequired() {
+    const hasTls = hasTlsField()
+    return hasTls ? false : ''
+  }
+
+  function fetchAliasOptions() {
+    return getAliasOptions ? getAliasOptions() : []
+  }
+
+  function getAliasOptions() {
+    return ['server', 'client', 'metrics-exporter']
+  }
+
+  function disableAlias() {
+    return !!(model && model.alias)
+  }
+
   function initNamespace() {
     const { namespace } = route.query || {}
     return namespace || null
@@ -1150,6 +1282,18 @@ export const useFunc = (model) => {
     getDbDetails,
     ifRequestTypeEqualsTo,
     onRequestTypeChange,
+    getDbTls,
+    hasTlsField,
+    initIssuerRefApiGroup,
+    getIssuerRefsName,
+    initTlsOperation,
+    isTlsEnabled,
+    onTlsOperationChange,
+    showIssuerRefAndCertificates,
+    isIssuerRefRequired,
+    fetchAliasOptions,
+    getAliasOptions,
+    disableAlias,
     initNamespace,
     initDatabaseRef,
     showAndInitName,


### PR DESCRIPTION
The weaviate opsrequest editor offered `ReconfigureTLS` as a request type (`ui/create-ui.yaml`) but had no TLS form block and no TLS helper functions — selecting it produced an ops request with no `spec.tls` at all.

Ports the TLS block and its 12 helpers verbatim from `opskubedbcom-zookeeperopsrequest-editor`:

- `ui/functions.js` — `getDbTls`, `hasTlsField`, `initIssuerRefApiGroup`, `getIssuerRefsName`, `initTlsOperation`, `isTlsEnabled`, `onTlsOperationChange`, `showIssuerRefAndCertificates`, `isIssuerRefRequired`, `fetchAliasOptions`, `getAliasOptions`, `disableAlias`
- `ui/create-ui.yaml` — `label: TLS` / `if: ifRequestTypeEqualsTo|ReconfigureTLS` block: TLS operation radio, remove/rotate switches, issuer reference, certificates

`spec.tls.clientAuth` (which weaviate's schema has and zookeeper's does not) is left unexposed, so the block stays identical across editors.

`ui/language.yaml` already carried every label key used, and `values.openapiv3_schema.yaml` has every schema path the block references — no schema or language changes, so no `make gen`.