### PR TITLE
Add Neo4j TLS backup/certificates and HorizontalScaling reallocate options

### DIFF
--- a/apis/wizards/v1alpha1/kubedbcom_neo4j_editor_options_types.go
+++ b/apis/wizards/v1alpha1/kubedbcom_neo4j_editor_options_types.go
@@ -19,6 +19,7 @@ package v1alpha1
 import (
 	alerts "go.appscode.dev/alerts/apis/alerts/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kmapi "kmodules.xyz/client-go/api/v1"
 	api "x-helm.dev/apimachinery/apis/releases/v1alpha1"
 )
 
@@ -70,6 +71,9 @@ type Neo4jTLS struct {
 	Bolt      Neo4jProtocolTLS `json:"bolt"`
 	HTTP      Neo4jProtocolTLS `json:"http"`
 	Cluster   Neo4jProtocolTLS `json:"cluster"`
+	Backup    Neo4jProtocolTLS `json:"backup"`
+	// +optional
+	Certificates []kmapi.CertificateSpec `json:"certificates,omitempty"`
 }
 
 type Neo4jIssuerRef struct {

--- a/apis/wizards/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/wizards/v1alpha1/zz_generated.deepcopy.go
@@ -25,6 +25,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
+	clientgoapiv1 "kmodules.xyz/client-go/api/v1"
 	apiv1 "kmodules.xyz/monitoring-agent-api/api/v1"
 	offshootapiapiv1 "kmodules.xyz/offshoot-api/api/v1"
 )
@@ -3886,7 +3887,7 @@ func (in *KubedbcomNeo4jEditorOptionsSpecSpec) DeepCopyInto(out *KubedbcomNeo4jE
 	out.Persistence = in.Persistence
 	in.PodResources.DeepCopyInto(&out.PodResources)
 	out.AuthSecret = in.AuthSecret
-	out.TLS = in.TLS
+	in.TLS.DeepCopyInto(&out.TLS)
 	in.Admin.DeepCopyInto(&out.Admin)
 	in.Backup.DeepCopyInto(&out.Backup)
 	in.Monitoring.DeepCopyInto(&out.Monitoring)
@@ -6386,6 +6387,14 @@ func (in *Neo4jTLS) DeepCopyInto(out *Neo4jTLS) {
 	out.Bolt = in.Bolt
 	out.HTTP = in.HTTP
 	out.Cluster = in.Cluster
+	out.Backup = in.Backup
+	if in.Certificates != nil {
+		in, out := &in.Certificates, &out.Certificates
+		*out = make([]clientgoapiv1.CertificateSpec, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	return
 }
 

--- a/charts/kubedbcom-neo4j-editor-options/templates/db.yaml
+++ b/charts/kubedbcom-neo4j-editor-options/templates/db.yaml
@@ -160,4 +160,12 @@ spec:
     cluster:
       mode: {{ .Values.spec.tls.cluster.mode }}
     {{- end }}
+    {{- if .Values.spec.tls.backup }}
+    backup:
+      mode: {{ .Values.spec.tls.backup.mode }}
+    {{- end }}
+    {{- if .Values.spec.tls.certificates }}
+    certificates:
+      {{- toYaml .Values.spec.tls.certificates | nindent 6 }}
+    {{- end }}
 {{- end }}

--- a/charts/kubedbcom-neo4j-editor-options/values.yaml
+++ b/charts/kubedbcom-neo4j-editor-options/values.yaml
@@ -59,6 +59,9 @@ spec:
       mode: TLS
     cluster:
       mode: mTLS
+    backup:
+      mode: mTLS
+    certificates: []
 
   openshift:
     securityContext:

--- a/charts/opskubedbcom-neo4jopsrequest-editor/ui/create-ui.yaml
+++ b/charts/opskubedbcom-neo4jopsrequest-editor/ui/create-ui.yaml
@@ -137,6 +137,25 @@ step:
           setting this to 3 creates three copies of the database for better availability.
         type: info
       type: horizontal-layout
+    - elements:
+      - label: Reallocation Strategy
+        options:
+        - text: incremental
+          value: incremental
+        - text: full
+          value: full
+        - text: none
+          value: none
+        schema: schema/properties/spec/properties/horizontalScaling/properties/reallocate/properties/strategy
+        subtitle: Controls how database shards are redistributed after scaling. 'incremental'
+          reallocates in batches, 'full' reallocates everything at once, 'none' skips
+          reallocation
+        type: select
+      - label: Batch Size
+        schema: schema/properties/spec/properties/horizontalScaling/properties/reallocate/properties/batchSize
+        subtitle: Number of databases reallocated per batch when the strategy is 'incremental'
+        type: input
+      type: horizontal-layout
     fixedBlock: true
     if:
       name: ifRequestTypeEqualsTo|HorizontalScaling


### PR DESCRIPTION
- `kubedbcom-neo4j-editor-options`: pass through `spec.tls.backup.mode` and `spec.tls.certificates` (alias, secretName, duration, renewBefore, subject, dnsNames) in `templates/db.yaml`; backing fields added to `Neo4jTLS` in `apis/` and to `values.yaml`.
- `opskubedbcom-neo4jopsrequest-editor`: expose `spec.horizontalScaling.reallocate.strategy` and `.batchSize` in the HorizontalScaling form. The chart schema already had these fields.

Note: `values.openapiv3_schema.yaml` for the neo4j editor-options chart is not regenerated — `make gen` requires Docker, which was unavailable locally. Needs a `make gen` run before/after merge.