### PR TITLE
Fix MSSQLServer auth username and run backup jobs as root

### DIFF
--- a/charts/kubedbcom-mssqlserver-editor-options/templates/_helpers.tpl
+++ b/charts/kubedbcom-mssqlserver-editor-options/templates/_helpers.tpl
@@ -130,6 +130,18 @@ seccompProfile:
   type: RuntimeDefault
 {{- end }}
 
+{{- define "backup.securityContext" -}}
+allowPrivilegeEscalation: false
+capabilities:
+  drop:
+  - ALL
+runAsGroup: 0
+runAsNonRoot: false
+runAsUser: 0
+seccompProfile:
+  type: RuntimeDefault
+{{- end }}
+
 {{- define "resource-profiles" -}}
 {{- $machines := .Files.Get "data/machines.yaml" | fromYaml -}}
 {{- $profiles := "" -}}

--- a/charts/kubedbcom-mssqlserver-editor-options/templates/kubestash/backupconfiguration.yaml
+++ b/charts/kubedbcom-mssqlserver-editor-options/templates/kubestash/backupconfiguration.yaml
@@ -30,7 +30,7 @@ spec:
           template:
             spec:
               containerSecurityContext:
-                {{- include "container.securityContext" . | nindent 16 }}
+                {{- include "backup.securityContext" . | nindent 16 }}
               nodeSelector:
                 kubernetes.io/os: linux
           backoffLimit: 2
@@ -50,7 +50,7 @@ spec:
         jobTemplate:
           spec:
             containerSecurityContext:
-              {{- include "container.securityContext" . | nindent 14 }}
+              {{- include "backup.securityContext" . | nindent 14 }}
             nodeSelector:
               kubernetes.io/os: linux
 {{- end }}

--- a/charts/kubedbcom-mssqlserver-editor-options/templates/secret.yaml
+++ b/charts/kubedbcom-mssqlserver-editor-options/templates/secret.yaml
@@ -8,6 +8,6 @@ metadata:
     {{- include "kubedbcom-mssqlserver-editor-options.labels" . | nindent 4 }}
 type: kubernetes.io/basic-auth
 data:
-  username: {{ "root" | b64enc | quote }}
+  username: {{ "sa" | b64enc | quote }}
   password: {{ .Values.spec.authSecret.password | trim | b64enc | quote }}
 {{- end }}


### PR DESCRIPTION
`charts/kubedbcom-mssqlserver-editor-options`:

- **Auth secret username `root` -> `sa`** (`templates/secret.yaml`). MSSQLServer's built-in admin account is `sa`; `root` was never a valid login.
- **Backup jobs run as root** (`templates/kubestash/backupconfiguration.yaml`). New `backup.securityContext` helper with `runAsUser: 0` / `runAsNonRoot: false`, applied to both the scheduler and addon `containerSecurityContext`. DB pod containers keep `container.securityContext` (uid 10001).

`runAsNonRoot` has to be `false` alongside `runAsUser: 0` — kubelet rejects the pod otherwise.