### PR TITLE
Fetch DatabaseConfiguration via GET instead of CREATE

### DIFF
--- a/charts/opskubedbcom-cassandraopsrequest-editor/ui/functions.js
+++ b/charts/opskubedbcom-cassandraopsrequest-editor/ui/functions.js
@@ -832,29 +832,13 @@ export const useFunc = (model) => {
     const name = getValue(model, '/spec/databaseRef/name')
     const dbGroup = getValue(model, '/route/params/group')
     const dbKind = getValue(store.state, '/resource/definition/result/kind')
-    const dbResource = getValue(model, '/route/params/resource')
-    const dbVersion = getValue(model, '/route/params/version')
 
     try {
-      const resp = await axios.post(
-        `/clusters/${owner}/${cluster}/proxy/ui.kubedb.com/v1alpha1/databaseconfigurations`,
+      const resp = await axios.get(
+        `/clusters/${owner}/${cluster}/proxy/ui.kubedb.com/v1alpha1/namespaces/${namespace}/databaseconfigurations/${name}~${dbKind}.${dbGroup}`,
         {
-          apiVersion: 'ui.kubedb.com/v1alpha1',
-          kind: 'DatabaseConfiguration',
-          request: {
-            source: {
-              ref: {
-                name: name,
-                namespace: namespace,
-              },
-              resource: {
-                group: dbGroup,
-                kind: dbKind,
-                name: dbResource,
-                version: dbVersion,
-              },
-            },
-            keys: ['cassandra.yaml'],
+          params: {
+            keys: ['cassandra.yaml'].join(','),
           },
         },
       )

--- a/charts/opskubedbcom-clickhouseopsrequest-editor/ui/functions.js
+++ b/charts/opskubedbcom-clickhouseopsrequest-editor/ui/functions.js
@@ -835,29 +835,13 @@ export const useFunc = (model) => {
     const name = getValue(model, '/spec/databaseRef/name')
     const dbGroup = getValue(model, '/route/params/group')
     const dbKind = getValue(store.state, '/resource/definition/result/kind')
-    const dbResource = getValue(model, '/route/params/resource')
-    const dbVersion = getValue(model, '/route/params/version')
 
     try {
-      const resp = await axios.post(
-        `/clusters/${owner}/${cluster}/proxy/ui.kubedb.com/v1alpha1/databaseconfigurations`,
+      const resp = await axios.get(
+        `/clusters/${owner}/${cluster}/proxy/ui.kubedb.com/v1alpha1/namespaces/${namespace}/databaseconfigurations/${name}~${dbKind}.${dbGroup}`,
         {
-          apiVersion: 'ui.kubedb.com/v1alpha1',
-          kind: 'DatabaseConfiguration',
-          request: {
-            source: {
-              ref: {
-                name: name,
-                namespace: namespace,
-              },
-              resource: {
-                group: dbGroup,
-                kind: dbKind,
-                name: dbResource,
-                version: dbVersion,
-              },
-            },
-            keys: ['kubedb-user.cnf'],
+          params: {
+            keys: ['kubedb-user.cnf'].join(','),
           },
         },
       )

--- a/charts/opskubedbcom-documentdbopsrequest-editor/ui/functions.js
+++ b/charts/opskubedbcom-documentdbopsrequest-editor/ui/functions.js
@@ -834,29 +834,13 @@ export const useFunc = (model) => {
     const name = getValue(model, '/spec/databaseRef/name')
     const dbGroup = getValue(model, '/route/params/group')
     const dbKind = getValue(store.state, '/resource/definition/result/kind')
-    const dbResource = getValue(model, '/route/params/resource')
-    const dbVersion = getValue(model, '/route/params/version')
 
     try {
-      const resp = await axios.post(
-        `/clusters/${owner}/${cluster}/proxy/ui.kubedb.com/v1alpha1/databaseconfigurations`,
+      const resp = await axios.get(
+        `/clusters/${owner}/${cluster}/proxy/ui.kubedb.com/v1alpha1/namespaces/${namespace}/databaseconfigurations/${name}~${dbKind}.${dbGroup}`,
         {
-          apiVersion: 'ui.kubedb.com/v1alpha1',
-          kind: 'DatabaseConfiguration',
-          request: {
-            source: {
-              ref: {
-                name: name,
-                namespace: namespace,
-              },
-              resource: {
-                group: dbGroup,
-                kind: dbKind,
-                name: dbResource,
-                version: dbVersion,
-              },
-            },
-            keys: ['kubedb-user.cnf'],
+          params: {
+            keys: ['kubedb-user.cnf'].join(','),
           },
         },
       )

--- a/charts/opskubedbcom-druidopsrequest-editor/ui/functions.js
+++ b/charts/opskubedbcom-druidopsrequest-editor/ui/functions.js
@@ -1027,29 +1027,13 @@ export const useFunc = (model) => {
     const name = getValue(model, '/spec/databaseRef/name')
     const dbGroup = getValue(model, '/route/params/group')
     const dbKind = getValue(store.state, '/resource/definition/result/kind')
-    const dbResource = getValue(model, '/route/params/resource')
-    const dbVersion = getValue(model, '/route/params/version')
 
     try {
-      const resp = await axios.post(
-        `/clusters/${owner}/${cluster}/proxy/ui.kubedb.com/v1alpha1/databaseconfigurations`,
+      const resp = await axios.get(
+        `/clusters/${owner}/${cluster}/proxy/ui.kubedb.com/v1alpha1/namespaces/${namespace}/databaseconfigurations/${name}~${dbKind}.${dbGroup}`,
         {
-          apiVersion: 'ui.kubedb.com/v1alpha1',
-          kind: 'DatabaseConfiguration',
-          request: {
-            source: {
-              ref: {
-                name: name,
-                namespace: namespace,
-              },
-              resource: {
-                group: dbGroup,
-                kind: dbKind,
-                name: dbResource,
-                version: dbVersion,
-              },
-            },
-            keys: ['.properties'],
+          params: {
+            keys: ['.properties'].join(','),
           },
         },
       )

--- a/charts/opskubedbcom-elasticsearchopsrequest-editor/ui/functions.js
+++ b/charts/opskubedbcom-elasticsearchopsrequest-editor/ui/functions.js
@@ -1035,29 +1035,13 @@ export const useFunc = (model) => {
     const name = getValue(model, '/spec/databaseRef/name')
     const dbGroup = getValue(model, '/route/params/group')
     const dbKind = getValue(store.state, '/resource/definition/result/kind')
-    const dbResource = getValue(model, '/route/params/resource')
-    const dbVersion = getValue(model, '/route/params/version')
 
     try {
-      const resp = await axios.post(
-        `/clusters/${owner}/${cluster}/proxy/ui.kubedb.com/v1alpha1/databaseconfigurations`,
+      const resp = await axios.get(
+        `/clusters/${owner}/${cluster}/proxy/ui.kubedb.com/v1alpha1/namespaces/${namespace}/databaseconfigurations/${name}~${dbKind}.${dbGroup}`,
         {
-          apiVersion: 'ui.kubedb.com/v1alpha1',
-          kind: 'DatabaseConfiguration',
-          request: {
-            source: {
-              ref: {
-                name: name,
-                namespace: namespace,
-              },
-              resource: {
-                group: dbGroup,
-                kind: dbKind,
-                name: dbResource,
-                version: dbVersion,
-              },
-            },
-            keys: ['elasticsearch.yml', 'data-elasticsearch.yml', 'ingest-elasticsearch.yml'],
+          params: {
+            keys: ['elasticsearch.yml', 'data-elasticsearch.yml', 'ingest-elasticsearch.yml'].join(','),
           },
         },
       )

--- a/charts/opskubedbcom-hanadbopsrequest-editor/ui/functions.js
+++ b/charts/opskubedbcom-hanadbopsrequest-editor/ui/functions.js
@@ -669,29 +669,13 @@ export const useFunc = (model) => {
     const name = getValue(model, '/spec/databaseRef/name')
     const dbGroup = getValue(model, '/route/params/group')
     const dbKind = getValue(store.state, '/resource/definition/result/kind')
-    const dbResource = getValue(model, '/route/params/resource')
-    const dbVersion = getValue(model, '/route/params/version')
 
     try {
-      const resp = await axios.post(
-        `/clusters/${owner}/${cluster}/proxy/ui.kubedb.com/v1alpha1/databaseconfigurations`,
+      const resp = await axios.get(
+        `/clusters/${owner}/${cluster}/proxy/ui.kubedb.com/v1alpha1/namespaces/${namespace}/databaseconfigurations/${name}~${dbKind}.${dbGroup}`,
         {
-          apiVersion: 'ui.kubedb.com/v1alpha1',
-          kind: 'DatabaseConfiguration',
-          request: {
-            source: {
-              ref: {
-                name: name,
-                namespace: namespace,
-              },
-              resource: {
-                group: dbGroup,
-                kind: dbKind,
-                name: dbResource,
-                version: dbVersion,
-              },
-            },
-            keys: ['hanadb.cnf'],
+          params: {
+            keys: ['hanadb.cnf'].join(','),
           },
         },
       )

--- a/charts/opskubedbcom-hazelcastopsrequest-editor/ui/functions.js
+++ b/charts/opskubedbcom-hazelcastopsrequest-editor/ui/functions.js
@@ -832,29 +832,13 @@ export const useFunc = (model) => {
     const name = getValue(model, '/spec/databaseRef/name')
     const dbGroup = getValue(model, '/route/params/group')
     const dbKind = getValue(store.state, '/resource/definition/result/kind')
-    const dbResource = getValue(model, '/route/params/resource')
-    const dbVersion = getValue(model, '/route/params/version')
 
     try {
-      const resp = await axios.post(
-        `/clusters/${owner}/${cluster}/proxy/ui.kubedb.com/v1alpha1/databaseconfigurations`,
+      const resp = await axios.get(
+        `/clusters/${owner}/${cluster}/proxy/ui.kubedb.com/v1alpha1/namespaces/${namespace}/databaseconfigurations/${name}~${dbKind}.${dbGroup}`,
         {
-          apiVersion: 'ui.kubedb.com/v1alpha1',
-          kind: 'DatabaseConfiguration',
-          request: {
-            source: {
-              ref: {
-                name: name,
-                namespace: namespace,
-              },
-              resource: {
-                group: dbGroup,
-                kind: dbKind,
-                name: dbResource,
-                version: dbVersion,
-              },
-            },
-            keys: ['hazelcast.cnf'],
+          params: {
+            keys: ['hazelcast.cnf'].join(','),
           },
         },
       )

--- a/charts/opskubedbcom-igniteopsrequest-editor/ui/functions.js
+++ b/charts/opskubedbcom-igniteopsrequest-editor/ui/functions.js
@@ -840,29 +840,13 @@ export const useFunc = (model) => {
     const name = getValue(model, '/spec/databaseRef/name')
     const dbGroup = getValue(model, '/route/params/group')
     const dbKind = getValue(store.state, '/resource/definition/result/kind')
-    const dbResource = getValue(model, '/route/params/resource')
-    const dbVersion = getValue(model, '/route/params/version')
 
     try {
-      const resp = await axios.post(
-        `/clusters/${owner}/${cluster}/proxy/ui.kubedb.com/v1alpha1/databaseconfigurations`,
+      const resp = await axios.get(
+        `/clusters/${owner}/${cluster}/proxy/ui.kubedb.com/v1alpha1/namespaces/${namespace}/databaseconfigurations/${name}~${dbKind}.${dbGroup}`,
         {
-          apiVersion: 'ui.kubedb.com/v1alpha1',
-          kind: 'DatabaseConfiguration',
-          request: {
-            source: {
-              ref: {
-                name: name,
-                namespace: namespace,
-              },
-              resource: {
-                group: dbGroup,
-                kind: dbKind,
-                name: dbResource,
-                version: dbVersion,
-              },
-            },
-            keys: ['kubedb-user.cnf'],
+          params: {
+            keys: ['kubedb-user.cnf'].join(','),
           },
         },
       )

--- a/charts/opskubedbcom-kafkaopsrequest-editor/ui/functions.js
+++ b/charts/opskubedbcom-kafkaopsrequest-editor/ui/functions.js
@@ -869,29 +869,13 @@ export const useFunc = (model) => {
     const name = getValue(model, '/spec/databaseRef/name')
     const dbGroup = getValue(model, '/route/params/group')
     const dbKind = getValue(store.state, '/resource/definition/result/kind')
-    const dbResource = getValue(model, '/route/params/resource')
-    const dbVersion = getValue(model, '/route/params/version')
 
     try {
-      const resp = await axios.post(
-        `/clusters/${owner}/${cluster}/proxy/ui.kubedb.com/v1alpha1/databaseconfigurations`,
+      const resp = await axios.get(
+        `/clusters/${owner}/${cluster}/proxy/ui.kubedb.com/v1alpha1/namespaces/${namespace}/databaseconfigurations/${name}~${dbKind}.${dbGroup}`,
         {
-          apiVersion: 'ui.kubedb.com/v1alpha1',
-          kind: 'DatabaseConfiguration',
-          request: {
-            source: {
-              ref: {
-                name: name,
-                namespace: namespace,
-              },
-              resource: {
-                group: dbGroup,
-                kind: dbKind,
-                name: dbResource,
-                version: dbVersion,
-              },
-            },
-            keys: ['server.properties', 'broker.properties', 'controller.properties'],
+          params: {
+            keys: ['server.properties', 'broker.properties', 'controller.properties'].join(','),
           },
         },
       )

--- a/charts/opskubedbcom-mariadbopsrequest-editor/ui/functions.js
+++ b/charts/opskubedbcom-mariadbopsrequest-editor/ui/functions.js
@@ -825,29 +825,13 @@ export const useFunc = (model) => {
     const name = getValue(model, '/spec/databaseRef/name')
     const dbGroup = getValue(model, '/route/params/group')
     const dbKind = getValue(store.state, '/resource/definition/result/kind')
-    const dbResource = getValue(model, '/route/params/resource')
-    const dbVersion = getValue(model, '/route/params/version')
 
     try {
-      const resp = await axios.post(
-        `/clusters/${owner}/${cluster}/proxy/ui.kubedb.com/v1alpha1/databaseconfigurations`,
+      const resp = await axios.get(
+        `/clusters/${owner}/${cluster}/proxy/ui.kubedb.com/v1alpha1/namespaces/${namespace}/databaseconfigurations/${name}~${dbKind}.${dbGroup}`,
         {
-          apiVersion: 'ui.kubedb.com/v1alpha1',
-          kind: 'DatabaseConfiguration',
-          request: {
-            source: {
-              ref: {
-                name: name,
-                namespace: namespace,
-              },
-              resource: {
-                group: dbGroup,
-                kind: dbKind,
-                name: dbResource,
-                version: dbVersion,
-              },
-            },
-            keys: ['kubedb-user.cnf'],
+          params: {
+            keys: ['kubedb-user.cnf'].join(','),
           },
         },
       )

--- a/charts/opskubedbcom-memcachedopsrequest-editor/ui/functions.js
+++ b/charts/opskubedbcom-memcachedopsrequest-editor/ui/functions.js
@@ -947,29 +947,13 @@ export const useFunc = (model) => {
     const name = getValue(model, '/spec/databaseRef/name')
     const dbGroup = getValue(model, '/route/params/group')
     const dbKind = getValue(store.state, '/resource/definition/result/kind')
-    const dbResource = getValue(model, '/route/params/resource')
-    const dbVersion = getValue(model, '/route/params/version')
 
     try {
-      const resp = await axios.post(
-        `/clusters/${owner}/${cluster}/proxy/ui.kubedb.com/v1alpha1/databaseconfigurations`,
+      const resp = await axios.get(
+        `/clusters/${owner}/${cluster}/proxy/ui.kubedb.com/v1alpha1/namespaces/${namespace}/databaseconfigurations/${name}~${dbKind}.${dbGroup}`,
         {
-          apiVersion: 'ui.kubedb.com/v1alpha1',
-          kind: 'DatabaseConfiguration',
-          request: {
-            source: {
-              ref: {
-                name: name,
-                namespace: namespace,
-              },
-              resource: {
-                group: dbGroup,
-                kind: dbKind,
-                name: dbResource,
-                version: dbVersion,
-              },
-            },
-            keys: ['kubedb-user.cnf'],
+          params: {
+            keys: ['kubedb-user.cnf'].join(','),
           },
         },
       )

--- a/charts/opskubedbcom-milvusopsrequest-editor/ui/functions.js
+++ b/charts/opskubedbcom-milvusopsrequest-editor/ui/functions.js
@@ -829,29 +829,13 @@ export const useFunc = (model) => {
     const name = getValue(model, '/spec/databaseRef/name')
     const dbGroup = getValue(model, '/route/params/group')
     const dbKind = getValue(store.state, '/resource/definition/result/kind')
-    const dbResource = getValue(model, '/route/params/resource')
-    const dbVersion = getValue(model, '/route/params/version')
 
     try {
-      const resp = await axios.post(
-        `/clusters/${owner}/${cluster}/proxy/ui.kubedb.com/v1alpha1/databaseconfigurations`,
+      const resp = await axios.get(
+        `/clusters/${owner}/${cluster}/proxy/ui.kubedb.com/v1alpha1/namespaces/${namespace}/databaseconfigurations/${name}~${dbKind}.${dbGroup}`,
         {
-          apiVersion: 'ui.kubedb.com/v1alpha1',
-          kind: 'DatabaseConfiguration',
-          request: {
-            source: {
-              ref: {
-                name: name,
-                namespace: namespace,
-              },
-              resource: {
-                group: dbGroup,
-                kind: dbKind,
-                name: dbResource,
-                version: dbVersion,
-              },
-            },
-            keys: ['milvus.yaml'],
+          params: {
+            keys: ['milvus.yaml'].join(','),
           },
         },
       )

--- a/charts/opskubedbcom-mongodbopsrequest-editor/ui/functions.js
+++ b/charts/opskubedbcom-mongodbopsrequest-editor/ui/functions.js
@@ -893,29 +893,13 @@ export const useFunc = (model) => {
     const name = getValue(model, '/spec/databaseRef/name')
     const dbGroup = getValue(model, '/route/params/group')
     const dbKind = getValue(store.state, '/resource/definition/result/kind')
-    const dbResource = getValue(model, '/route/params/resource')
-    const dbVersion = getValue(model, '/route/params/version')
 
     try {
-      const resp = await axios.post(
-        `/clusters/${owner}/${cluster}/proxy/ui.kubedb.com/v1alpha1/databaseconfigurations`,
+      const resp = await axios.get(
+        `/clusters/${owner}/${cluster}/proxy/ui.kubedb.com/v1alpha1/namespaces/${namespace}/databaseconfigurations/${name}~${dbKind}.${dbGroup}`,
         {
-          apiVersion: 'ui.kubedb.com/v1alpha1',
-          kind: 'DatabaseConfiguration',
-          request: {
-            source: {
-              ref: {
-                name: name,
-                namespace: namespace,
-              },
-              resource: {
-                group: dbGroup,
-                kind: dbKind,
-                name: dbResource,
-                version: dbVersion,
-              },
-            },
-            keys: ['mongod.conf', 'replicaset.json', 'configuration.js'],
+          params: {
+            keys: ['mongod.conf', 'replicaset.json', 'configuration.js'].join(','),
           },
         },
       )

--- a/charts/opskubedbcom-mssqlserveropsrequest-editor/ui/functions.js
+++ b/charts/opskubedbcom-mssqlserveropsrequest-editor/ui/functions.js
@@ -843,29 +843,13 @@ export const useFunc = (model) => {
     const name = getValue(model, '/spec/databaseRef/name')
     const dbGroup = getValue(model, '/route/params/group')
     const dbKind = getValue(store.state, '/resource/definition/result/kind')
-    const dbResource = getValue(model, '/route/params/resource')
-    const dbVersion = getValue(model, '/route/params/version')
 
     try {
-      const resp = await axios.post(
-        `/clusters/${owner}/${cluster}/proxy/ui.kubedb.com/v1alpha1/databaseconfigurations`,
+      const resp = await axios.get(
+        `/clusters/${owner}/${cluster}/proxy/ui.kubedb.com/v1alpha1/namespaces/${namespace}/databaseconfigurations/${name}~${dbKind}.${dbGroup}`,
         {
-          apiVersion: 'ui.kubedb.com/v1alpha1',
-          kind: 'DatabaseConfiguration',
-          request: {
-            source: {
-              ref: {
-                name: name,
-                namespace: namespace,
-              },
-              resource: {
-                group: dbGroup,
-                kind: dbKind,
-                name: dbResource,
-                version: dbVersion,
-              },
-            },
-            keys: ['mssql.conf'],
+          params: {
+            keys: ['mssql.conf'].join(','),
           },
         },
       )

--- a/charts/opskubedbcom-mysqlopsrequest-editor/ui/functions.js
+++ b/charts/opskubedbcom-mysqlopsrequest-editor/ui/functions.js
@@ -851,29 +851,13 @@ export const useFunc = (model) => {
     const name = getValue(model, '/spec/databaseRef/name')
     const dbGroup = getValue(model, '/route/params/group')
     const dbKind = getValue(store.state, '/resource/definition/result/kind')
-    const dbResource = getValue(model, '/route/params/resource')
-    const dbVersion = getValue(model, '/route/params/version')
 
     try {
-      const resp = await axios.post(
-        `/clusters/${owner}/${cluster}/proxy/ui.kubedb.com/v1alpha1/databaseconfigurations`,
+      const resp = await axios.get(
+        `/clusters/${owner}/${cluster}/proxy/ui.kubedb.com/v1alpha1/namespaces/${namespace}/databaseconfigurations/${name}~${dbKind}.${dbGroup}`,
         {
-          apiVersion: 'ui.kubedb.com/v1alpha1',
-          kind: 'DatabaseConfiguration',
-          request: {
-            source: {
-              ref: {
-                name: name,
-                namespace: namespace,
-              },
-              resource: {
-                group: dbGroup,
-                kind: dbKind,
-                name: dbResource,
-                version: dbVersion,
-              },
-            },
-            keys: ['kubedb-user.cnf'],
+          params: {
+            keys: ['kubedb-user.cnf'].join(','),
           },
         },
       )

--- a/charts/opskubedbcom-neo4jopsrequest-editor/ui/functions.js
+++ b/charts/opskubedbcom-neo4jopsrequest-editor/ui/functions.js
@@ -829,29 +829,13 @@ export const useFunc = (model) => {
     const name = getValue(model, '/spec/databaseRef/name')
     const dbGroup = getValue(model, '/route/params/group')
     const dbKind = getValue(store.state, '/resource/definition/result/kind')
-    const dbResource = getValue(model, '/route/params/resource')
-    const dbVersion = getValue(model, '/route/params/version')
 
     try {
-      const resp = await axios.post(
-        `/clusters/${owner}/${cluster}/proxy/ui.kubedb.com/v1alpha1/databaseconfigurations`,
+      const resp = await axios.get(
+        `/clusters/${owner}/${cluster}/proxy/ui.kubedb.com/v1alpha1/namespaces/${namespace}/databaseconfigurations/${name}~${dbKind}.${dbGroup}`,
         {
-          apiVersion: 'ui.kubedb.com/v1alpha1',
-          kind: 'DatabaseConfiguration',
-          request: {
-            source: {
-              ref: {
-                name: name,
-                namespace: namespace,
-              },
-              resource: {
-                group: dbGroup,
-                kind: dbKind,
-                name: dbResource,
-                version: dbVersion,
-              },
-            },
-            keys: ['kubedb-user.cnf'],
+          params: {
+            keys: ['kubedb-user.cnf'].join(','),
           },
         },
       )

--- a/charts/opskubedbcom-oracleopsrequest-editor/ui/functions.js
+++ b/charts/opskubedbcom-oracleopsrequest-editor/ui/functions.js
@@ -676,29 +676,13 @@ export const useFunc = (model) => {
     const name = getValue(model, '/spec/databaseRef/name')
     const dbGroup = getValue(model, '/route/params/group')
     const dbKind = getValue(store.state, '/resource/definition/result/kind')
-    const dbResource = getValue(model, '/route/params/resource')
-    const dbVersion = getValue(model, '/route/params/version')
 
     try {
-      const resp = await axios.post(
-        `/clusters/${owner}/${cluster}/proxy/ui.kubedb.com/v1alpha1/databaseconfigurations`,
+      const resp = await axios.get(
+        `/clusters/${owner}/${cluster}/proxy/ui.kubedb.com/v1alpha1/namespaces/${namespace}/databaseconfigurations/${name}~${dbKind}.${dbGroup}`,
         {
-          apiVersion: 'ui.kubedb.com/v1alpha1',
-          kind: 'DatabaseConfiguration',
-          request: {
-            source: {
-              ref: {
-                name: name,
-                namespace: namespace,
-              },
-              resource: {
-                group: dbGroup,
-                kind: dbKind,
-                name: dbResource,
-                version: dbVersion,
-              },
-            },
-            keys: ['kubedb-user.cnf'],
+          params: {
+            keys: ['kubedb-user.cnf'].join(','),
           },
         },
       )

--- a/charts/opskubedbcom-perconaxtradbopsrequest-editor/ui/functions.js
+++ b/charts/opskubedbcom-perconaxtradbopsrequest-editor/ui/functions.js
@@ -687,29 +687,13 @@ export const useFunc = (model) => {
     const name = getValue(model, '/spec/databaseRef/name')
     const dbGroup = getValue(model, '/route/params/group')
     const dbKind = getValue(store.state, '/resource/definition/result/kind')
-    const dbResource = getValue(model, '/route/params/resource')
-    const dbVersion = getValue(model, '/route/params/version')
 
     try {
-      const resp = await axios.post(
-        `/clusters/${owner}/${cluster}/proxy/ui.kubedb.com/v1alpha1/databaseconfigurations`,
+      const resp = await axios.get(
+        `/clusters/${owner}/${cluster}/proxy/ui.kubedb.com/v1alpha1/namespaces/${namespace}/databaseconfigurations/${name}~${dbKind}.${dbGroup}`,
         {
-          apiVersion: 'ui.kubedb.com/v1alpha1',
-          kind: 'DatabaseConfiguration',
-          request: {
-            source: {
-              ref: {
-                name: name,
-                namespace: namespace,
-              },
-              resource: {
-                group: dbGroup,
-                kind: dbKind,
-                name: dbResource,
-                version: dbVersion,
-              },
-            },
-            keys: ['kubedb-user.cnf'],
+          params: {
+            keys: ['kubedb-user.cnf'].join(','),
           },
         },
       )

--- a/charts/opskubedbcom-pgbounceropsrequest-editor/ui/functions.js
+++ b/charts/opskubedbcom-pgbounceropsrequest-editor/ui/functions.js
@@ -786,29 +786,13 @@ export const useFunc = (model) => {
     const name = getValue(model, '/spec/databaseRef/name')
     const dbGroup = getValue(model, '/route/params/group')
     const dbKind = getValue(store.state, '/resource/definition/result/kind')
-    const dbResource = getValue(model, '/route/params/resource')
-    const dbVersion = getValue(model, '/route/params/version')
 
     try {
-      const resp = await axios.post(
-        `/clusters/${owner}/${cluster}/proxy/ui.kubedb.com/v1alpha1/databaseconfigurations`,
+      const resp = await axios.get(
+        `/clusters/${owner}/${cluster}/proxy/ui.kubedb.com/v1alpha1/namespaces/${namespace}/databaseconfigurations/${name}~${dbKind}.${dbGroup}`,
         {
-          apiVersion: 'ui.kubedb.com/v1alpha1',
-          kind: 'DatabaseConfiguration',
-          request: {
-            source: {
-              ref: {
-                name: name,
-                namespace: namespace,
-              },
-              resource: {
-                group: dbGroup,
-                kind: dbKind,
-                name: dbResource,
-                version: dbVersion,
-              },
-            },
-            keys: ['kubedb-user.ini'],
+          params: {
+            keys: ['kubedb-user.ini'].join(','),
           },
         },
       )

--- a/charts/opskubedbcom-pgpoolopsrequest-editor/ui/functions.js
+++ b/charts/opskubedbcom-pgpoolopsrequest-editor/ui/functions.js
@@ -834,29 +834,13 @@ export const useFunc = (model) => {
     const name = getValue(model, '/spec/databaseRef/name')
     const dbGroup = getValue(model, '/route/params/group')
     const dbKind = getValue(store.state, '/resource/definition/result/kind')
-    const dbResource = getValue(model, '/route/params/resource')
-    const dbVersion = getValue(model, '/route/params/version')
 
     try {
-      const resp = await axios.post(
-        `/clusters/${owner}/${cluster}/proxy/ui.kubedb.com/v1alpha1/databaseconfigurations`,
+      const resp = await axios.get(
+        `/clusters/${owner}/${cluster}/proxy/ui.kubedb.com/v1alpha1/namespaces/${namespace}/databaseconfigurations/${name}~${dbKind}.${dbGroup}`,
         {
-          apiVersion: 'ui.kubedb.com/v1alpha1',
-          kind: 'DatabaseConfiguration',
-          request: {
-            source: {
-              ref: {
-                name: name,
-                namespace: namespace,
-              },
-              resource: {
-                group: dbGroup,
-                kind: dbKind,
-                name: dbResource,
-                version: dbVersion,
-              },
-            },
-            keys: ['kubedb-user.conf'],
+          params: {
+            keys: ['kubedb-user.conf'].join(','),
           },
         },
       )

--- a/charts/opskubedbcom-postgresopsrequest-editor/ui/functions.js
+++ b/charts/opskubedbcom-postgresopsrequest-editor/ui/functions.js
@@ -821,29 +821,13 @@ export const useFunc = (model) => {
     const name = getValue(model, '/spec/databaseRef/name')
     const dbGroup = getValue(model, '/route/params/group')
     const dbKind = getValue(store.state, '/resource/definition/result/kind')
-    const dbResource = getValue(model, '/route/params/resource')
-    const dbVersion = getValue(model, '/route/params/version')
 
     try {
-      const resp = await axios.post(
-        `/clusters/${owner}/${cluster}/proxy/ui.kubedb.com/v1alpha1/databaseconfigurations`,
+      const resp = await axios.get(
+        `/clusters/${owner}/${cluster}/proxy/ui.kubedb.com/v1alpha1/namespaces/${namespace}/databaseconfigurations/${name}~${dbKind}.${dbGroup}`,
         {
-          apiVersion: 'ui.kubedb.com/v1alpha1',
-          kind: 'DatabaseConfiguration',
-          request: {
-            source: {
-              ref: {
-                name: name,
-                namespace: namespace,
-              },
-              resource: {
-                group: dbGroup,
-                kind: dbKind,
-                name: dbResource,
-                version: dbVersion,
-              },
-            },
-            keys: ['user.conf'],
+          params: {
+            keys: ['user.conf'].join(','),
           },
         },
       )

--- a/charts/opskubedbcom-qdrantopsrequest-editor/ui/functions.js
+++ b/charts/opskubedbcom-qdrantopsrequest-editor/ui/functions.js
@@ -833,29 +833,13 @@ export const useFunc = (model) => {
     const name = getValue(model, '/spec/databaseRef/name')
     const dbGroup = getValue(model, '/route/params/group')
     const dbKind = getValue(store.state, '/resource/definition/result/kind')
-    const dbResource = getValue(model, '/route/params/resource')
-    const dbVersion = getValue(model, '/route/params/version')
 
     try {
-      const resp = await axios.post(
-        `/clusters/${owner}/${cluster}/proxy/ui.kubedb.com/v1alpha1/databaseconfigurations`,
+      const resp = await axios.get(
+        `/clusters/${owner}/${cluster}/proxy/ui.kubedb.com/v1alpha1/namespaces/${namespace}/databaseconfigurations/${name}~${dbKind}.${dbGroup}`,
         {
-          apiVersion: 'ui.kubedb.com/v1alpha1',
-          kind: 'DatabaseConfiguration',
-          request: {
-            source: {
-              ref: {
-                name: name,
-                namespace: namespace,
-              },
-              resource: {
-                group: dbGroup,
-                kind: dbKind,
-                name: dbResource,
-                version: dbVersion,
-              },
-            },
-            keys: ['kubedb-user.cnf'],
+          params: {
+            keys: ['kubedb-user.cnf'].join(','),
           },
         },
       )

--- a/charts/opskubedbcom-rabbitmqopsrequest-editor/ui/functions.js
+++ b/charts/opskubedbcom-rabbitmqopsrequest-editor/ui/functions.js
@@ -827,29 +827,13 @@ export const useFunc = (model) => {
     const name = getValue(model, '/spec/databaseRef/name')
     const dbGroup = getValue(model, '/route/params/group')
     const dbKind = getValue(store.state, '/resource/definition/result/kind')
-    const dbResource = getValue(model, '/route/params/resource')
-    const dbVersion = getValue(model, '/route/params/version')
 
     try {
-      const resp = await axios.post(
-        `/clusters/${owner}/${cluster}/proxy/ui.kubedb.com/v1alpha1/databaseconfigurations`,
+      const resp = await axios.get(
+        `/clusters/${owner}/${cluster}/proxy/ui.kubedb.com/v1alpha1/namespaces/${namespace}/databaseconfigurations/${name}~${dbKind}.${dbGroup}`,
         {
-          apiVersion: 'ui.kubedb.com/v1alpha1',
-          kind: 'DatabaseConfiguration',
-          request: {
-            source: {
-              ref: {
-                name: name,
-                namespace: namespace,
-              },
-              resource: {
-                group: dbGroup,
-                kind: dbKind,
-                name: dbResource,
-                version: dbVersion,
-              },
-            },
-            keys: ['rabbitmq.conf'],
+          params: {
+            keys: ['rabbitmq.conf'].join(','),
           },
         },
       )

--- a/charts/opskubedbcom-redisopsrequest-editor/ui/functions.js
+++ b/charts/opskubedbcom-redisopsrequest-editor/ui/functions.js
@@ -820,29 +820,13 @@ export const useFunc = (model) => {
     const name = getValue(model, '/spec/databaseRef/name')
     const dbGroup = getValue(model, '/route/params/group')
     const dbKind = getValue(store.state, '/resource/definition/result/kind')
-    const dbResource = getValue(model, '/route/params/resource')
-    const dbVersion = getValue(model, '/route/params/version')
 
     try {
-      const resp = await axios.post(
-        `/clusters/${owner}/${cluster}/proxy/ui.kubedb.com/v1alpha1/databaseconfigurations`,
+      const resp = await axios.get(
+        `/clusters/${owner}/${cluster}/proxy/ui.kubedb.com/v1alpha1/namespaces/${namespace}/databaseconfigurations/${name}~${dbKind}.${dbGroup}`,
         {
-          apiVersion: 'ui.kubedb.com/v1alpha1',
-          kind: 'DatabaseConfiguration',
-          request: {
-            source: {
-              ref: {
-                name: name,
-                namespace: namespace,
-              },
-              resource: {
-                group: dbGroup,
-                kind: dbKind,
-                name: dbResource,
-                version: dbVersion,
-              },
-            },
-            keys: ['kubedb-user.conf'],
+          params: {
+            keys: ['kubedb-user.conf'].join(','),
           },
         },
       )

--- a/charts/opskubedbcom-singlestoreopsrequest-editor/ui/functions.js
+++ b/charts/opskubedbcom-singlestoreopsrequest-editor/ui/functions.js
@@ -829,29 +829,13 @@ export const useFunc = (model) => {
     const name = getValue(model, '/spec/databaseRef/name')
     const dbGroup = getValue(model, '/route/params/group')
     const dbKind = getValue(store.state, '/resource/definition/result/kind')
-    const dbResource = getValue(model, '/route/params/resource')
-    const dbVersion = getValue(model, '/route/params/version')
 
     try {
-      const resp = await axios.post(
-        `/clusters/${owner}/${cluster}/proxy/ui.kubedb.com/v1alpha1/databaseconfigurations`,
+      const resp = await axios.get(
+        `/clusters/${owner}/${cluster}/proxy/ui.kubedb.com/v1alpha1/namespaces/${namespace}/databaseconfigurations/${name}~${dbKind}.${dbGroup}`,
         {
-          apiVersion: 'ui.kubedb.com/v1alpha1',
-          kind: 'DatabaseConfiguration',
-          request: {
-            source: {
-              ref: {
-                name: name,
-                namespace: namespace,
-              },
-              resource: {
-                group: dbGroup,
-                kind: dbKind,
-                name: dbResource,
-                version: dbVersion,
-              },
-            },
-            keys: ['kubedb-user.cnf'],
+          params: {
+            keys: ['kubedb-user.cnf'].join(','),
           },
         },
       )

--- a/charts/opskubedbcom-solropsrequest-editor/ui/functions.js
+++ b/charts/opskubedbcom-solropsrequest-editor/ui/functions.js
@@ -872,29 +872,13 @@ export const useFunc = (model) => {
     const name = getValue(model, '/spec/databaseRef/name')
     const dbGroup = getValue(model, '/route/params/group')
     const dbKind = getValue(store.state, '/resource/definition/result/kind')
-    const dbResource = getValue(model, '/route/params/resource')
-    const dbVersion = getValue(model, '/route/params/version')
 
     try {
-      const resp = await axios.post(
-        `/clusters/${owner}/${cluster}/proxy/ui.kubedb.com/v1alpha1/databaseconfigurations`,
+      const resp = await axios.get(
+        `/clusters/${owner}/${cluster}/proxy/ui.kubedb.com/v1alpha1/namespaces/${namespace}/databaseconfigurations/${name}~${dbKind}.${dbGroup}`,
         {
-          apiVersion: 'ui.kubedb.com/v1alpha1',
-          kind: 'DatabaseConfiguration',
-          request: {
-            source: {
-              ref: {
-                name: name,
-                namespace: namespace,
-              },
-              resource: {
-                group: dbGroup,
-                kind: dbKind,
-                name: dbResource,
-                version: dbVersion,
-              },
-            },
-            keys: ['solr.xml'],
+          params: {
+            keys: ['solr.xml'].join(','),
           },
         },
       )

--- a/charts/opskubedbcom-weaviateopsrequest-editor/ui/functions.js
+++ b/charts/opskubedbcom-weaviateopsrequest-editor/ui/functions.js
@@ -795,29 +795,13 @@ export const useFunc = (model) => {
     const name = getValue(model, '/spec/databaseRef/name')
     const dbGroup = getValue(model, '/route/params/group')
     const dbKind = getValue(store.state, '/resource/definition/result/kind')
-    const dbResource = getValue(model, '/route/params/resource')
-    const dbVersion = getValue(model, '/route/params/version')
 
     try {
-      const resp = await axios.post(
-        `/clusters/${owner}/${cluster}/proxy/ui.kubedb.com/v1alpha1/databaseconfigurations`,
+      const resp = await axios.get(
+        `/clusters/${owner}/${cluster}/proxy/ui.kubedb.com/v1alpha1/namespaces/${namespace}/databaseconfigurations/${name}~${dbKind}.${dbGroup}`,
         {
-          apiVersion: 'ui.kubedb.com/v1alpha1',
-          kind: 'DatabaseConfiguration',
-          request: {
-            source: {
-              ref: {
-                name: name,
-                namespace: namespace,
-              },
-              resource: {
-                group: dbGroup,
-                kind: dbKind,
-                name: dbResource,
-                version: dbVersion,
-              },
-            },
-            keys: ['kubedb-user.cnf'],
+          params: {
+            keys: ['kubedb-user.cnf'].join(','),
           },
         },
       )

--- a/charts/opskubedbcom-zookeeperopsrequest-editor/ui/functions.js
+++ b/charts/opskubedbcom-zookeeperopsrequest-editor/ui/functions.js
@@ -823,29 +823,13 @@ export const useFunc = (model) => {
     const name = getValue(model, '/spec/databaseRef/name')
     const dbGroup = getValue(model, '/route/params/group')
     const dbKind = getValue(store.state, '/resource/definition/result/kind')
-    const dbResource = getValue(model, '/route/params/resource')
-    const dbVersion = getValue(model, '/route/params/version')
 
     try {
-      const resp = await axios.post(
-        `/clusters/${owner}/${cluster}/proxy/ui.kubedb.com/v1alpha1/databaseconfigurations`,
+      const resp = await axios.get(
+        `/clusters/${owner}/${cluster}/proxy/ui.kubedb.com/v1alpha1/namespaces/${namespace}/databaseconfigurations/${name}~${dbKind}.${dbGroup}`,
         {
-          apiVersion: 'ui.kubedb.com/v1alpha1',
-          kind: 'DatabaseConfiguration',
-          request: {
-            source: {
-              ref: {
-                name: name,
-                namespace: namespace,
-              },
-              resource: {
-                group: dbGroup,
-                kind: dbKind,
-                name: dbResource,
-                version: dbVersion,
-              },
-            },
-            keys: ['zoo.cfg'],
+          params: {
+            keys: ['zoo.cfg'].join(','),
           },
         },
       )


### PR DESCRIPTION
`ui.kubedb.com/v1alpha1 DatabaseConfiguration` is now namespaced and get-able (kubedb/apimachinery#1849, served by kubedb/ui-server#220), so the ops request editors no longer need create permission on it.

Per chart, `fetchConfigSecrets()` now does:

```js
const resp = await axios.get(
  `/clusters/${owner}/${cluster}/proxy/ui.kubedb.com/v1alpha1/namespaces/${namespace}/databaseconfigurations/${name}~${dbKind}.${dbGroup}`,
  { params: { keys: ['mongod.conf', 'replicaset.json', 'configuration.js'].join(',') } },
)
```

- name format `{.metadata.name}~Kind.Group` is what the API server parses, same convention as `databaseconnections`
- `keys` is comma-joined; the server splits it back apart
- response shape is unchanged, so `resp?.data?.response` parsing stays as is
- `dbResource` / `dbVersion` dropped (unused now); `dbGroup` / `dbKind` unchanged, so the resolved GroupKind matches what the old CREATE body sent

28 `opskubedbcom-*opsrequest-editor` charts, per-chart `keys` values preserved verbatim.